### PR TITLE
fix: add checkout step to deployment workflows

### DIFF
--- a/.github/workflows/deploy-coverage-pages.yml
+++ b/.github/workflows/deploy-coverage-pages.yml
@@ -36,6 +36,9 @@ jobs:
             api.github.com:443
             uploads.github.com:443
 
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Download coverage artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:

--- a/.github/workflows/deploy-lighthouse-pages.yml
+++ b/.github/workflows/deploy-lighthouse-pages.yml
@@ -36,6 +36,9 @@ jobs:
             api.github.com:443
             uploads.github.com:443
 
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Download Lighthouse reports artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:


### PR DESCRIPTION
## Summary

Fix exit code 127 errors in lighthouse and coverage deployment workflows by adding missing checkout steps.

## Type

- [x] 🐛 Bug fix (`bug-fix:`)

## Changes Made

- Add checkout step to `deploy-lighthouse-pages.yml` after Harden Runner
- Add checkout step to `deploy-coverage-pages.yml` after Harden Runner
- Ensures scripts are available when deployment workflows run

## Related Issues

Fixes exit code 127 errors in:
- Deploy - Lighthouse Reports to GitHub Pages workflow
- Deploy - Coverage to GitHub Pages workflow

## Testing

- [x] Manual testing of workflow structure performed
- [x] Linting passes (no linter errors found)
- [x] Commits are signed with ED25519 key

## Quality Checks

- [x] No new warnings or errors introduced

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)