### PR TITLE
fix(security): replace invalid email in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
-- Report vulnerabilities to: security@turbocoder13.dev
+- Report vulnerabilities via
+  [GitHub's private vulnerability reporting](https://github.com/lgtm-hq/turbo-themes/security/advisories/new).
 - Do not create public issues for security problems.
 - Acknowledgement within 3 business days; initial assessment in 7 days.
 - Coordinated disclosure: We will work on a fix and publish an advisory.
-- PGP optional: Provide a key if encrypted email is preferred.

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.20.1",
-  "$generated": "3b0531b21cdb1506278beb04b64c34bb370bbfcc2b1f0b3f0faf8148c73507e4",
+  "$generated": "ec1adee158df7ea7949c69d4cb89cc468259b639817f43eb916c2b712d57baa6",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.20.1",
-  "$generated": "3b0531b21cdb1506278beb04b64c34bb370bbfcc2b1f0b3f0faf8148c73507e4",
+  "$generated": "ec1adee158df7ea7949c69d4cb89cc468259b639817f43eb916c2b712d57baa6",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.20.1",
-  "$generated": "3b0531b21cdb1506278beb04b64c34bb370bbfcc2b1f0b3f0faf8148c73507e4",
+  "$generated": "ec1adee158df7ea7949c69d4cb89cc468259b639817f43eb916c2b712d57baa6",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

Replace the fabricated `security@turbocoder13.dev` email in SECURITY.md with a link to GitHub's private vulnerability reporting. Remove the PGP line since it's not applicable.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- Replace fake email with GitHub vulnerability reporting link
- Remove inapplicable PGP line

## Closes

- Closes #370

## Quality Checks

- [x] Linting passes
- [x] Formatting passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability reporting process to use GitHub's private vulnerability reporting feature, replacing the previous direct email submission method.

* **Chores**
  * Updated design token metadata across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->