### PR TITLE
fix(ci): use GitHub-hosted runner for npm publish provenance

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -127,7 +127,8 @@ jobs:
   publish:
     name: 📦 Publish to npm
     needs: [build]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Must use GitHub-hosted runner for npm provenance attestation (sigstore)
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Reverts the `publish` job runner from Blacksmith (`blacksmith-4vcpu-ubuntu-2404`) back to GitHub-hosted (`ubuntu-24.04`)
- Blacksmith runners are classified as "self-hosted" by npm, which breaks sigstore provenance attestation
- The `build` job remains on Blacksmith since it doesn't require provenance signing

## Context

The recent Blacksmith migration (commit 8fc1f3c) changed all workflow runners to Blacksmith. However, npm's `--provenance` flag only works with GitHub-hosted runners for sigstore attestation.

Error from failed publish:
```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Unsupported GitHub Actions runner environment: "self-hosted". 
Only "github-hosted" runners are supported when publishing with provenance.
```

## Test plan

- [ ] Merge and verify npm publish succeeds with provenance attestation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing infrastructure for improved workflow stability and compliance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->