### PR TITLE
ci: rename Renovate workflow and fix permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,15 +9,18 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: renovate
-  cancel-in-progress: false
-
 jobs:
   renovate:
     name: 🔄 Automated Dependency Updates
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: renovate
+      cancel-in-progress: false
     steps:
       - name: Harden Runner
         if: ${{ !env.ACT }}
@@ -31,8 +34,10 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             registry.npmjs.org:443
             rubygems.org:443
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -41,3 +46,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json
+        env:
+          LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && 'debug' || 'info' }}


### PR DESCRIPTION
## Summary

Rename `maintenance-renovate.yml` → `renovate.yml` for org-wide naming consistency and add explicit job-level permissions so Renovate can fully manage dependency updates including the Dependency Dashboard.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [x] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Conventional Commits

This project uses [Conventional Commits](https://www.conventionalcommits.org/) for
automated releases and changelog generation.

**Commit Title Format:**

```
<type>(<scope>): <description>
```

## Changes Made

- Rename `maintenance-renovate.yml` → `renovate.yml` for org-wide consistency
- Add explicit job-level permissions: `contents: write`, `issues: write`, `pull-requests: write`
- Move `concurrency` block from top-level to job-level (matching org convention)
- Add conditional `LOG_LEVEL`: `debug` for manual dispatch, `info` for scheduled runs
- Add `release-assets.githubusercontent.com:443` to egress allowlist

## Related Issues

Fixes #361 Relates to #358

## Testing

- [ ] Unit tests added/updated — N/A (CI workflow only)
- [ ] Integration tests added/updated — N/A
- [x] Manual testing performed — validated against [Rustume PR #53](https://github.com/lgtm-hq/Rustume/pull/53)
- [x] All tests pass locally (`npm test`) — N/A

### Test Coverage

- [x] Coverage maintained or improved — N/A
- [x] No decrease in code coverage — N/A
- [x] Coverage report reviewed — N/A

## Quality Checks

- [x] Linting passes (`npm run lint`) — N/A (YAML only)
- [x] Formatting passes (`npm run format`) — N/A
- [x] TypeScript build successful (`npm run build`) — N/A
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable) — N/A

## Documentation

- [x] README updated (if needed) — N/A
- [x] API documentation updated (if needed) — N/A
- [x] Comments added to complex code — N/A
- [x] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — N/A
- [x] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works — N/A
- [x] New and existing unit tests pass locally with my changes — N/A
- [x] Any dependent changes have been merged and published — N/A
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**