### PR TITLE
fix(ci): add missing rose-pine.synced.ts to repository

### DIFF
--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.19.0",
-  "$generated": "2026-02-07T12:58:18.252Z",
+  "$generated": "2026-02-09T07:23:54.025Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.19.0",
-  "$generated": "2026-02-07T12:58:18.252Z",
+  "$generated": "2026-02-09T07:23:54.025Z",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/src/themes/packs/rose-pine.synced.ts
+++ b/src/themes/packs/rose-pine.synced.ts
@@ -1,0 +1,277 @@
+import type { ThemePackage } from '../types.js';
+
+/**
+ * Rosé Pine theme - All natural pine, faux fur and a bit of soho vibes
+ * Auto-synced from @rose-pine/palette
+ * @see https://rosepinetheme.com/
+ * @license MIT
+ *
+ * DO NOT EDIT MANUALLY - regenerate with: node scripts/sync-rose-pine.mjs
+ */
+export const rosePineSynced: ThemePackage = {
+  id: 'rose-pine',
+  name: 'Rosé Pine (synced)',
+  homepage: 'https://rosepinetheme.com/',
+  license: {
+    spdx: 'MIT',
+    url: 'https://github.com/rose-pine/rose-pine-theme/blob/main/license',
+    copyright: 'Rosé Pine',
+  },
+  source: {
+    package: '@rose-pine/palette',
+    version: '4.0.1',
+    repository: 'https://github.com/rose-pine/palette',
+  },
+  flavors: [
+    {
+      id: 'rose-pine-dawn',
+      label: 'Rosé Pine Dawn',
+      vendor: 'rose-pine',
+      appearance: 'light',
+      iconUrl: '/assets/img/rose-pine-dawn.png',
+      tokens: {
+        background: {
+          base: '#faf4ed',
+          surface: '#fffaf3',
+          overlay: '#f2e9e1',
+        },
+        text: {
+          primary: '#575279',
+          secondary: '#797593',
+          inverse: '#faf4ed',
+        },
+        brand: {
+          primary: '#907aa9',
+        },
+        state: {
+          info: '#56949f',
+          success: '#286983',
+          warning: '#ea9d34',
+          danger: '#b4637a',
+          warningText: '#000000',
+        },
+        border: {
+          default: '#dfdad9',
+        },
+        accent: {
+          link: '#907aa9',
+        },
+        typography: {
+          fonts: {
+            sans: 'Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"',
+            mono: 'JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          },
+          webFonts: [
+            'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap',
+            'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap',
+          ],
+        },
+        content: {
+          heading: {
+            h1: '#286983',
+            h2: '#907aa9',
+            h3: '#56949f',
+            h4: '#ea9d34',
+            h5: '#d7827e',
+            h6: '#b4637a',
+          },
+          body: {
+            primary: '#575279',
+            secondary: '#797593',
+          },
+          link: {
+            default: '#907aa9',
+          },
+          selection: {
+            fg: '#575279',
+            bg: '#cecacd',
+          },
+          blockquote: {
+            border: '#cecacd',
+            fg: '#575279',
+            bg: '#fffaf3',
+          },
+          codeInline: {
+            fg: '#575279',
+            bg: '#f2e9e1',
+          },
+          codeBlock: {
+            fg: '#575279',
+            bg: '#f2e9e1',
+          },
+          table: {
+            border: '#cecacd',
+            stripe: '#f2e9e1',
+            theadBg: '#dfdad9',
+          },
+        },
+      },
+    },
+    {
+      id: 'rose-pine',
+      label: 'Rosé Pine',
+      vendor: 'rose-pine',
+      appearance: 'dark',
+      iconUrl: '/assets/img/rose-pine.png',
+      tokens: {
+        background: {
+          base: '#191724',
+          surface: '#1f1d2e',
+          overlay: '#26233a',
+        },
+        text: {
+          primary: '#e0def4',
+          secondary: '#908caa',
+          inverse: '#191724',
+        },
+        brand: {
+          primary: '#c4a7e7',
+        },
+        state: {
+          info: '#9ccfd8',
+          success: '#31748f',
+          warning: '#f6c177',
+          danger: '#eb6f92',
+        },
+        border: {
+          default: '#403d52',
+        },
+        accent: {
+          link: '#c4a7e7',
+        },
+        typography: {
+          fonts: {
+            sans: 'Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"',
+            mono: 'JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          },
+          webFonts: [
+            'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap',
+            'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap',
+          ],
+        },
+        content: {
+          heading: {
+            h1: '#31748f',
+            h2: '#c4a7e7',
+            h3: '#9ccfd8',
+            h4: '#f6c177',
+            h5: '#ebbcba',
+            h6: '#eb6f92',
+          },
+          body: {
+            primary: '#e0def4',
+            secondary: '#908caa',
+          },
+          link: {
+            default: '#c4a7e7',
+          },
+          selection: {
+            fg: '#e0def4',
+            bg: '#524f67',
+          },
+          blockquote: {
+            border: '#524f67',
+            fg: '#e0def4',
+            bg: '#1f1d2e',
+          },
+          codeInline: {
+            fg: '#e0def4',
+            bg: '#26233a',
+          },
+          codeBlock: {
+            fg: '#e0def4',
+            bg: '#26233a',
+          },
+          table: {
+            border: '#524f67',
+            stripe: '#26233a',
+            theadBg: '#403d52',
+          },
+        },
+      },
+    },
+    {
+      id: 'rose-pine-moon',
+      label: 'Rosé Pine Moon',
+      vendor: 'rose-pine',
+      appearance: 'dark',
+      iconUrl: '/assets/img/rose-pine-moon.png',
+      tokens: {
+        background: {
+          base: '#232136',
+          surface: '#2a273f',
+          overlay: '#393552',
+        },
+        text: {
+          primary: '#e0def4',
+          secondary: '#908caa',
+          inverse: '#232136',
+        },
+        brand: {
+          primary: '#c4a7e7',
+        },
+        state: {
+          info: '#9ccfd8',
+          success: '#3e8fb0',
+          warning: '#f6c177',
+          danger: '#eb6f92',
+        },
+        border: {
+          default: '#44415a',
+        },
+        accent: {
+          link: '#c4a7e7',
+        },
+        typography: {
+          fonts: {
+            sans: 'Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"',
+            mono: 'JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          },
+          webFonts: [
+            'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap',
+            'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap',
+          ],
+        },
+        content: {
+          heading: {
+            h1: '#3e8fb0',
+            h2: '#c4a7e7',
+            h3: '#9ccfd8',
+            h4: '#f6c177',
+            h5: '#ea9a97',
+            h6: '#eb6f92',
+          },
+          body: {
+            primary: '#e0def4',
+            secondary: '#908caa',
+          },
+          link: {
+            default: '#c4a7e7',
+          },
+          selection: {
+            fg: '#e0def4',
+            bg: '#56526e',
+          },
+          blockquote: {
+            border: '#56526e',
+            fg: '#e0def4',
+            bg: '#2a273f',
+          },
+          codeInline: {
+            fg: '#e0def4',
+            bg: '#393552',
+          },
+          codeBlock: {
+            fg: '#e0def4',
+            bg: '#393552',
+          },
+          table: {
+            border: '#56526e',
+            stripe: '#393552',
+            theadBg: '#44415a',
+          },
+        },
+      },
+    },
+  ],
+} as const;

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.19.0",
-  "$generated": "2026-02-07T12:58:18.252Z",
+  "$generated": "2026-02-09T07:23:54.025Z",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

- Generates and commits the missing `rose-pine.synced.ts` file that was omitted in d55e0e7 (#328)
- The file was gitignored by the `*.synced.ts` rule but never force-added (unlike catppuccin and github synced files)
- Fixes the weekly "External Link Validation" [workflow failure on main](https://github.com/lgtm-hq/turbo-themes/actions/runs/21812159201), where the Astro site build failed with: `Could not resolve "./packs/rose-pine.synced.js" from "../../src/themes/registry.ts"`

## Test plan

- [x] `uv run lintro chk` — all 20 tools pass
- [x] `bun run build` — 24 themes built (including 3 Rose Pine variants)
- [x] `bun run examples:build` — 4/4 examples pass
- [x] `bun run test` — 2188/2188 unit tests pass (78 files)
- [x] `bun run examples:test` — 139/139 E2E tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rosé Pine theme with multiple flavor variants (dawn, rose-pine, moon, rose-pine-moon), including comprehensive color, typography, and content styling tokens.

* **Chores**
  * Updated theme token generation timestamps across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->