### PR TITLE
fix(ci): check for existing remote branch before creating local one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ The format is based on Keep a Changelog and this project adheres to SemVer.
 
 - TBD
 
+## [0.3.0] - 2025-10-19
+
+### ✨ Added
+
+- implement PR-based release workflow system (#31)
+
+### 🐛 Fixed
+
+- remove monitoring uptime workflow (#30)
+
+### 🔧 Changed
+
+- update actions/github-script digest to ed59741 (#33)
+- update actions/checkout digest to ff7abcd (#32)
+- update dependency stylelint-config-standard to v39 (#29)
+- update dependency lint-staged to v16 (#28)
+- update typescript-eslint monorepo to v8.46.1 (#27)
+- update dependency ruby to v3.4.7 (#26)
+- update dependency eslint to v9.38.0 (#25)
+
 ## [0.2.0] - 2025-10-19
 
 ### ✨ Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbocoder13/bulma-turbo-themes",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Bulma theme packs and an accessible theme selector.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Problem: The release workflow was failing with non-fast-forward errors when trying to push to a remote branch that already existed. The script only checked for local branch existence but didn't handle remote branch conflicts.

Additionally, the workflow was creating recurring version bump PRs after release merges and had malformed PR descriptions.

Solution:
- Added checkRemoteBranch() function to detect remote branch existence using git ls-remote
- Updated createVersionBranch() to handle remote branch conflicts gracefully  
- Added fallback logic to checkout existing local branch if remote checkout fails
- Exclude release commits from version bump analysis to prevent loops
- Fix PR description formatting by using --body-file instead of shell escaping
- Prevents workflow failures when remote release branch already exists

Testing:
- Dry run test passed
- Remote branch detection verified
- Pre-commit checks passed
- All tests passing

Fixes the issues with:
- Non-fast-forward errors when remote branch exists
- Recurring version bump PRs after release merges
- Broken PR description formatting (escaped \n, missing values)