### PR TITLE
ci: add merge_group trigger to dependency vulnerability scan

### DIFF
--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -15,6 +15,10 @@ concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # py-lintro 0.61.0 pinned to immutable digest for reproducibility
+  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
+
 jobs:
   lintro:
     name: 🔍 Code Quality & Linting
@@ -31,29 +35,16 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-            astral.sh:443
-            bun.sh:443
             codeload.github.com:443
-            files.pythonhosted.org:443
-            github-releases.githubusercontent.com:443
             github.com:443
-            npmjs.org:443
+            ghcr.io:443
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
-            pipelines.actions.githubusercontent.com:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            registry.npmjs.org:443
-            release-assets.githubusercontent.com:443
-            releases.astral.sh:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-        with:
-          node-version: '22'
-          skip-ruby: 'true'
+      - name: Pull py-lintro Docker image
+        run: ./scripts/ci/pull-lintro-image.sh
 
       - name: Run lintro check
         id: lintro

--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -27,7 +27,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Harden Runner
         if: ${{ !env.ACT }}
@@ -54,21 +53,61 @@ jobs:
         continue-on-error: true
         run: ./scripts/ci/run-lintro.sh
 
-      - name: Generate PR comment
-        if: github.event_name == 'pull_request'
-        run: ./scripts/ci/lintro-pr-comment.sh
-
-      - name: Post PR comment
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: ./.github/actions/post-pr-comment
+      - name: Upload lintro output artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-file: lintro-comment.md
-          marker: lintro-report
+          name: lintro-output
+          path: chk-output.txt
+          if-no-files-found: ignore
 
       - name: Fail on lint errors
         if: env.CHK_EXIT_CODE != '0'
         run: |
           echo "::error::Lintro check failed. Review the PR comment or CI logs for details."
           exit 1
+
+  lint-comment:
+    name: 💬 Lintro PR Comment
+    needs: lintro
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.lintro.result != 'skipped' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        if: ${{ !env.ACT }}
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download lintro output artifact
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: lintro-output
+
+      - name: Generate PR comment
+        env:
+          CHK_EXIT_CODE: ${{ needs.lintro.result == 'success' && '0' || '1' }}
+        run: ./scripts/ci/lintro-pr-comment.sh
+
+      - name: Post PR comment
+        continue-on-error: true
+        uses: ./.github/actions/post-pr-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-file: lintro-comment.md
+          marker: lintro-report

--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -1,0 +1,79 @@
+---
+name: Quality - Lint & Format
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lintro:
+    name: 🔍 Code Quality & Linting
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        if: ${{ !env.ACT }}
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            astral.sh:443
+            bun.sh:443
+            codeload.github.com:443
+            files.pythonhosted.org:443
+            github-releases.githubusercontent.com:443
+            github.com:443
+            npmjs.org:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            releases.astral.sh:443
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          node-version: '22'
+          skip-ruby: 'true'
+
+      - name: Run lintro check
+        id: lintro
+        continue-on-error: true
+        run: ./scripts/ci/run-lintro.sh
+
+      - name: Generate PR comment
+        if: github.event_name == 'pull_request'
+        run: ./scripts/ci/lintro-pr-comment.sh
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/post-pr-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-file: lintro-comment.md
+          marker: lintro-report
+
+      - name: Fail on lint errors
+        if: env.CHK_EXIT_CODE != '0'
+        run: |
+          echo "::error::Lintro check failed. Review the PR comment or CI logs for details."
+          exit 1

--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: ./.github/actions/post-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -35,6 +36,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            api.osv.dev:443
+            api.deps.dev:443
             codeload.github.com:443
             github.com:443
             ghcr.io:443

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -19,7 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.60.2
+  # py-lintro 0.60.2 pinned to immutable digest for reproducibility
+  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.60.2@sha256:480cd6cfc40c6ad27ec1491a208fa3111fc72c679fc3a4246762c5cbd8752175
 
 jobs:
   security-audit:

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # py-lintro 0.60.2 pinned to immutable digest for reproducibility
-  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.60.2@sha256:480cd6cfc40c6ad27ec1491a208fa3111fc72c679fc3a4246762c5cbd8752175
+  # py-lintro 0.61.0 pinned to immutable digest for reproducibility
+  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
 
 jobs:
   security-audit:

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -3,6 +3,7 @@ name: Security - Dependency Vulnerability Scan
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -4,6 +4,7 @@ name: Security - Dependency Vulnerability Scan
 on:
   pull_request:
   merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -10,7 +10,8 @@ on:
 permissions: {}
 
 env:
