### PR TITLE
ci: add missing harden-runner allowed-endpoints

### DIFF
--- a/.github/workflows/maintenance-renovate.yml
+++ b/.github/workflows/maintenance-renovate.yml
@@ -27,6 +27,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             codeload.github.com:443
+            ghcr.io:443
             github.com:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443

--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -28,9 +28,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            api.osv.dev:443
             codeload.github.com:443
+            fulcio.sigstore.dev:443
             github.com:443
             objects.githubusercontent.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-17T07:27:24.772Z",
+  "$generated": "2026-01-19T07:52:03.188Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-17T07:27:24.772Z",
+  "$generated": "2026-01-19T07:52:03.188Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-17T07:27:24.772Z",
+  "$generated": "2026-01-19T07:52:03.188Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary
- Add required network endpoints to harden-runner configurations in two workflow files
- Fix OSSF Security Scorecard workflow by adding endpoints for vulnerability checks and result signing
- Fix Renovate workflow by adding `ghcr.io` endpoint for pulling Docker images

## Context
Two CI workflows were failing due to blocked network egress:

1. **OpenSSF Security Scorecard** ([run 21127322916](https://github.com/TurboCoder13/turbo-themes/actions/runs/21127322916)): The scorecard action needs to connect to external services for vulnerability checks (api.osv.dev), fuzzing checks (oss-fuzz-build-logs.storage.googleapis.com), best practices checks (www.bestpractices.dev), and result signing (fulcio.sigstore.dev, rekor.sigstore.dev, tuf-repo-cdn.sigstore.dev)

2. **Renovate Dependencies** ([run 21119301880](https://github.com/TurboCoder13/turbo-themes/actions/runs/21119301880)): The Renovate action failed with `docker: Error response from daemon: Get "https://ghcr.io/v2/": dial tcp: connect: connection refused` because `ghcr.io` was not in the allowed endpoints

## Test plan
- [ ] Verify OSSF Security Scorecard workflow passes after merge
- [ ] Verify Renovate Dependencies workflow passes after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configurations with additional security endpoints.
  * Updated theme token file timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->