### PR TITLE
fix(site): fix search and add multi-language coverage reports

### DIFF
--- a/.github/workflows/quality-coverage-multi.yml
+++ b/.github/workflows/quality-coverage-multi.yml
@@ -1,0 +1,136 @@
+---
+name: Quality Check - Multi-Language Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'python/**'
+      - 'spec/**'
+      - 'lib/**'
+      - 'examples/swift-swiftui/**'
+      - '.github/workflows/quality-coverage-multi.yml'
+  pull_request:
+    paths:
+      - 'python/**'
+      - 'spec/**'
+      - 'lib/**'
+      - 'examples/swift-swiftui/**'
+      - '.github/workflows/quality-coverage-multi.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-multi-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Python and Ruby run on Ubuntu (fast, parallel)
+  coverage-ubuntu:
+    name: ${{ matrix.language.name }} Coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - name: 🐍 Python
+            id: python
+            working_directory: python
+            setup_command: uv sync --extra dev
+            test_command: uv run pytest tests/ -v
+            coverage_source: python/htmlcov
+            artifact_name: coverage-python-html
+          - name: 💎 Ruby
+            id: ruby
+            working_directory: .
+            setup_command: bundle install
+            test_command: bundle exec rspec
+            coverage_source: rspec-coverage
+            artifact_name: coverage-ruby-html
+    steps:
+      - name: Harden Runner
+        if: ${{ !env.ACT }}
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          skip-ruby: ${{ matrix.language.id == 'python' && 'true' || 'false' }}
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.language.working_directory }}
+        run: ${{ matrix.language.setup_command }}
+
+      - name: Run tests with coverage
+        working-directory: ${{ matrix.language.working_directory }}
+        run: ${{ matrix.language.test_command }}
+
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ matrix.language.artifact_name }}
+          path: ${{ matrix.language.coverage_source }}
+          retention-days: 30
+          if-no-files-found: warn
+
+  # Swift requires macOS with Xcode
+  coverage-swift:
+    name: 🍎 Swift Coverage
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
+
+      - name: Run Swift tests with coverage
+        working-directory: examples/swift-swiftui
+        run: swift test --enable-code-coverage
+
+      - name: Generate coverage report
+        working-directory: examples/swift-swiftui
+        run: |
+          rm -rf htmlcov && mkdir -p htmlcov
+
+          # Find the test binary (architecture may vary)
+          TEST_BINARY=$(find .build -name "TurboThemesPackageTests" -type f | head -1)
+          PROFDATA=$(find .build -name "default.profdata" -type f | head -1)
+
+          if [ -z "${TEST_BINARY}" ] || [ -z "${PROFDATA}" ]; then
+            echo "⚠️ Could not find test binary or profdata"
+            echo "Test binary: ${TEST_BINARY}"
+            echo "Profdata: ${PROFDATA}"
+            exit 0
+          fi
+
+          xcrun llvm-cov show \
+            "${TEST_BINARY}" \
+            -instr-profile="${PROFDATA}" \
+            -format=html \
+            -output-dir=htmlcov \
+            -show-branches=count \
+            -ignore-filename-regex='.*Tests.*' \
+            -ignore-filename-regex='.*/.build/.*' || true
+
+          echo "✅ Swift coverage report generated"
+
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coverage-swift-html
+          path: examples/swift-swiftui/htmlcov
+          retention-days: 30
+          if-no-files-found: warn

--- a/apps/site/src/components/SearchDropdown.astro
+++ b/apps/site/src/components/SearchDropdown.astro
@@ -4,11 +4,12 @@
  * Opens with click or Cmd+K / Ctrl+K keyboard shortcut.
  * Uses Pagefind for static search.
  */
+const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
-<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+<link rel="stylesheet" href={`${baseUrl}/pagefind/pagefind-ui.css`} />
 
-<div class="search-bar" id="search-bar">
+<div class="search-bar" id="search-bar" data-base-url={baseUrl}>
   <div class="search-bar-inner" id="search-trigger">
     <span class="search-bar-placeholder">What are you looking for?</span>
     <span class="search-bar-shortcut"><span class="search-bar-shortcut-mod"></span>K</span>
@@ -34,6 +35,7 @@
     var searchBar = document.getElementById('search-bar');
     var trigger = document.getElementById('search-trigger');
     var menu = document.getElementById('search-menu');
+    var baseUrl = searchBar.getAttribute('data-base-url') || '';
     var searchInitialized = false;
 
     function openSearch() {
@@ -64,7 +66,7 @@
       if (searchInitialized) return;
 
       try {
-        var PagefindUI = (await import('/pagefind/pagefind-ui.js')).PagefindUI;
+        var PagefindUI = (await import(baseUrl + '/pagefind/pagefind-ui.js')).PagefindUI;
         new PagefindUI({
           element: '#search-input-container',
           showImages: false,

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.11.0",
-  "$generated": "2026-01-16T08:24:17.153Z",
+  "$generated": "2026-01-16T09:41:14.605Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.11.0",
-  "$generated": "2026-01-16T08:24:17.153Z",
+  "$generated": "2026-01-16T09:41:14.605Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.11.0",
-  "$generated": "2026-01-16T08:24:17.153Z",
+  "$generated": "2026-01-16T09:41:14.605Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary
- Fix Pagefind search to use `BASE_URL` for GitHub Pages compatibility (was showing "Search available after build")
- Add `quality-coverage-multi.yml` workflow for Python, Ruby, and Swift coverage reports
- Update `download-test-artifacts.sh` to fetch all missing test reports

## Changes
### Search Fix (`SearchDropdown.astro`)
- Added `baseUrl` from `import.meta.env.BASE_URL`
- Updated CSS link and JS import to use dynamic paths
- Search now works on deployed site at `/turbo-themes/`

### Multi-Language Coverage Workflow
- Matrix-based jobs for Python and Ruby (Ubuntu)
- Separate Swift job (macOS with Xcode)
- Artifacts: `coverage-{python,ruby,swift}-html`

### Download Script Updates
- Added `download_examples_playwright()` for Examples Playwright report
- Added `download_multi_language_coverage()` for Python/Ruby/Swift
- Updated `copy_reports_to_site_dist()` with correct paths

## Test plan
- [ ] Verify search works on deployed GitHub Pages site
- [ ] Check that all report links in nav work after deployment
- [ ] Confirm new workflow runs successfully on push to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search dropdown with dynamic URL support for enhanced compatibility across different deployment environments.

* **Infrastructure**
  * Expanded CI pipeline with comprehensive test coverage reporting across Python, Ruby, and Swift.
  * Updated generated resource timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->