### PR TITLE
fix(ci): add missing endpoints to Scorecard workflow

### DIFF
--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -27,8 +27,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             api.osv.dev:443
+            api.scorecard.dev:443
             codeload.github.com:443
             fulcio.sigstore.dev:443
             github.com:443

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.22",
-  "$generated": "2026-01-30T11:46:14.797Z",
+  "$version": "0.12.27",
+  "$generated": "2026-01-30T18:57:50.149Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.22",
-  "$generated": "2026-01-30T11:46:14.797Z",
+  "$version": "0.12.27",
+  "$generated": "2026-01-30T18:57:50.149Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.22",
-  "$generated": "2026-01-30T11:46:14.797Z",
+  "$version": "0.12.27",
+  "$generated": "2026-01-30T18:57:50.149Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

- Add `api.deps.dev:443` and `api.scorecard.dev:443` to the harden-runner allowed-endpoints list
- These endpoints are required by the ossf/scorecard-action for dependency analysis and publishing results

## Problem

The OpenSSF Scorecard Analysis workflow has been failing every week since Dec 29, 2025 due to blocked egress:
```
domain not allowed: api.deps.dev
domain not allowed: api.scorecard.dev
```

## Test plan

- [ ] Verify Scorecard workflow passes after merge (can manually trigger with workflow_dispatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated theme version metadata.
  * Expanded security configuration for continuous integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->