### PR TITLE
fix(release): sync tokens.json version during release

### DIFF
--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.30",
+  "$version": "0.12.31",
   "$generated": "2026-01-30T21:44:17.416Z",
   "meta": {
     "themeIds": [

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.30",
+  "$version": "0.12.31",
   "$generated": "2026-01-30T21:44:17.416Z",
   "meta": {
     "themeIds": [

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
-  "$version": "0.12.30",
+  "$version": "0.12.31",
   "$generated": "2026-01-30T21:44:17.416Z",
   "meta": {
     "themeIds": [


### PR DESCRIPTION
## Summary

Fixes the CI failure in the "Verify Theme Sync Determinism" check on main.

**Root cause**: The release workflow updates `package.json` version but was not updating the `$version` field embedded in `tokens.json` files. When CI ran the determinism check, regenerating tokens produced different versions, causing the check to fail.

**Changes**:
- Add `tokens.json` files to `sync-version.mjs` so `$version` is updated during releases (prevents future occurrences)
- Update `tokens.json` files to `0.12.31` (fixes the current CI failure)

## Affected files

- `scripts/sync-version.mjs` - now syncs tokens.json $version
- `packages/core/src/themes/tokens.json`
- `python/src/turbo_themes/tokens.json`
- `swift/Sources/TurboThemes/Resources/tokens.json`

## Test plan

- [ ] CI passes (theme sync determinism check should now succeed)
- [ ] Future releases will automatically sync tokens.json version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated design tokens to version 0.12.31 across all platforms.
  * Improved the version-sync behavior to respect file newline formatting when updating token files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->