### PR TITLE
ci: add pkg-containers endpoint for Renovate Docker pulls

### DIFF
--- a/.github/workflows/maintenance-renovate.yml
+++ b/.github/workflows/maintenance-renovate.yml
@@ -30,6 +30,7 @@ jobs:
             ghcr.io:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             registry.npmjs.org:443
             rubygems.org:443
       - name: Checkout repository

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-19T07:52:03.188Z",
+  "$generated": "2026-01-20T08:49:42.829Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-19T07:52:03.188Z",
+  "$generated": "2026-01-20T08:49:42.829Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-19T07:52:03.188Z",
+  "$generated": "2026-01-20T08:49:42.829Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary
- Add `pkg-containers.githubusercontent.com:443` to harden-runner allowed-endpoints in the Renovate workflow
- This endpoint is required for pulling Docker container layers from ghcr.io (GitHub Container Registry)

## Problem
The Renovate CI workflow was failing because the harden-runner was blocking network access to `pkg-containers.githubusercontent.com`. When Docker pulls images from ghcr.io, the image manifest comes from ghcr.io but the actual layer data is fetched from `pkg-containers.githubusercontent.com`.

Error from logs:
```
domain not allowed: pkg-containers.githubusercontent.com.
ip address dropped: 54.185.253.63
```

## Test plan
- [x] Lint passes
- [x] All unit tests pass (1268 tests)
- [x] All example tests pass (139 tests)
- [ ] Verify Renovate workflow succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated theme token generation timestamps across core packages
  * Enhanced GitHub Actions workflow configuration for improved build infrastructure support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->