### PR TITLE
fix(a11y): add per-state text color tokens for WCAG contrast on state buttons

### DIFF
--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.17.0",
-  "$generated": "2026-02-06T20:50:07.242Z",
+  "$generated": "2026-02-07T08:22:11.189Z",
   "meta": {
     "themeIds": [
       "bulma-dark",
@@ -242,7 +242,9 @@
           "info": "#3e8ed0",
           "success": "#48c78e",
           "warning": "#ffe08a",
-          "danger": "#f14668"
+          "danger": "#f14668",
+          "successText": "#363636",
+          "warningText": "#363636"
         },
         "border": {
           "default": "#dbdbdb"
@@ -482,7 +484,10 @@
           "info": "#04a5e5",
           "success": "#40a02b",
           "warning": "#df8e1d",
-          "danger": "#d20f39"
+          "danger": "#d20f39",
+          "infoText": "#000000",
+          "successText": "#ffffff",
+          "warningText": "#4c4f69"
         },
         "border": {
           "default": "#9ca0b0"
@@ -885,7 +890,9 @@
           "info": "#4493f8",
           "success": "#3fb950",
           "warning": "#d29922",
-          "danger": "#f85149"
+          "danger": "#f85149",
+          "successText": "#0d1117",
+          "warningText": "#0d1117"
         },
         "border": {
           "default": "#3d444d"
@@ -1569,7 +1576,8 @@
           "info": "#076678",
           "success": "#79740e",
           "warning": "#b57614",
-          "danger": "#9d0006"
+          "danger": "#9d0006",
+          "warningText": "#3c3836"
         },
         "border": {
           "default": "#bdae93"
@@ -1911,7 +1919,8 @@
           "info": "#56949f",
           "success": "#286983",
           "warning": "#ea9d34",
-          "danger": "#b4637a"
+          "danger": "#b4637a",
+          "warningText": "#575279"
         },
         "border": {
           "default": "#dfdad9"
@@ -2287,7 +2296,10 @@
           "info": "#2aa198",
           "success": "#859900",
           "warning": "#b58900",
-          "danger": "#dc322f"
+          "danger": "#dc322f",
+          "infoText": "#002b36",
+          "successText": "#002b36",
+          "warningText": "#002b36"
         },
         "border": {
           "default": "#93a1a1"

--- a/packages/core/src/themes/types.ts
+++ b/packages/core/src/themes/types.ts
@@ -20,6 +20,10 @@ export interface ThemeTokens {
     success: string;
     warning: string;
     danger: string;
+    infoText?: string;
+    successText?: string;
+    warningText?: string;
+    dangerText?: string;
   };
   border: {
     default: string;

--- a/packages/css/src/components/buttons.css
+++ b/packages/css/src/components/buttons.css
@@ -83,9 +83,9 @@
   background: var(--turbo-brand-primary);
 }
 
-/* State variants */
+/* State variants - use per-state text tokens with bg-base fallback (#267) */
 .btn-success {
-  color: var(--turbo-bg-base);
+  color: var(--turbo-state-success-text, var(--turbo-bg-base));
   background: var(--turbo-state-success);
 }
 
@@ -94,7 +94,7 @@
 }
 
 .btn-warning {
-  color: var(--turbo-bg-base);
+  color: var(--turbo-state-warning-text, var(--turbo-bg-base));
   background: var(--turbo-state-warning);
 }
 
@@ -103,7 +103,7 @@
 }
 
 .btn-danger {
-  color: var(--turbo-bg-base);
+  color: var(--turbo-state-danger-text, var(--turbo-bg-base));
   background: var(--turbo-state-danger);
 }
 
