### PR TITLE
fix(ci): stabilize tokens.json $generated and use osv-scanner entrypoint for vuln probe

### DIFF
--- a/.github/workflows/maintenance-renovate-theme-sync.yml
+++ b/.github/workflows/maintenance-renovate-theme-sync.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Commit and push regen if needed
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          COMMIT_REF: ${{ github.head_ref }}
         run: |
           if git diff --quiet -- 'src/themes/packs/*.synced.ts'; then
             echo "No theme sync changes — nothing to commit."
@@ -90,5 +91,5 @@ jobs:
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
           git add -- 'src/themes/packs/*.synced.ts'
-          git commit -m "chore(deps): regenerate synced themes for ${{ github.head_ref }}"
+          git commit -m "chore(deps): regenerate synced themes for ${COMMIT_REF}"
           git push

--- a/.github/workflows/maintenance-renovate-theme-sync.yml
+++ b/.github/workflows/maintenance-renovate-theme-sync.yml
@@ -1,0 +1,94 @@
+---
+name: Maintenance - Renovate Theme Sync
+
+# Renovate (Mend Cloud) doesn't run postUpgradeTasks, so when it bumps one of
+# the npm packages backing our *.synced.ts theme files we need to regenerate
+# those files ourselves. This workflow listens for Renovate PRs touching the
+# three source packages, runs `bun run theme:sync`, and pushes the regenerated
+# *.synced.ts back onto the PR branch using a GitHub App token (so CI
+# re-triggers).
+#
+# Recursion: the push fires another `pull_request: synchronize`. The follow-up
+# run re-syncs, finds no diff, and exits. One wasted cycle, no infinite loop.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'package.json'
+      - 'bun.lock'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-theme-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: 🔄 Regenerate Synced Themes
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      (contains(github.head_ref, 'primer-primitives') ||
+       contains(github.head_ref, 'catppuccin-palette') ||
+       contains(github.head_ref, 'rose-pine-palette'))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        if: ${{ !env.ACT }}
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            bun.sh:443
+            codeload.github.com:443
+            github.com:443
+            npmjs.org:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          node-version: '22'
+          skip-ruby: 'true'
+
+      - name: Run theme sync
+        run: bun run theme:sync
+
+      - name: Commit and push regen if needed
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          if git diff --quiet -- 'src/themes/packs/*.synced.ts'; then
+            echo "No theme sync changes — nothing to commit."
+            exit 0
+          fi
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git add -- 'src/themes/packs/*.synced.ts'
+          git commit -m "chore(deps): regenerate synced themes for ${{ github.head_ref }}"
+          git push

--- a/.github/workflows/maintenance-renovate-theme-sync.yml
+++ b/.github/workflows/maintenance-renovate-theme-sync.yml
@@ -83,13 +83,4 @@ jobs:
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           COMMIT_REF: ${{ github.head_ref }}
-        run: |
-          if git diff --quiet -- 'src/themes/packs/*.synced.ts'; then
-            echo "No theme sync changes — nothing to commit."
-            exit 0
-          fi
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-          git add -- 'src/themes/packs/*.synced.ts'
-          git commit -m "chore(deps): regenerate synced themes for ${COMMIT_REF}"
-          git push
+        run: ./scripts/ci/renovate-theme-sync-commit.sh

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -40,16 +40,3 @@ reason = "h3@2.0.0 — fix only in RC, transitive via astro/nitro, waiting for s
 id = "GHSA-wr4h-v87w-p3r7"
 ignoreUntil = 2026-06-29
 reason = "h3@2.0.0 — fix only in RC, transitive via astro/nitro, waiting for stable release"
-
-# --- npm packages with impractical remediation ---
-# OSV suggests downgrading to older major versions, which is not viable.
-
-[[IgnoredVulns]]
-id = "GHSA-wf6x-7x77-mvgw"
-ignoreUntil = 2026-09-29
-reason = "immutable@5.1.4 — not actionable, OSV suggests downgrading to v4 (breaking major)"
-
-[[IgnoredVulns]]
-id = "GHSA-mw96-cpmx-2vgc"
-ignoreUntil = 2026-09-29
-reason = "rollup@4.57.0 — not actionable, OSV suggests downgrading to v2 (breaking major)"

