### PR TITLE
ci: add pkg-containers endpoint to all harden-runner configs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,6 +51,7 @@ jobs:
             index.rubygems.org:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pypi.org:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/maintenance-auto-bump-refs.yml
+++ b/.github/workflows/maintenance-auto-bump-refs.yml
@@ -45,6 +45,7 @@ jobs:
             codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
 
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -51,6 +51,7 @@ jobs:
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
@@ -144,6 +145,7 @@ jobs:
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             cache.ruby-lang.org:443

--- a/.github/workflows/publish-npm-test.yml
+++ b/.github/workflows/publish-npm-test.yml
@@ -46,6 +46,7 @@ jobs:
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             codeload.github.com:443
             registry.npmjs.org:443
             bun.sh:443

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -55,6 +55,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
@@ -145,6 +146,7 @@ jobs:
             codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             registry.npmjs.org:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -30,6 +30,7 @@ jobs:
             github-releases.githubusercontent.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
             pypi.org:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -61,6 +61,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -74,6 +74,7 @@ jobs:
             npmjs.org:443
             objects.githubusercontent.com:443
             packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
             playwright-akamai.azureedge.net:443
             playwright-verizon.azureedge.net:443
             playwright.azureedge.net:443

--- a/.github/workflows/quality-semantic-pr-title.yml
+++ b/.github/workflows/quality-semantic-pr-title.yml
@@ -28,6 +28,7 @@ jobs:
             codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Validate PR title
         id: semantic

--- a/.github/workflows/quality-theme-sync.yml
+++ b/.github/workflows/quality-theme-sync.yml
@@ -38,6 +38,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pypi.org:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/quality-validate-action-pinning.yml
+++ b/.github/workflows/quality-validate-action-pinning.yml
@@ -31,6 +31,7 @@ jobs:
             codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -45,6 +45,7 @@ jobs:
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             github-releases.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443

--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -47,8 +47,9 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            github.com:443
             api.github.com:443
+            github.com:443
+            pkg-containers.githubusercontent.com:443
             uploads.github.com:443
 
       - name: Download SBOM artifacts

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -31,6 +31,7 @@ jobs:
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             github-releases.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443

--- a/.github/workflows/reporting-lighthouse-ci.yml
+++ b/.github/workflows/reporting-lighthouse-ci.yml
@@ -41,6 +41,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             packages.microsoft.com:443
             pipelines.actions.githubusercontent.com:443
             productionresultssa3.blob.core.windows.net:443

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -35,6 +35,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
             pypi.org:443
             registry.npmjs.org:443

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -34,6 +34,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pypi.org:443
             raw.githubusercontent.com:443
             registry.npmjs.org:443

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -33,6 +33,7 @@ jobs:
             github.com:443
             npmjs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
             raw.githubusercontent.com:443
             registry.npmjs.org:443

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -32,6 +32,7 @@ jobs:
             github-releases.githubusercontent.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             release-assets.githubusercontent.com:443
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: github/codeql-action/init@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -26,6 +26,7 @@ jobs:
             codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Skip dependency review (requires Advanced Security)
         run: ./scripts/ci/skip-dependency-review.sh

--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -33,6 +33,7 @@ jobs:
             fulcio.sigstore.dev:443
             github.com:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-20T08:49:42.829Z",
+  "$generated": "2026-01-20T09:23:50.122Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-20T08:49:42.829Z",
+  "$generated": "2026-01-20T09:23:50.122Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.8",
-  "$generated": "2026-01-20T08:49:42.829Z",
+  "$generated": "2026-01-20T09:23:50.122Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

- Add `pkg-containers.githubusercontent.com:443` to harden-runner allowed-endpoints across all GitHub Actions workflows
- Ensures Renovate can pull Docker images without network restrictions

## Changes

Updates 21 workflow files to include the pkg-containers endpoint in their harden-runner configurations.

## Test plan

- [ ] CI workflows run successfully with the new endpoint allowlisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline security configurations to support container registry access across multiple workflows
  * Regenerated theme token files with current build timestamps

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->