-  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.60.2
+  # py-lintro 0.61.0 pinned to immutable digest for reproducibility
+  LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
 
 jobs:
   check-suppressions:

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
-  "$version": "0.20.30",
-  "$generated": "de4f0f42bfc13ac3eaad52918f83fc3d494f8a75d98846e240711409d988dc0d",
+  "$version": "0.20.28",
+  "$generated": "12f1a66ecd6adc20079d096dfa36ad65e5f6ded807b6a84fa1755b03e10c8f1d",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
-  "$version": "0.20.28",
-  "$generated": "12f1a66ecd6adc20079d096dfa36ad65e5f6ded807b6a84fa1755b03e10c8f1d",
+  "$version": "0.20.30",
+  "$generated": "5fc5db6ce0a722574f17a9d9bf0e1549ab5b3ca1fa84f2aed99d870951bb6652",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
-  "$version": "0.20.30",
-  "$generated": "de4f0f42bfc13ac3eaad52918f83fc3d494f8a75d98846e240711409d988dc0d",
+  "$version": "0.20.28",
+  "$generated": "12f1a66ecd6adc20079d096dfa36ad65e5f6ded807b6a84fa1755b03e10c8f1d",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
-  "$version": "0.20.28",
-  "$generated": "12f1a66ecd6adc20079d096dfa36ad65e5f6ded807b6a84fa1755b03e10c8f1d",
+  "$version": "0.20.30",
+  "$generated": "5fc5db6ce0a722574f17a9d9bf0e1549ab5b3ca1fa84f2aed99d870951bb6652",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/scripts/ci/lintro-pr-comment.sh
+++ b/scripts/ci/lintro-pr-comment.sh
@@ -8,31 +8,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../utils/utils.sh"
 
 if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
-    log_info "Not a pull_request event, skipping comment generation"
-    exit 0
+  log_info "Not a pull_request event, skipping comment generation"
+  exit 0
 fi
 
 # Extract execution summary section from chk-output.txt
 if [[ -f chk-output.txt ]]; then
-    start_line=$(grep -n "EXECUTION SUMMARY" chk-output.txt | head -n1 | cut -d: -f1 || true)
-    if [[ -n "${start_line:-}" ]]; then
-        tail -n +"$start_line" chk-output.txt > chk-summary.txt || true
-    else
-        tail -n 50 chk-output.txt > chk-summary.txt || true
-    fi
+  start_line=$(grep -n "EXECUTION SUMMARY" chk-output.txt | head -n1 | cut -d: -f1 || true)
+  if [[ -n "${start_line:-}" ]]; then
+    tail -n +"$start_line" chk-output.txt >chk-summary.txt || true
+  else
+    tail -n 50 chk-output.txt >chk-summary.txt || true
+  fi
 fi
 
 if [[ -f chk-summary.txt ]]; then
-    OUTPUT=$(cat chk-summary.txt)
+  OUTPUT=$(cat chk-summary.txt)
 else
-    OUTPUT="❌ Analysis failed — check the CI logs for details"
+  OUTPUT="❌ Analysis failed — check the CI logs for details"
 fi
 
 # GitHub PR comment max is 65536 chars; cap well below to leave room for
 # wrapper markdown, status header, and footer.
 MAX_BYTES="${LINTRO_COMMENT_MAX_BYTES:-60000}"