@@ -112,7 +112,7 @@
 }
 
 .btn-info {
-  color: var(--turbo-bg-base);
+  color: var(--turbo-state-info-text, var(--turbo-bg-base));
   background: var(--turbo-state-info);
 }
 

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.17.0",
-  "$generated": "2026-02-06T20:50:07.242Z",
+  "$generated": "2026-02-07T08:22:11.189Z",
   "meta": {
     "themeIds": [
       "bulma-dark",
@@ -242,7 +242,9 @@
           "info": "#3e8ed0",
           "success": "#48c78e",
           "warning": "#ffe08a",
-          "danger": "#f14668"
+          "danger": "#f14668",
+          "successText": "#363636",
+          "warningText": "#363636"
         },
         "border": {
           "default": "#dbdbdb"
@@ -482,7 +484,10 @@
           "info": "#04a5e5",
           "success": "#40a02b",
           "warning": "#df8e1d",
-          "danger": "#d20f39"
+          "danger": "#d20f39",
+          "infoText": "#000000",
+          "successText": "#ffffff",
+          "warningText": "#4c4f69"
         },
         "border": {
           "default": "#9ca0b0"
@@ -885,7 +890,9 @@
           "info": "#4493f8",
           "success": "#3fb950",
           "warning": "#d29922",
-          "danger": "#f85149"
+          "danger": "#f85149",
+          "successText": "#0d1117",
+          "warningText": "#0d1117"
         },
         "border": {
           "default": "#3d444d"
@@ -1569,7 +1576,8 @@
           "info": "#076678",
           "success": "#79740e",
           "warning": "#b57614",
-          "danger": "#9d0006"
+          "danger": "#9d0006",
+          "warningText": "#3c3836"
         },
         "border": {
           "default": "#bdae93"
@@ -1911,7 +1919,8 @@
           "info": "#56949f",
           "success": "#286983",
           "warning": "#ea9d34",
-          "danger": "#b4637a"
+          "danger": "#b4637a",
+          "warningText": "#575279"
         },
         "border": {
           "default": "#dfdad9"
@@ -2287,7 +2296,10 @@
           "info": "#2aa198",
           "success": "#859900",
           "warning": "#b58900",
-          "danger": "#dc322f"
+          "danger": "#dc322f",
+          "infoText": "#002b36",
+          "successText": "#002b36",
+          "warningText": "#002b36"
         },
         "border": {
           "default": "#93a1a1"

--- a/schema/tokens/themes/bulma-light.tokens.json
+++ b/schema/tokens/themes/bulma-light.tokens.json
@@ -55,6 +55,14 @@
       "danger": {
         "$value": "#f14668",
         "$type": "color"
+      },
+      "successText": {
+        "$value": "#363636",
+        "$type": "color"
+      },
+      "warningText": {
+        "$value": "#363636",
+        "$type": "color"
       }
     },
     "border": {

--- a/schema/tokens/themes/catppuccin-latte.tokens.json
+++ b/schema/tokens/themes/catppuccin-latte.tokens.json
@@ -55,6 +55,18 @@
       "danger": {
         "$value": "#d20f39",
         "$type": "color"
+      },
+      "infoText": {
+        "$value": "#000000",
+        "$type": "color"
+      },
+      "successText": {
+        "$value": "#ffffff",
+        "$type": "color"
+      },
+      "warningText": {
+        "$value": "#4c4f69",
+        "$type": "color"
       }
     },
     "border": {

--- a/schema/tokens/themes/github-dark.tokens.json
+++ b/schema/tokens/themes/github-dark.tokens.json
@@ -55,6 +55,14 @@
       "danger": {
         "$value": "#f85149",
         "$type": "color"
+      },
+      "successText": {
+        "$value": "#0d1117",
+        "$type": "color"
+      },
+      "warningText": {
+        "$value": "#0d1117",
+        "$type": "color"
       }
     },
     "border": {

--- a/schema/tokens/themes/gruvbox-light-soft.tokens.json
+++ b/schema/tokens/themes/gruvbox-light-soft.tokens.json
@@ -55,6 +55,10 @@
       "danger": {
         "$value": "#9d0006",
         "$type": "color"
+      },
+      "warningText": {
+        "$value": "#3c3836",
+        "$type": "color"
       }
     },
     "border": {

--- a/schema/tokens/themes/rose-pine-dawn.tokens.json
+++ b/schema/tokens/themes/rose-pine-dawn.tokens.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../turbo-themes.schema.json#/$defs/ThemeFile",
   "id": "rose-pine-dawn",
-  "label": "Rosé Pine Dawn",
+  "label": "Ros\u00e9 Pine Dawn",
   "vendor": "rose-pine",
   "appearance": "light",
   "tokens": {
@@ -54,6 +54,10 @@
       },
       "danger": {
         "$value": "#b4637a",
+        "$type": "color"
+      },
+      "warningText": {
+        "$value": "#575279",
         "$type": "color"
       }
     },

--- a/schema/tokens/themes/solarized-light.tokens.json
+++ b/schema/tokens/themes/solarized-light.tokens.json
@@ -55,6 +55,18 @@
       "danger": {
         "$value": "#dc322f",
         "$type": "color"
+      },
+      "infoText": {
+        "$value": "#002b36",
+        "$type": "color"
+      },
+      "successText": {
+        "$value": "#002b36",
+        "$type": "color"
+      },
+      "warningText": {
+        "$value": "#002b36",
+        "$type": "color"
       }
     },
     "border": {

--- a/scripts/format-utils.mjs
+++ b/scripts/format-utils.mjs
@@ -24,3 +24,65 @@ export function escapeString(str) {
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
 }
+
+// ---------------------------------------------------------------------------
+// WCAG contrast helpers for per-state text color overrides (#267)
+// ---------------------------------------------------------------------------
+
+function sRGBtoLinear(c) {
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/**
+ * Relative luminance per WCAG 2.1.
+ * @param {string} hex - Hex color (e.g. '#ff0000')
+ * @returns {number}
+ */
+export function getLuminance(hex) {
+  const h = hex.replace('#', '');
+  const r = sRGBtoLinear(parseInt(h.slice(0, 2), 16) / 255);
+  const g = sRGBtoLinear(parseInt(h.slice(2, 4), 16) / 255);
+  const b = sRGBtoLinear(parseInt(h.slice(4, 6), 16) / 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * WCAG contrast ratio between two hex colors.
+ * @param {string} fg
+ * @param {string} bg
+ * @returns {number}
+ */
+export function contrastRatio(fg, bg) {
+  const l1 = getLuminance(fg);
+  const l2 = getLuminance(bg);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+/**
+ * Compute per-state text color overrides where the default inverse text
+ * does not meet WCAG AA large-text contrast (3:1) against the state
+ * background color.
+ *
+ * @param {Record<string, string>} stateColors - e.g. { info, success, warning, danger }
+ * @param {string} inverse - Default text color used on state buttons
+ * @param {string} textPrimary - Theme primary text color (candidate override)
+ * @returns {Record<string, string>} e.g. { successText: '#000000', warningText: '#363636' }
+ */
+export function stateTextOverrides(stateColors, inverse, textPrimary) {
+  const overrides = {};
+  const WCAG_AA_LARGE = 3.0;
+  for (const [key, bg] of Object.entries(stateColors)) {
+    const invCR = contrastRatio(inverse, bg);
+    if (invCR >= WCAG_AA_LARGE) continue;
+    const candidates = [
+      { color: textPrimary, cr: contrastRatio(textPrimary, bg) },
+      { color: '#ffffff', cr: contrastRatio('#ffffff', bg) },
+      { color: '#000000', cr: contrastRatio('#000000', bg) },
+    ];
+    candidates.sort((a, b) => b.cr - a.cr);
+    if (candidates[0].cr >= WCAG_AA_LARGE) {
+      overrides[`${key}Text`] = candidates[0].color;
+    }
+  }
+  return overrides;
+}

--- a/scripts/sync-catppuccin.mjs
+++ b/scripts/sync-catppuccin.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { flavors as catFlavors } from '@catppuccin/palette';
 
-import { escapeString, isValidIdentifier } from './format-utils.mjs';
+import { escapeString, isValidIdentifier, stateTextOverrides } from './format-utils.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -42,6 +42,16 @@ function buildTokens(flavor) {
       success: catColor('green', flavor) ?? '#22c55e',
       warning: catColor('yellow', flavor) ?? '#facc15',
       danger: catColor('red', flavor) ?? '#ef4444',
+      ...stateTextOverrides(
+        {
+          info: catColor('sky', flavor) ?? brandPrimary,
+          success: catColor('green', flavor) ?? '#22c55e',
+          warning: catColor('yellow', flavor) ?? '#facc15',
+          danger: catColor('red', flavor) ?? '#ef4444',
+        },
+        bgBase,
+        textPrimary,
+      ),
     },
     border: { default: catColor('overlay0', flavor) ?? '#e5e7eb' },
     accent: { link: catColor('blue', flavor) ?? brandPrimary },

--- a/scripts/sync-github.mjs
+++ b/scripts/sync-github.mjs
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { escapeString, isValidIdentifier } from './format-utils.mjs';
+import { escapeString, isValidIdentifier, stateTextOverrides } from './format-utils.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -83,6 +83,11 @@ function buildTokens(tokens, appearance) {
       success: successColor,
       warning: warningColor,
       danger: dangerColor,
+      ...stateTextOverrides(
+        { info: infoColor, success: successColor, warning: warningColor, danger: dangerColor },
+        textInverse,
+        textPrimary,
+      ),
     },
     border: { default: borderDefault },
     accent: { link: linkColor },

--- a/scripts/sync-rose-pine.mjs
+++ b/scripts/sync-rose-pine.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { variants } from '@rose-pine/palette';
 
-import { escapeString, isValidIdentifier } from './format-utils.mjs';
+import { escapeString, isValidIdentifier, stateTextOverrides } from './format-utils.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -45,6 +45,16 @@ function buildTokens(variant) {
       success: rpColor('pine', variant) ?? '#22c55e',
       warning: rpColor('gold', variant) ?? '#facc15',
       danger: rpColor('love', variant) ?? '#ef4444',
+      ...stateTextOverrides(
+        {
+          info: rpColor('foam', variant) ?? brandPrimary,
+          success: rpColor('pine', variant) ?? '#22c55e',
+          warning: rpColor('gold', variant) ?? '#facc15',
+          danger: rpColor('love', variant) ?? '#ef4444',
+        },
+        bgBase,
+        textPrimary,
+      ),
     },
     border: { default: rpColor('highlightMed', variant) ?? '#e5e7eb' },
     accent: { link: rpColor('iris', variant) ?? brandPrimary },

--- a/src/themes/packs/bulma.ts
+++ b/src/themes/packs/bulma.ts
@@ -48,6 +48,8 @@ export const bulmaThemes: ThemePackage = {
           info: '#3e8ed0',
           success: '#48c78e',
           warning: '#ffe08a',
+          successText: '#363636',
+          warningText: '#363636',
           danger: '#f14668',
         },
         border: {

--- a/src/themes/packs/catppuccin.synced.ts
+++ b/src/themes/packs/catppuccin.synced.ts
@@ -48,6 +48,9 @@ export const catppuccinSynced: ThemePackage = {
           success: '#40a02b',
           warning: '#df8e1d',
           danger: '#d20f39',
+          infoText: '#000000',
+          successText: '#000000',
+          warningText: '#000000',
         },
         border: {
           default: '#9ca0b0',

--- a/src/themes/packs/github.synced.ts
+++ b/src/themes/packs/github.synced.ts
@@ -131,6 +131,8 @@ export const githubSynced: ThemePackage = {
           success: '#3fb950',
           warning: '#d29922',
           danger: '#f85149',
+          successText: '#000000',
+          warningText: '#000000',
         },
         border: {
           default: '#3d444d',

--- a/src/themes/packs/gruvbox.ts
+++ b/src/themes/packs/gruvbox.ts
@@ -326,16 +326,19 @@ export const gruvboxThemes: ThemePackage = {
       vendor: 'gruvbox',
       appearance: 'light',
       iconUrl: '/assets/img/gruvbox-light-soft.png',
-      tokens: buildTokens({
-        appearance: 'light',
-        background: {
-          base: '#f2e5bc',
-          surface: '#ebdbb2',
-          overlay: '#d5c4a1',
-        },
-        text: LIGHT_TEXT,
-        border: LIGHT_BORDER,
-      }),
+      tokens: (() => {
+        const t = buildTokens({
+          appearance: 'light',
+          background: {
+            base: '#f2e5bc',
+            surface: '#ebdbb2',
+            overlay: '#d5c4a1',
+          },
+          text: LIGHT_TEXT,
+          border: LIGHT_BORDER,
+        });
+        return { ...t, state: { ...t.state, warningText: '#3c3836' } };
+      })(),
     },
   ],
 } as const;

--- a/src/themes/packs/solarized.ts
+++ b/src/themes/packs/solarized.ts
@@ -174,6 +174,9 @@ export const solarizedThemes: ThemePackage = {
           success: '#859900',
           warning: '#b58900',
           danger: '#dc322f',
+          infoText: '#002b36',
+          successText: '#002b36',
+          warningText: '#002b36',
         },
         border: {
           default: '#93a1a1',

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -20,6 +20,10 @@ export interface ThemeTokens {
     success: string;
     warning: string;
     danger: string;
+    infoText?: string;
+    successText?: string;
+    warningText?: string;
+    dangerText?: string;
   };
   border: {
     default: string;

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.17.0",
-  "$generated": "2026-02-06T20:50:07.242Z",
+  "$generated": "2026-02-07T08:22:11.189Z",
   "meta": {
     "themeIds": [
       "bulma-dark",
@@ -242,7 +242,9 @@
           "info": "#3e8ed0",
           "success": "#48c78e",
           "warning": "#ffe08a",
-          "danger": "#f14668"
+          "danger": "#f14668",
+          "successText": "#363636",
+          "warningText": "#363636"
         },
         "border": {
           "default": "#dbdbdb"
@@ -482,7 +484,10 @@
           "info": "#04a5e5",
           "success": "#40a02b",
           "warning": "#df8e1d",
-          "danger": "#d20f39"
+          "danger": "#d20f39",
+          "infoText": "#000000",
+          "successText": "#ffffff",
+          "warningText": "#4c4f69"
         },
         "border": {
           "default": "#9ca0b0"
@@ -885,7 +890,9 @@
           "info": "#4493f8",
           "success": "#3fb950",
           "warning": "#d29922",
-          "danger": "#f85149"
+          "danger": "#f85149",
+          "successText": "#0d1117",
+          "warningText": "#0d1117"
         },
         "border": {
           "default": "#3d444d"
@@ -1569,7 +1576,8 @@
           "info": "#076678",
           "success": "#79740e",
           "warning": "#b57614",
-          "danger": "#9d0006"
+          "danger": "#9d0006",
+          "warningText": "#3c3836"
         },
         "border": {
           "default": "#bdae93"
@@ -1911,7 +1919,8 @@
           "info": "#56949f",
           "success": "#286983",
           "warning": "#ea9d34",
-          "danger": "#b4637a"
+          "danger": "#b4637a",
+          "warningText": "#575279"
         },
         "border": {
           "default": "#dfdad9"
@@ -2287,7 +2296,10 @@
           "info": "#2aa198",
           "success": "#859900",
           "warning": "#b58900",
-          "danger": "#dc322f"
+          "danger": "#dc322f",
+          "infoText": "#002b36",
+          "successText": "#002b36",
+          "warningText": "#002b36"
         },
         "border": {
           "default": "#93a1a1"

--- a/test/css-output/state-button-contrast.test.ts
+++ b/test/css-output/state-button-contrast.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { flavors } from '../../packages/core/src/tokens/index';
+import { getContrastRatio } from './test-utils';
+
+const WCAG_AA_LARGE = 3.0;
+const WCAG_AA_NORMAL = 4.5;
+const stateKeys = ['info', 'success', 'warning', 'danger'] as const;
+
+describe('State button text contrast', () => {
+	for (const flavor of flavors) {
+		describe(flavor.id, () => {
+			for (const key of stateKeys) {
+				const stateBg = flavor.tokens.state[key];
+				const stateTextKey = `${key}Text` as keyof typeof flavor.tokens.state;
+				const textColor =
+					(flavor.tokens.state[stateTextKey] as string | undefined) ??
+					flavor.tokens.text.inverse;
+
+				it(`${key} button meets WCAG AA large text (3:1)`, () => {
+					const ratio = getContrastRatio(textColor, stateBg);
+					expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_LARGE);
+				});
+			}
+		});
+	}
+
+	// Advisory: flag themes that don't meet WCAG AA normal text (4.5:1)
+	describe('advisory: WCAG AA normal text (4.5:1)', () => {
+		for (const flavor of flavors) {
+			for (const key of stateKeys) {
+				const stateBg = flavor.tokens.state[key];
+				const stateTextKey = `${key}Text` as keyof typeof flavor.tokens.state;
+				const textColor =
+					(flavor.tokens.state[stateTextKey] as string | undefined) ??
+					flavor.tokens.text.inverse;
+				const ratio = getContrastRatio(textColor, stateBg);
+
+				if (ratio < WCAG_AA_NORMAL) {
+					it.skip(`${flavor.id} ${key}: ${ratio.toFixed(2)} < 4.5:1 (advisory)`, () => {
+						// Advisory only - skipped
+					});
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

State buttons (`.btn-success`, `.btn-warning`, `.btn-danger`, `.btn-info`) used `--turbo-bg-base` as text color, which had insufficient contrast on several light themes (catppuccin-latte, bulma-light, solarized-light, rose-pine-dawn, gruvbox-light-soft) and github-dark. Add optional per-state text color tokens computed via WCAG contrast analysis, and update `buttons.css` to consume them with a graceful fallback.

## Type

- [ ] ✨ Feature (`feat:`)
- [x] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Add optional per-state text tokens (`successText`, `warningText`, `infoText`, `dangerText`) to `ThemeTokens.state` in both `src/themes/types.ts` and `packages/core/src/themes/types.ts`
- Extract shared WCAG contrast helpers (`contrastRatio`, `stateTextOverrides`, `getLuminance`) to `scripts/format-utils.mjs`
- Update `sync-catppuccin.mjs`, `sync-github.mjs`, and `sync-rose-pine.mjs` to auto-compute text overrides via `stateTextOverrides()`
- Add manual text overrides for bulma-light, gruvbox-light-soft, and solarized-light theme packs
- Update `packages/css/src/components/buttons.css` to use `var(--turbo-state-*-text, var(--turbo-bg-base))` with graceful fallback
- Update schema token files for 6 affected themes with per-state text tokens
- Regenerate `tokens.json` for core, python, and swift packages
- Add `test/css-output/state-button-contrast.test.ts` — 96 tests enforcing WCAG AA large text (3:1) across all 24 themes

## Closes

- Closes #267

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`bun run test`)

### Test Coverage

- [x] Coverage maintained or improved
- [x] No decrease in code coverage
- [x] Coverage report reviewed

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors
- [ ] Markdown linting passes (if applicable)

## Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [x] Comments added to complex code
- [ ] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

<!-- No breaking changes -->

- [ ] This PR contains breaking changes
- [ ] Migration guide provided below

## Screenshots / Demos

<!-- Visual spot-check of state buttons on light themes recommended during review -->

## Deployment Notes

<!-- No special deployment notes -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

## Additional Context

All 24 themes now pass WCAG AA large text contrast (3:1) for state buttons. The 27 skipped tests are advisory flags for themes that don't meet the stricter WCAG AA normal text threshold (4.5:1).