--- a/bun.lock
+++ b/bun.lock
@@ -158,7 +158,7 @@
     "@isaacs/brace-expansion": "5.0.1",
     "ajv": "8.20.0",
     "astro": "6.2.1",
-    "basic-ftp": "5.3.0",
+    "basic-ftp": "5.3.1",
     "brace-expansion": "5.0.5",
     "devalue": "5.8.0",
     "esbuild": "0.28.0",
@@ -857,7 +857,7 @@
 
     "basic-auth": ["basic-auth@2.0.1", "", { "dependencies": { "safe-buffer": "5.1.2" } }, "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg=="],
 
-    "basic-ftp": ["basic-ftp@5.3.0", "", {}, "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w=="],
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "body-parser": ["body-parser@1.20.5", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA=="],
 

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "picomatch": "4.0.4",
     "yaml": "2.8.3",
     "qs": "6.15.0",
-    "basic-ftp": "5.3.0",
+    "basic-ftp": "5.3.1",
     "uuid": "14.0.0",
     "follow-redirects": "1.16.0",
     "astro": "6.2.1",

--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.20.44",
-  "$generated": "5fc5db6ce0a722574f17a9d9bf0e1549ab5b3ca1fa84f2aed99d870951bb6652",
+  "$generated": "578ff006e2ad6a3b4ef5d5f663625b1da305529ea9c1cfb56de0967824ac09a3",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.20.44",
-  "$generated": "5fc5db6ce0a722574f17a9d9bf0e1549ab5b3ca1fa84f2aed99d870951bb6652",
+  "$generated": "578ff006e2ad6a3b4ef5d5f663625b1da305529ea9c1cfb56de0967824ac09a3",
   "meta": {
     "themeIds": [
       "bulma-dark",

--- a/scripts/ci/check-vuln-suppressions.sh
+++ b/scripts/ci/check-vuln-suppressions.sh
@@ -48,12 +48,16 @@ trap cleanup EXIT
 
 # Probe osv-scanner without suppressions (--config /dev/null bypasses .osv-scanner.toml)
 # to see which vulnerabilities still exist in the current lockfiles.
+# The py-lintro image's default entrypoint is `python -m lintro`; override it to
+# call the osv-scanner binary directly so we get raw osv-scanner JSON (which
+# parse_osv_scanner_output in classify-suppressions.py expects).
 log_info "Probing osv-scanner without suppressions..."
 PROBE_DIAG=""
 PROBE_OUTPUT=$(
   docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
+    --entrypoint osv-scanner \
     -v "$PWD:/code" -w /code "${LINTRO_IMAGE}" \
-    osv-scanner scan --format json --config /dev/null --recursive . \
+    scan --format json --config /dev/null --recursive . \
     2>"${PROBE_TMPFILE}.diag" || true
 )
 PROBE_DIAG=$(cat "${PROBE_TMPFILE}.diag" 2>/dev/null || true)
@@ -89,10 +93,11 @@ log_info "Classifying suppressions..."
 printf '%s' "${PROBE_OUTPUT}" >"${PROBE_TMPFILE}"
 CLASSIFICATION_JSON=$(
   docker run --rm \
+    --entrypoint sh \
     -v "$PWD:/code" -w /code \
     -v "${PROBE_TMPFILE}:/tmp/probe-output.json:ro" \
     "${LINTRO_IMAGE}" \
-    sh -c 'python3 /code/scripts/ci/classify-suppressions.py < /tmp/probe-output.json'
+    -c '/app/.venv/bin/python3 /code/scripts/ci/classify-suppressions.py < /tmp/probe-output.json'
 )
 
 # Validate that CLASSIFICATION_JSON is well-formed before extracting arrays.

--- a/scripts/ci/check-vuln-suppressions.sh
+++ b/scripts/ci/check-vuln-suppressions.sh
@@ -92,7 +92,7 @@ fi
 log_info "Classifying suppressions..."
 printf '%s' "${PROBE_OUTPUT}" >"${PROBE_TMPFILE}"
 CLASSIFICATION_JSON=$(
-  docker run --rm \
+  docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
     --entrypoint sh \
     -v "$PWD:/code" -w /code \
     -v "${PROBE_TMPFILE}:/tmp/probe-output.json:ro" \

--- a/scripts/ci/renovate-theme-sync-commit.sh
+++ b/scripts/ci/renovate-theme-sync-commit.sh
@@ -26,4 +26,4 @@ git config user.name "${APP_SLUG}[bot]"
 git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 git add -- 'src/themes/packs/*.synced.ts'
 git commit -m "chore(deps): regenerate synced themes for ${COMMIT_REF}"
-git push
+git push origin "HEAD:${COMMIT_REF}"

--- a/scripts/ci/renovate-theme-sync-commit.sh
+++ b/scripts/ci/renovate-theme-sync-commit.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 : "${APP_SLUG:?APP_SLUG is required}"
 : "${COMMIT_REF:?COMMIT_REF is required}"
 
-if git diff --quiet -- 'src/themes/packs/*.synced.ts'; then
+if git diff --quiet -- 'src/themes/packs/*.synced.ts' &&
+  [[ -z "$(git ls-files --others --exclude-standard -- 'src/themes/packs/*.synced.ts')" ]]; then
   echo "No theme sync changes — nothing to commit."
   exit 0
 fi

--- a/scripts/ci/renovate-theme-sync-commit.sh
+++ b/scripts/ci/renovate-theme-sync-commit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Commit and push regenerated *.synced.ts files back onto a Renovate PR
+# branch. Called by .github/workflows/maintenance-renovate-theme-sync.yml
+# after `bun run theme:sync`.
+#
+# Idempotent: exits cleanly if theme:sync produced no diff.
+#
+# Usage: renovate-theme-sync-commit.sh
+#
+# Environment:
+#   APP_SLUG    - GitHub App slug used as the bot identity in commit author
+#   COMMIT_REF  - Renovate branch name being updated (used in commit message)
+
+set -euo pipefail
+
+: "${APP_SLUG:?APP_SLUG is required}"
+: "${COMMIT_REF:?COMMIT_REF is required}"
+
+if git diff --quiet -- 'src/themes/packs/*.synced.ts'; then
+  echo "No theme sync changes — nothing to commit."
+  exit 0
+fi
+
+git config user.name "${APP_SLUG}[bot]"
+git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+git add -- 'src/themes/packs/*.synced.ts'
+git commit -m "chore(deps): regenerate synced themes for ${COMMIT_REF}"
+git push

--- a/scripts/ci/theme-sync-determinism-check.sh
+++ b/scripts/ci/theme-sync-determinism-check.sh
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
-# Run theme sync determinism check
+# Verify the theme generation pipeline is deterministic.
+#
+# The workflow runs `bun run build` before this script, which executes the
+# full token build pipeline (prepare-style-dictionary -> style-dictionary ->
+# copy to platform tokens.json). Rebuilding from committed inputs MUST
+# produce no diff; any drift here is a real non-determinism bug in the
+# generators.
+#
+# Note: this script intentionally does NOT run `theme:sync`. Upstream
+# package freshness is a separate concern and is handled by the Renovate
+# companion workflow (.github/workflows/maintenance-renovate-theme-sync.yml),
+# which regenerates the *.synced.ts files when Renovate bumps the source
+# packages. Mixing the two checks made this job fail on every upstream
+# release regardless of PR content.
+#
 # Usage: theme-sync-determinism-check.sh
 
 set -euo pipefail
 
-# Detect package manager (prefer bun, fall back to npm)
-if command -v bun >/dev/null 2>&1; then
-  PKG_RUN="bun run"
-elif command -v npm >/dev/null 2>&1; then
-  PKG_RUN="npm run"
-else
-  echo "❌ No package manager found!"
-  exit 1
-fi
-
-$PKG_RUN theme:sync
-
-# Check for changes — $generated is now a deterministic SHA-256 content hash of the generated JSON,
-# so any diff here represents a real non-deterministic change.
 STATUS_OUTPUT=$(git status --porcelain || true)
 
 if [[ -n "$STATUS_OUTPUT" ]]; then
-  echo 'Non-deterministic theme sync detected:'
+  echo 'Non-deterministic theme generation detected:'
   git status --porcelain
   git --no-pager diff | cat
   exit 1

--- a/scripts/ci/theme-sync-determinism-check.sh
+++ b/scripts/ci/theme-sync-determinism-check.sh
@@ -18,7 +18,10 @@
 
 set -euo pipefail
 
-STATUS_OUTPUT=$(git status --porcelain || true)
+if ! STATUS_OUTPUT=$(git status --porcelain); then
+  echo "git status failed" >&2
+  exit 1
+fi
 
 if [[ -n "$STATUS_OUTPUT" ]]; then
   echo 'Non-deterministic theme generation detected:'

--- a/scripts/prepare-style-dictionary.mjs
+++ b/scripts/prepare-style-dictionary.mjs
@@ -9,23 +9,23 @@
  * Output: dist/tokens/style-dictionary/themes.json
  */
 
-import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, readdirSync, mkdirSync, existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { validateThemeId } from './utils/validation.mjs';
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, readdirSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateThemeId } from "./utils/validation.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const projectRoot = join(__dirname, '..');
+const projectRoot = join(__dirname, "..");
 
-const themesDir = join(projectRoot, 'schema', 'tokens', 'themes');
-const sharedTokensPath = join(projectRoot, 'schema', 'tokens', '_shared.tokens.json');
-const outputDir = join(projectRoot, 'dist', 'tokens', 'style-dictionary');
-const packageJsonPath = join(projectRoot, 'package.json');
+const themesDir = join(projectRoot, "schema", "tokens", "themes");
+const sharedTokensPath = join(projectRoot, "schema", "tokens", "_shared.tokens.json");
+const outputDir = join(projectRoot, "dist", "tokens", "style-dictionary");
+const packageJsonPath = join(projectRoot, "package.json");
 
 // Get version from package.json
-const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 const version = packageJson.version;
 
 /**
@@ -47,7 +47,7 @@ function extractValues(obj) {
   }
 
   // If it's a W3C token with $value, extract it
-  if (typeof obj === 'object' && '$value' in obj) {
+  if (typeof obj === "object" && "$value" in obj) {
     return obj.$value;
   }
 
@@ -57,11 +57,11 @@ function extractValues(obj) {
   }
 
   // If it's an object, recursively process each property
-  if (typeof obj === 'object') {
+  if (typeof obj === "object") {
     const result = {};
     for (const [key, value] of Object.entries(obj)) {
       // Skip schema metadata keys
-      if (key.startsWith('$')) continue;
+      if (key.startsWith("$")) continue;
       result[key] = extractValues(value);
     }
     return result;
@@ -73,15 +73,18 @@ function extractValues(obj) {
 
 // Vendor metadata for byVendor grouping
 const vendorMeta = {
-  bulma: { name: 'Bulma', homepage: 'https://bulma.io/' },
-  catppuccin: { name: 'Catppuccin (synced)', homepage: 'https://catppuccin.com/palette/' },
-  dracula: { name: 'Dracula', homepage: 'https://draculatheme.com/' },
-  gruvbox: { name: 'Gruvbox', homepage: 'https://github.com/morhetz/gruvbox' },
-  github: { name: 'GitHub (synced)', homepage: 'https://primer.style/' },
-  nord: { name: 'Nord', homepage: 'https://www.nordtheme.com/' },
-  'rose-pine': { name: 'Rosé Pine (synced)', homepage: 'https://rosepinetheme.com/' },
-  solarized: { name: 'Solarized', homepage: 'https://ethanschoonover.com/solarized/' },
-  'tokyo-night': { name: 'Tokyo Night', homepage: 'https://github.com/enkia/tokyo-night-vscode-theme' },
+  bulma: { name: "Bulma", homepage: "https://bulma.io/" },
+  catppuccin: { name: "Catppuccin (synced)", homepage: "https://catppuccin.com/palette/" },
+  dracula: { name: "Dracula", homepage: "https://draculatheme.com/" },
+  gruvbox: { name: "Gruvbox", homepage: "https://github.com/morhetz/gruvbox" },
+  github: { name: "GitHub (synced)", homepage: "https://primer.style/" },
+  nord: { name: "Nord", homepage: "https://www.nordtheme.com/" },
+  "rose-pine": { name: "Rosé Pine (synced)", homepage: "https://rosepinetheme.com/" },
+  solarized: { name: "Solarized", homepage: "https://ethanschoonover.com/solarized/" },
+  "tokyo-night": {
+    name: "Tokyo Night",
+    homepage: "https://github.com/enkia/tokyo-night-vscode-theme",
+  },
 };
 
 /**
@@ -95,7 +98,7 @@ function groupByVendor(themes) {
     if (!vendors[vendor]) {
       vendors[vendor] = {
         name: vendorMeta[vendor]?.name || vendor,
-        homepage: vendorMeta[vendor]?.homepage || '',
+        homepage: vendorMeta[vendor]?.homepage || "",
         themes: [],
       };
     }
@@ -115,7 +118,7 @@ function transformTokenTree(obj, path = []) {
   }
 
   // If it's a W3C token with $value, transform it
-  if (typeof obj === 'object' && '$value' in obj) {
+  if (typeof obj === "object" && "$value" in obj) {
     return transformToken(obj);
   }
 
@@ -125,11 +128,11 @@ function transformTokenTree(obj, path = []) {
   }
 
   // If it's an object, recursively process each property
-  if (typeof obj === 'object') {
+  if (typeof obj === "object") {
     const result = {};
     for (const [key, value] of Object.entries(obj)) {
       // Skip schema metadata keys (except $type which we preserve on tokens)
-      if (key === '$schema' || key === '$description') continue;
+      if (key === "$schema" || key === "$description") continue;
       result[key] = transformTokenTree(value, [...path, key]);
     }
     return result;
@@ -148,12 +151,13 @@ function deepMerge(target, source) {
   for (const [key, value] of Object.entries(source)) {
     if (
       value &&
-      typeof value === 'object' &&
+      typeof value === "object" &&
       !Array.isArray(value) &&
-      !('value' in value) && // Don't recurse into token objects
+      !("$value" in value) && // Don't recurse into W3C token objects
       result[key] &&
-      typeof result[key] === 'object' &&
-      !Array.isArray(result[key])
+      typeof result[key] === "object" &&
+      !Array.isArray(result[key]) &&
+      !("$value" in result[key]) // Don't recurse into target W3C token objects either
     ) {
       result[key] = deepMerge(result[key], value);
     } else {
@@ -168,7 +172,7 @@ function deepMerge(target, source) {
  * Load and transform shared tokens
  */
 function loadSharedTokens() {
-  const data = JSON.parse(readFileSync(sharedTokensPath, 'utf-8'));
+  const data = JSON.parse(readFileSync(sharedTokensPath, "utf-8"));
   return transformTokenTree(data);
 }
 
@@ -176,7 +180,7 @@ function loadSharedTokens() {
  * Load and transform a single theme file
  */
 function loadTheme(filePath) {
-  const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+  const data = JSON.parse(readFileSync(filePath, "utf-8"));
 
   // Extract theme metadata
   const { id, label, vendor, appearance, iconUrl, tokens } = data;
@@ -201,7 +205,7 @@ function loadTheme(filePath) {
  * Main function
  */
 function main() {
-  console.log('[prepare-style-dictionary] Starting token transformation...');
+  console.log("[prepare-style-dictionary] Starting token transformation...");
 
   // Ensure output directory exists
   if (!existsSync(outputDir)) {
@@ -214,7 +218,7 @@ function main() {
 
   // Load all theme files
   const themeFiles = readdirSync(themesDir)
-    .filter((f) => f.endsWith('.tokens.json'))
+    .filter((f) => f.endsWith(".tokens.json"))
     .sort();
 
   const themes = {};
@@ -233,10 +237,10 @@ function main() {
 
   // Build output structure for Style Dictionary
   const output = {
-    $schema: 'https://design-tokens.org/schema.json',
+    $schema: "https://design-tokens.org/schema.json",
     $description: `Turbo Themes - Design tokens for ${themeIds.length} themes`,
     $version: version,
-    $generated: '', // replaced with content hash below
+    $generated: "", // replaced with content hash below
     meta: {
       themeIds,
       totalThemes: themeIds.length,
@@ -246,12 +250,14 @@ function main() {
     byVendor,
   };
 
-  // Compute deterministic content hash (excludes $generated itself)
-  const { $generated: _g1, ...outputHashable } = output;
-  output.$generated = createHash('sha256').update(JSON.stringify(outputHashable)).digest('hex');
+  // Compute deterministic content hash (excludes $generated and $version)
+  // $version is excluded so release-time version bumps via sync-version.mjs do
+  // not invalidate the hash on the next regeneration.
+  const { $generated: _g1, $version: _v1, ...outputHashable } = output;
+  output.$generated = createHash("sha256").update(JSON.stringify(outputHashable)).digest("hex");
 
   // Write main themes file (SD format with $value)
-  const outputPath = join(outputDir, 'themes.json');
+  const outputPath = join(outputDir, "themes.json");
   writeFileSync(outputPath, JSON.stringify(output, null, 2));
   console.log(`[prepare-style-dictionary] Wrote ${outputPath}`);
 
@@ -270,10 +276,10 @@ function main() {
   }
 
   const tokensOutput = {
-    $schema: 'https://design-tokens.org/schema.json',
+    $schema: "https://design-tokens.org/schema.json",
     $description: `Turbo Themes - Flat tokens for ${themeIds.length} themes`,
     $version: version,
-    $generated: '', // replaced with content hash below
+    $generated: "", // replaced with content hash below
     meta: {
       themeIds,
       totalThemes: themeIds.length,
@@ -283,12 +289,14 @@ function main() {
     byVendor,
   };
 
-  // Compute deterministic content hash
-  const { $generated: _g2, ...tokensHashable } = tokensOutput;
-  tokensOutput.$generated = createHash('sha256').update(JSON.stringify(tokensHashable)).digest('hex');
+  // Compute deterministic content hash (excludes $generated and $version; see above)
+  const { $generated: _g2, $version: _v2, ...tokensHashable } = tokensOutput;
+  tokensOutput.$generated = createHash("sha256")
+    .update(JSON.stringify(tokensHashable))
+    .digest("hex");
 
   // Write flat tokens file for TypeScript/runtime
-  const tokensPath = join(outputDir, 'tokens.json');
+  const tokensPath = join(outputDir, "tokens.json");
   writeFileSync(tokensPath, JSON.stringify(tokensOutput, null, 2));
   console.log(`[prepare-style-dictionary] Wrote ${tokensPath}`);
 
@@ -304,7 +312,7 @@ function main() {
   }
 
   console.log(`[prepare-style-dictionary] Wrote ${themeIds.length} individual theme files`);
-  console.log('[prepare-style-dictionary] Done!');
+  console.log("[prepare-style-dictionary] Done!");
 }
 
 main();

--- a/src/themes/packs/github.synced.ts
+++ b/src/themes/packs/github.synced.ts
@@ -19,7 +19,7 @@ export const githubSynced: ThemePackage = {
   },
   source: {
     package: "@primer/primitives",
-    version: "11.6.0",
+    version: "11.7.1",
     repository: "https://github.com/primer/primitives",
   },
   flavors: [

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/schema.json",
   "$description": "Turbo Themes - Flat tokens for 24 themes",
   "$version": "0.20.44",
-  "$generated": "5fc5db6ce0a722574f17a9d9bf0e1549ab5b3ca1fa84f2aed99d870951bb6652",
+  "$generated": "578ff006e2ad6a3b4ef5d5f663625b1da305529ea9c1cfb56de0967824ac09a3",
   "meta": {
     "themeIds": [
       "bulma-dark",


### PR DESCRIPTION
## Summary

Fixes the two recurring weekly-scheduled CI failures on `main`:

- **Theme Sync Determinism** (4 of last ~13 failures): `$generated` hash in committed `tokens.json` files included `$version`, so semantic-release's version bump invalidated the hash and made the next scheduled determinism check fail. Excluding `$version` from the hash makes it invariant under release bumps.
- **Vulnerability Suppression Check** (5 of last ~13 failures): py-lintro 0.61.0 image entrypoint is `python -m lintro`, so the script's `osv-scanner scan ...` and `sh -c '...'` calls were misinterpreted as lintro subcommands. Override `--entrypoint` and use the venv python so the binary and lintro deps are reachable directly.

While verifying Bug B end-to-end (real Docker run against the pinned image digest), the now-working classifier reported `GHSA-wf6x-7x77-mvgw` (immutable) and `GHSA-mw96-cpmx-2vgc` (rollup) as no longer present in any lockfile — included a small follow-up commit removing those stale `[[IgnoredVulns]]` entries.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- `scripts/prepare-style-dictionary.mjs`: exclude `$version` from `$generated` SHA-256 input (both the SD-format `themes.json` and the flat `tokens.json` outputs)
- `packages/core/src/themes/tokens.json`, `python/src/turbo_themes/tokens.json`, `swift/Sources/TurboThemes/Resources/tokens.json`: one-time `$generated` regeneration onto the new stable hash function
- `scripts/ci/check-vuln-suppressions.sh`: add `--entrypoint osv-scanner` to the probe step (preserves raw osv-scanner JSON consumed by `parse_osv_scanner_output`); add `--entrypoint sh` and switch the classifier to `/app/.venv/bin/python3` so lintro deps (loguru, etc.) load
- `.osv-scanner.toml`: remove now-stale `immutable@5.1.4` and `rollup@4.57.0` suppression entries

## Related Issues

Relates to recurring failures: weekly Theme Sync Determinism and Vulnerability Suppression Check workflows on `main`.

## Testing

- [x] Manual testing performed
- [x] All tests pass locally (`bun run test` — 79 files / 2252 tests / 95.8% statements coverage)

### Test Coverage

- [x] Coverage maintained or improved

### Verification details

**Bug A (Theme Sync Determinism)**
- After the fix, `bun run build:tokens` is idempotent against the new committed `tokens.json` (no diff on second run).
- Simulated post-release scenario: manually changed `$version` to `0.99.99-test`, re-ran `build:tokens` → `$version` was reset from `package.json`, `$generated` unchanged (`578ff006e2ad6a3b` before and after).

**Bug B (Vulnerability Suppression Check)**
- Pulled the pinned image digest (`ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd…`).
- Probe step ran cleanly via `--entrypoint osv-scanner`: scanned `uv.lock`, `python/uv.lock`, `bun.lock`, `examples/tailwind/bun.lock` (~1380 packages).
- Classifier ran via `/app/.venv/bin/python3` and reported all 6 remaining `h3` GHSAs as `Active`, exit 0 with `All suppressions are active. Nothing to do.`

## Quality Checks

- [x] Linting passes (`uv run lintro chk` — all 25 tools PASS, 0 issues)
- [x] Formatting passes (`uv run lintro fmt` — clean)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors

## Documentation

- [x] Comments added to complex code (rationale on the `$version` exclusion)

## Breaking Changes

- [ ] This PR contains breaking changes

No runtime API changes — only the `$generated` hash *value* differs from prior `tokens.json` releases. Downstream consumers reading `$value`, `$version`, or `meta.themeIds` are unaffected.

## Deployment Notes

After merge, the next scheduled run of `Vulnerability Suppression Check` (Mondays 04:00 UTC) and `Quality Check - Theme Sync Determinism` (Mondays 06:00 UTC) should both go green. To validate without waiting, trigger them manually via `workflow_dispatch`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Additional Context

Follow-up worth tracking separately: PR-time security audit comments (`security-audit.sh`) only echo the raw `[[IgnoredVulns]]` list from `.osv-scanner.toml` — they don't run the staleness classifier, so a stale suppression can persist up to 7 days before the weekly housekeeping workflow surfaces it (and even then, as a separate auto-PR rather than a comment on the open one). Adding a fast probe-and-classify pass to the PR-time comment is a deliberate trade-off worth revisiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a vulnerability suppression entry with an expiry and removed two prior suppressions.
  * Refreshed generated design-token metadata hashes across platforms.
  * Updated a package override.
* **CI / Tooling**
  * Improved vulnerability-scan invocation for reliable JSON output and classification.
  * Tightened token-processing and deterministic hashing during token generation.
  * Added helper scripts to commit/push regenerated theme artifacts and simplified determinism checks.
* **New Features**
  * Added a maintenance workflow to auto-sync regenerated theme artifacts.
* **Bug Fixes**
  * Bumped one theme primitive source version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->