### PR TITLE
fix(ci): restore Node 24 for npm publish with OIDC provenance

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: https://registry.npmjs.org
 
       - name: Publish to npm (OIDC)

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.3",
-  "$generated": "2026-01-16T21:18:32.996Z",
+  "$version": "0.12.4",
+  "$generated": "2026-01-16T21:39:18.633Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.3",
-  "$generated": "2026-01-16T21:18:32.996Z",
+  "$version": "0.12.4",
+  "$generated": "2026-01-16T21:39:18.633Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.3",
-  "$generated": "2026-01-16T21:18:32.996Z",
+  "$version": "0.12.4",
+  "$generated": "2026-01-16T21:39:18.633Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

1. **Fix npm OIDC publishing** - Restore Node 24 for publish job (was incorrectly changed to Node 22)
2. **Modernize README** - Remove Bulma/Jekyll-heavy focus, make it platform-agnostic

## Changes

### CI Fix
- Reverts Node version in publish job from 22 back to 24
- Node 24 is required for npm OIDC provenance publishing

### README Updates
- Add PyPI badge (was missing, only had npm and RubyGems)
- Update version references (Ruby ~> 0.12, Swift 0.12.0+)
- Rewrite Features to be framework-agnostic (not Bulma-specific)
- Add installation table showing all platforms equally
- Simplify Quick Start with design tokens as primary focus
- Remove heavy Bulma/Jekyll-specific markup examples
- Update prerequisites to include Python, make Ruby optional

## Test plan

- [ ] CI passes
- [ ] npm publish succeeds for next version