### PR TITLE
fix(ci): use RELEASE_TOKEN for version PR creation

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -87,7 +87,7 @@ jobs:
         if: steps.guard.outputs.is_release != 'true' && steps.check-pr.outputs.pr_exists != 'true'
         run: node scripts/ci/create-version-pr.mjs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Generate Version PR Summary
         if: always()


### PR DESCRIPTION
## Summary

Use `RELEASE_TOKEN` (with `GITHUB_TOKEN` fallback) when creating version bump PRs so CI workflows trigger on the resulting PR. Currently, version bump PRs are created with `GITHUB_TOKEN`, which means GitHub won't trigger workflows on them (loop prevention), leaving required status checks permanently pending.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- `release-version-pr.yml`: Change `GH_TOKEN` from `secrets.GITHUB_TOKEN` to `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN` for the PR creation step
- Matches py-lintro's approach in `semantic-release.yml`

## Quality Checks

- [x] Linting passes
- [x] Formatting passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow configuration to enhance authentication token handling during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->