-if (( ${#OUTPUT} > MAX_BYTES )); then
-    OUTPUT="${OUTPUT:0:MAX_BYTES}
+if ((${#OUTPUT} > MAX_BYTES)); then
+  OUTPUT="${OUTPUT:0:MAX_BYTES}
 
 …[truncated — see CI logs for full output]"
 fi
@@ -41,9 +41,9 @@ fi
 OUTPUT="${OUTPUT//\`\`\`/\`\`\` }"
 
 if [[ "${CHK_EXIT_CODE:-1}" != "0" ]]; then
-    STATUS="⚠️ ISSUES FOUND"
+  STATUS="⚠️ ISSUES FOUND"
 else
-    STATUS="✅ PASSED"
+  STATUS="✅ PASSED"
 fi
 
 CONTENT="**Workflow:** 🔍 Performed code quality checks with \`lintro check\`

--- a/scripts/ci/lintro-pr-comment.sh
+++ b/scripts/ci/lintro-pr-comment.sh
@@ -28,6 +28,18 @@ else
     OUTPUT="❌ Analysis failed — check the CI logs for details"
 fi
 
+# GitHub PR comment max is 65536 chars; cap well below to leave room for
+# wrapper markdown, status header, and footer.
+MAX_BYTES="${LINTRO_COMMENT_MAX_BYTES:-60000}"
+if (( ${#OUTPUT} > MAX_BYTES )); then
+    OUTPUT="${OUTPUT:0:MAX_BYTES}
+
+…[truncated — see CI logs for full output]"
+fi
+
+# Escape backticks to prevent breaking out of the fenced code block.
+OUTPUT="${OUTPUT//\`\`\`/\`\`\` }"
+
 if [[ "${CHK_EXIT_CODE:-1}" != "0" ]]; then
     STATUS="⚠️ ISSUES FOUND"
 else

--- a/scripts/ci/lintro-pr-comment.sh
+++ b/scripts/ci/lintro-pr-comment.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Generate a PR comment from lintro check output (chk-output.txt).
+# Reads CHK_EXIT_CODE from the environment to determine pass/fail status.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../utils/utils.sh
+source "${SCRIPT_DIR}/../utils/utils.sh"
+
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
+    log_info "Not a pull_request event, skipping comment generation"
+    exit 0
+fi
+
+# Extract execution summary section from chk-output.txt
+if [[ -f chk-output.txt ]]; then
+    start_line=$(grep -n "EXECUTION SUMMARY" chk-output.txt | head -n1 | cut -d: -f1 || true)
+    if [[ -n "${start_line:-}" ]]; then
+        tail -n +"$start_line" chk-output.txt > chk-summary.txt || true
+    else
+        tail -n 50 chk-output.txt > chk-summary.txt || true
+    fi
+fi
+
+if [[ -f chk-summary.txt ]]; then
+    OUTPUT=$(cat chk-summary.txt)
+else
+    OUTPUT="❌ Analysis failed — check the CI logs for details"
+fi
+
+if [[ "${CHK_EXIT_CODE:-1}" != "0" ]]; then
+    STATUS="⚠️ ISSUES FOUND"
+else
+    STATUS="✅ PASSED"
+fi
+
+CONTENT="**Workflow:** 🔍 Performed code quality checks with \`lintro check\`
+
+### 📋 Results:
+\`\`\`
+$OUTPUT
+\`\`\`"
+
+generate_pr_comment "Lintro Code Quality Analysis" "$STATUS" "$CONTENT" "lintro-comment.md" "lintro"

--- a/scripts/ci/lintro-pr-comment.sh
+++ b/scripts/ci/lintro-pr-comment.sh
@@ -37,20 +37,24 @@ if ((${#OUTPUT} > MAX_BYTES)); then
 …[truncated — see CI logs for full output]"
 fi
 
-# Escape backticks to prevent breaking out of the fenced code block.
-OUTPUT="${OUTPUT//\`\`\`/\`\`\` }"
-
 if [[ "${CHK_EXIT_CODE:-1}" != "0" ]]; then
   STATUS="⚠️ ISSUES FOUND"
 else
   STATUS="✅ PASSED"
 fi
 
+# Choose a fence longer than any backtick run found in OUTPUT so the
+# embedded content cannot prematurely close the markdown code block.
+FENCE='```'
+while printf '%s\n' "$OUTPUT" | grep -qF "$FENCE"; do
+  FENCE="${FENCE}\`"
+done
+
 CONTENT="**Workflow:** 🔍 Performed code quality checks with \`lintro check\`
 
 ### 📋 Results:
-\`\`\`
+${FENCE}
 $OUTPUT
-\`\`\`"
+${FENCE}"
 
 generate_pr_comment "Lintro Code Quality Analysis" "$STATUS" "$CONTENT" "lintro-comment.md" "lintro"

--- a/scripts/ci/run-lintro.sh
+++ b/scripts/ci/run-lintro.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
-# Run lintro check and capture output for PR comment generation.
-# Sets CHK_EXIT_CODE in GITHUB_ENV for downstream steps.
+# Run lintro check inside the py-lintro Docker image and capture output for
+# PR comment generation. Sets CHK_EXIT_CODE in GITHUB_ENV for downstream steps.
+#
+# Required env: LINTRO_IMAGE (e.g. ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:...)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../utils/utils.sh
 source "${SCRIPT_DIR}/../utils/utils.sh"
 
-log_info "Running lintro check..."
+LINTRO_IMAGE="${LINTRO_IMAGE:?LINTRO_IMAGE env var must be set}"
+
+log_info "Running lintro check via ${LINTRO_IMAGE}..."
 
 set +eo pipefail
-uv run lintro check 2>&1 | tee chk-output.txt
+docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
+  -v "$PWD:/code" -w /code "${LINTRO_IMAGE}" \
+  lintro check --output-format grid 2>&1 | tee chk-output.txt
 EXIT_CODE=${PIPESTATUS[0]}
 set -eo pipefail
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
-    echo "CHK_EXIT_CODE=$EXIT_CODE" >> "$GITHUB_ENV"
+  echo "CHK_EXIT_CODE=$EXIT_CODE" >>"$GITHUB_ENV"
 fi
 
 log_info "lintro check completed (exit code: $EXIT_CODE)"

--- a/scripts/ci/run-lintro.sh
+++ b/scripts/ci/run-lintro.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run lintro check and capture output for PR comment generation.
+# Sets CHK_EXIT_CODE in GITHUB_ENV for downstream steps.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../utils/utils.sh
+source "${SCRIPT_DIR}/../utils/utils.sh"
+
+log_info "Running lintro check..."
+
+set +eo pipefail
+uv run lintro check 2>&1 | tee chk-output.txt
+EXIT_CODE=${PIPESTATUS[0]}
+set -eo pipefail
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "CHK_EXIT_CODE=$EXIT_CODE" >> "$GITHUB_ENV"
+fi
+
+log_info "lintro check completed (exit code: $EXIT_CODE)"

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
-  "$version": "0.20.30",
-  "$generated": "de4f0f42bfc13ac3eaad52918f83fc3d494f8a75d98846e240711409d988dc0d",
+  "$version": "0.20.28",
+  "$generated": "12f1a66ecd6adc20079d096dfa36ad65e5f6ded807b6a84fa1755b03e10c8f1d",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
-  "$version": "0.20.28",
-  "$generated": "12f1a66ecd6adc20079d096dfa36ad65e5f6ded807b6a84fa1755b03e10c8f1d",
+  "$version": "0.20.30",
+  "$generated": "5fc5db6ce0a722574f17a9d9bf0e1549ab5b3ca1fa84f2aed99d870951bb6652",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

- Closes #438

Adds `merge_group:` trigger to the OSV vulnerability scan workflow so it re-runs at the moment a PR enters the merge queue — catching CVEs that were published between PR creation and merge.

## Problem

The scan only ran on `pull_request` events. A PR could pass its initial scan, sit open for a few days while new CVEs are published, then get merged — failing the post-merge scan on `main`. This happened with PR #433: 3 CVEs were published in the 4-day window between when the PR was opened and when it was merged.

## Fix

GitHub's merge queue creates a temporary merge commit and re-runs all required checks synchronously before completing the merge. Adding `merge_group:` as a trigger ensures the vuln scan runs against the latest CVE database at the actual moment of merge.

## Changes

- `.github/workflows/security-dependency-review.yml`: added `merge_group:` to `on:` block

## Test plan

- [ ] Enable merge queue on `main` branch protection rule
- [ ] Confirm vuln scan appears as a required check in the merge queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated "Quality - Lint & Format" workflow that runs lint/format checks, posts summarized results to pull requests, and includes CI helpers to capture and publish lint output.

* **Chores**
  * Pinned and upgraded the lint/security tooling image to an immutable digest.
  * Broadened CI triggers to include merge-queue checks and manual dispatch.
  * Updated regenerated design token metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->