### PR TITLE
fix(ci): add missing egress endpoints for Bun download

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -44,6 +44,10 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
+            github-releases.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
             bun.sh:443
             registry.npmjs.org:443
 

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -30,6 +30,10 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
+            github-releases.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
             registry.npmjs.org:443
             bun.sh:443
 


### PR DESCRIPTION
## Summary

Fixes ECONNREFUSED errors in release workflows by adding missing GitHub infrastructure endpoints required for Bun binary downloads and GitHub Actions cache service access.

## Type

- [x] 🔧 CI/CD (`ci:`)

## Changes Made

- Added `objects.githubusercontent.com:443` endpoint for GitHub-hosted assets
- Added `github-releases.githubusercontent.com:443` endpoint for GitHub releases CDN
- Added `release-assets.githubusercontent.com:443` endpoint for release asset downloads
- Added `pipelines.actions.githubusercontent.com:443` endpoint for GitHub Actions cache service

These endpoints are needed by the `oven-sh/setup-bun` action to download Bun binaries, and for the GitHub Actions cache service to function properly.

## Related Issues

Fixes the egress policy issue causing:
- https://github.com/TurboCoder13/bulma-turbo-themes/actions/runs/19963550980/job/57249523177
- https://github.com/TurboCoder13/bulma-turbo-themes/actions/runs/19963551009/job/57249523344

## Testing

- [x] Manual testing performed
- [x] All tests pass locally (`npm test`)
- [x] Linting passes

## Quality Checks

- [x] Linting passes (`npm run lint`)
- [x] Formatting passes (`npm run format`)
- [x] No new warnings or errors
- [x] actionlint validation passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's Code of Conduct**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to improve build pipeline reliability and compatibility with GitHub services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->