### PR TITLE
fix(ci): pin Ruby to 4.0.0 for GitHub Actions

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.0'
           bundler-cache: true
 
       - name: Install dependencies
@@ -171,7 +171,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.0'
 
       - name: Configure RubyGems credentials
         uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.15",
-  "$generated": "2026-01-27T14:37:13.280Z",
+  "$version": "0.12.16",
+  "$generated": "2026-01-27T15:55:36.680Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.15",
-  "$generated": "2026-01-27T14:37:13.280Z",
+  "$version": "0.12.16",
+  "$generated": "2026-01-27T15:55:36.680Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.15",
-  "$generated": "2026-01-27T14:37:13.280Z",
+  "$version": "0.12.16",
+  "$generated": "2026-01-27T15:55:36.680Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

- Pin Ruby version to 4.0.0 in `publish-gem.yml` workflow
- Ruby 4.0.1 is not yet available in GitHub Actions runners (ruby/setup-ruby)

## Context

The RubyGems publish workflow was failing because `ruby/setup-ruby` doesn't have prebuilt binaries for Ruby 4.0.1 yet. This pins to 4.0.0 until the action is updated.

## Test plan

- [ ] Merge and trigger RubyGems publish workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped theme token version to 0.12.16 across all platform packages.
  * Updated CI workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->