### PR TITLE
revert(ci): switch from Blacksmith to GitHub runners

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build:
     name: 🏗️ Build Site
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     if:
       ${{ github.event.workflow_run.conclusion == 'success' || github.event_name ==
@@ -91,7 +91,7 @@ jobs:
   deploy:
     name: 🚀 Deploy to GitHub Pages
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
       name: github-pages

--- a/.github/workflows/maintenance-auto-bump-refs.yml
+++ b/.github/workflows/maintenance-auto-bump-refs.yml
@@ -29,7 +29,7 @@ jobs:
           !startsWith(github.event.head_commit.message, 'chore(release):')
       ) }}
     name: 🔄 Update Internal SHA References
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     concurrency:
       group: auto-bump-refs-${{ github.ref }}

--- a/.github/workflows/maintenance-generate-snapshots.yml
+++ b/.github/workflows/maintenance-generate-snapshots.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   generate-snapshots:
     name: Generate Linux Snapshots
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Harden Runner

--- a/.github/workflows/maintenance-renovate.yml
+++ b/.github/workflows/maintenance-renovate.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   renovate:
     name: 🔄 Automated Dependency Updates
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Harden Runner

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     name: 🔨 Build Gem Package
     needs: [sbom]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -128,7 +128,7 @@ jobs:
   publish:
     name: 📦 Publish to RubyGems
     needs: [build]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/publish-npm-test.yml
+++ b/.github/workflows/publish-npm-test.yml
@@ -32,7 +32,7 @@ jobs:
   publish:
     name: 📦 Publish to npm (Test)
     needs: [sbom]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     name: 🔨 Build npm Package
     needs: [sbom]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   publish-python:
     name: 📦 Publish to PyPI
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Harden Runner

--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build:
     name: 🏗️ Build & Quality Checks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -172,7 +172,7 @@ jobs:
 
   examples:
     name: 📦 Validate Examples
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: build
     steps:

--- a/.github/workflows/quality-coverage-multi.yml
+++ b/.github/workflows/quality-coverage-multi.yml
@@ -29,7 +29,7 @@ jobs:
   # Python and Ruby run on Ubuntu (fast, parallel)
   coverage-ubuntu:
     name: ${{ matrix.language.name }} Coverage
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   e2e-matrix:
     name: ${{ matrix.display_name }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false

--- a/.github/workflows/quality-examples.yml
+++ b/.github/workflows/quality-examples.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build-examples:
     name: 🔨 Build Examples
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -88,7 +88,7 @@ jobs:
 
   build-jekyll:
     name: 🔨 Build Jekyll Example
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Harden Runner
@@ -126,7 +126,7 @@ jobs:
 
   test-examples:
     name: 🧪 Test Examples
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: [build-examples, build-jekyll]
     steps:

--- a/.github/workflows/quality-semantic-pr-title.yml
+++ b/.github/workflows/quality-semantic-pr-title.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check:
     name: ✅ Validate Conventional Commits
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Harden Runner

--- a/.github/workflows/quality-theme-sync.yml
+++ b/.github/workflows/quality-theme-sync.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check-determinism:
     name: 🔍 Verify Theme Sync Determinism
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Harden Runner

--- a/.github/workflows/quality-validate-action-pinning.yml
+++ b/.github/workflows/quality-validate-action-pinning.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   check-pinning:
     name: 🔒 Validate SHA Pinning Compliance
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -31,7 +31,7 @@ jobs:
     name: 🏷️ Auto Create Release Tag
     # Uses trust-and-skip pattern: version PR already validated code quality
     # Skips quality, build, and lighthouse jobs to avoid duplication
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -37,7 +37,7 @@ jobs:
   github-release:
     name: 🚀 Create GitHub Release
     needs: [sbom]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   version-pr:
     name: 📝 Create Version PR
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: write

--- a/.github/workflows/reporting-lighthouse-ci.yml
+++ b/.github/workflows/reporting-lighthouse-ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   lhci:
     name: 📊 Lighthouse Performance Analysis
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Harden Runner

--- a/.github/workflows/reporting-link-monitoring.yml
+++ b/.github/workflows/reporting-link-monitoring.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   validate-external-links:
     name: 🔗 Check External Links
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Harden Runner

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
     name: 🏗️ Build Artifacts
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Harden Runner

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   quality:
     name: 🔍 Code Quality & Linting
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Harden Runner

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   sbom:
     name: 📋 Generate SBOM (Multi-format)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Harden Runner

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   analyze:
     name: 🔍 CodeQL Security Analysis
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   review:
     name: 🔐 Dependency Vulnerability Scan
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.33",
-  "$generated": "2026-01-30T21:44:17.416Z",
+  "$generated": "2026-02-05T06:11:01.188Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.33",
-  "$generated": "2026-01-30T21:44:17.416Z",
+  "$generated": "2026-02-05T06:11:01.188Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 9 themes",
   "$version": "0.12.33",
-  "$generated": "2026-01-30T21:44:17.416Z",
+  "$generated": "2026-02-05T06:11:01.188Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/test/integration/package-exports.test.ts
+++ b/test/integration/package-exports.test.ts
@@ -15,6 +15,7 @@ const DIST_DIRS = [
 function getFilesRecursively(dir: string, ext: string): string[] {
   const files: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // nosemgrep: path-join-resolve-traversal - Safe: entry.name comes from readdirSync, not user input
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
       files.push(...getFilesRecursively(fullPath, ext));


### PR DESCRIPTION
Reverts PR #286 that migrated workflows to Blacksmith runners.
All workflows now use ubuntu-24.04 instead of blacksmith-4vcpu-ubuntu-2404.

Also adds nosemgrep comment to fix false positive path traversal warning
in test file (entry.name comes from readdirSync, not user input).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow runners from custom runner to standard Ubuntu 24.04 image across all CI/CD pipelines for improved consistency and maintainability.
  * Refreshed generated metadata timestamps in configuration files.
  * Added internal testing infrastructure suppression comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->