### PR TITLE
fix(e2e): correct scroll drift assertion boundary condition

### DIFF
--- a/e2e/mobile-viewport.spec.ts
+++ b/e2e/mobile-viewport.spec.ts
@@ -178,7 +178,7 @@ test.describe('Mobile Viewport @mobile', () => {
       const scrollAfter = await page.evaluate(() => window.scrollY);
       // Allow up to 150px drift due to scrollIntoViewIfNeeded on theme selector
       // CI environments may have slightly different scroll behavior
-      expect(Math.abs(scrollAfter - scrollBefore)).toBeLessThan(150);
+      expect(Math.abs(scrollAfter - scrollBefore)).toBeLessThanOrEqual(150);
     });
   });
 

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.12",
-  "$generated": "2026-01-26T11:33:05.584Z",
+  "$version": "0.12.13",
+  "$generated": "2026-01-26T12:15:09.020Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.12",
-  "$generated": "2026-01-26T11:33:05.584Z",
+  "$version": "0.12.13",
+  "$generated": "2026-01-26T12:15:09.020Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.12",
-  "$generated": "2026-01-26T11:33:05.584Z",
+  "$version": "0.12.13",
+  "$generated": "2026-01-26T12:15:09.020Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

- Fix flaky E2E test `mobile-viewport.spec.ts` that failed when scroll drift was exactly 150px

## Problem

The test comment says "Allow up to 150px drift" but the assertion used `toBeLessThan(150)`, which rejects exactly 150px. This caused intermittent CI failures when the scroll drift happened to be exactly at the boundary.

**Failed run**: https://github.com/TurboCoder13/turbo-themes/actions/runs/21356926681

```
Error: expect(received).toBeLessThan(expected)
Expected: < 150
Received:   150
```

## Solution

Change `toBeLessThan(150)` to `toBeLessThanOrEqual(150)` to match the documented tolerance.

## Test plan

- [x] Lint passes
- [x] Unit tests pass (1,268 tests)
- [x] Example tests pass (139 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.12.13 across all JavaScript, Python, and Swift theme packages with updated generated timestamps.

* **Tests**
  * Adjusted mobile viewport accessibility and scroll-related test assertion boundary condition to accommodate equal tolerance on drift calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->