### PR TITLE
feat(theme-selector): set data-appearance on document root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on Keep a Changelog and this project adheres to SemVer.
 
 ### Added
 
-- TBD
+- Set `data-appearance="light|dark"` on `document.documentElement` alongside
+  `data-theme` in the blocking script and runtime theme application, so consumers can
+  style by appearance without hardcoding theme IDs
 
 ## [0.20.49] - 2026-05-14
 

--- a/bun.lock
+++ b/bun.lock
@@ -159,8 +159,8 @@
     "ajv": "8.20.0",
     "astro": "6.3.1",
     "basic-ftp": "5.3.1",
-    "brace-expansion": "5.0.5",
-    "devalue": "5.8.0",
+    "brace-expansion": "5.0.6",
+    "devalue": "5.8.1",
     "esbuild": "0.28.0",
     "flatted": "3.4.2",
     "follow-redirects": "1.16.0",
@@ -176,6 +176,7 @@
     "smol-toml": "1.6.1",
     "tmp": "0.2.5",
     "uuid": "14.0.0",
+    "ws": "8.20.1",
     "yaml": "2.8.3",
   },
   "packages": {
@@ -865,7 +866,7 @@
 
     "bootstrap": ["bootstrap@5.3.8", "", { "peerDependencies": { "@popperjs/core": "^2.11.8" } }, "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -1033,7 +1034,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "devalue": ["devalue@5.8.0", "", {}, "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg=="],
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -2201,7 +2202,7 @@
 
     "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "xdg-basedir": ["xdg-basedir@4.0.0", "", {}, "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="],
 
@@ -2326,8 +2327,6 @@
     "lighthouse/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "lighthouse/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
-
-    "lighthouse/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "lighthouse/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   },
   "overrides": {
     "ajv": "8.20.0",
-    "devalue": "5.8.0",
+    "devalue": "5.8.1",
     "flatted": "3.4.2",
     "picomatch": "4.0.4",
     "yaml": "2.8.3",
@@ -223,13 +223,14 @@
     "path-to-regexp": "8.4.2",
     "@isaacs/brace-expansion": "5.0.1",
     "minimatch": "10.2.5",
-    "brace-expansion": "5.0.5",
+    "brace-expansion": "5.0.6",
     "h3": "2.0.0",
     "tmp": "0.2.5",
     "esbuild": "0.28.0",
     "happy-dom": "20.9.0",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "ws": "8.20.1"
   }
 }

--- a/packages/theme-selector/src/appearance.ts
+++ b/packages/theme-selector/src/appearance.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Theme appearance (light/dark) resolution for DOM attributes.
+ */
+
+import { THEME_APPEARANCES } from '@lgtm-hq/turbo-themes-core';
+
+export type ThemeAppearance = 'light' | 'dark';
+
+/**
+ * Resolves light/dark appearance for a theme ID.
+ *
+ * Falls back to `'dark'` when the theme is unknown (e.g. custom themes without
+ * an explicit mapping).
+ */
+export function resolveThemeAppearance(
+  themeId: string,
+  appearances: Readonly<Record<string, ThemeAppearance>> = THEME_APPEARANCES,
+): ThemeAppearance {
+  return appearances[themeId] ?? 'dark';
+}

--- a/packages/theme-selector/src/blocking-script.ts
+++ b/packages/theme-selector/src/blocking-script.ts
@@ -15,7 +15,8 @@
  * <Fragment set:html={`<script>${blockingScript}</script>`} />
  */
 
-import { DEFAULT_THEME, VALID_THEMES } from '@lgtm-hq/turbo-themes-core';
+import { DEFAULT_THEME, THEME_APPEARANCES, VALID_THEMES } from '@lgtm-hq/turbo-themes-core';
+import type { ThemeAppearance } from './appearance.js';
 import { CSS_LINK_ID, STORAGE_KEY, LEGACY_STORAGE_KEYS } from './constants.js';
 
 export interface BlockingScriptOptions {
@@ -27,13 +28,15 @@ export interface BlockingScriptOptions {
   storageKey?: string;
   /** Legacy localStorage keys to migrate from. Defaults to LEGACY_STORAGE_KEYS from core. */
   legacyKeys?: readonly string[];
+  /** Light/dark mapping per theme ID. Defaults to THEME_APPEARANCES from core. */
+  themeAppearances?: Readonly<Record<string, ThemeAppearance>>;
 }
 
 /**
  * Generates a self-contained inline IIFE that prevents FOUC. It:
  * 1. Migrates legacy storage keys to the current `storageKey`
  * 2. Reads and validates the stored theme against the allowlist
- * 3. Sets `data-theme` and the `theme-{id}` class on `<html>`
+ * 3. Sets `data-theme`, `data-appearance`, and the `theme-{id}` class on `<html>`
  * 4. Sets `window.__INITIAL_THEME__` so `initTheme` can short-circuit
  * 5. Updates the existing CSS `<link>` href when the theme is non-default
  *
@@ -47,6 +50,7 @@ export function generateBlockingScript(options: BlockingScriptOptions = {}): str
     defaultTheme = DEFAULT_THEME,
     storageKey = STORAGE_KEY,
     legacyKeys = LEGACY_STORAGE_KEYS,
+    themeAppearances = THEME_APPEARANCES,
   } = options;
 
   const config = {
@@ -54,6 +58,7 @@ export function generateBlockingScript(options: BlockingScriptOptions = {}): str
     defaultTheme: JSON.stringify(defaultTheme),
     validThemes: JSON.stringify(validThemes),
     legacyKeys: JSON.stringify(legacyKeys),
+    themeAppearances: JSON.stringify(themeAppearances),
     cssLinkId: JSON.stringify(CSS_LINK_ID),
   };
 
@@ -63,6 +68,7 @@ export function generateBlockingScript(options: BlockingScriptOptions = {}): str
     var defaultTheme = ${config.defaultTheme};
     var validThemes = ${config.validThemes};
     var legacyKeys = ${config.legacyKeys};
+    var themeAppearances = ${config.themeAppearances};
     var cssLinkId = ${config.cssLinkId};
 
     for (var i = 0; i < legacyKeys.length; i++) {
@@ -78,6 +84,7 @@ export function generateBlockingScript(options: BlockingScriptOptions = {}): str
 
     var root = document.documentElement;
     root.setAttribute('data-theme', theme);
+    root.setAttribute('data-appearance', themeAppearances[theme] || 'dark');
     var classes = root.classList;
     for (var j = classes.length - 1; j >= 0; j--) {
       if (classes[j].indexOf('theme-') === 0) classes.remove(classes[j]);

--- a/packages/theme-selector/src/persistence.ts
+++ b/packages/theme-selector/src/persistence.ts
@@ -7,6 +7,7 @@
  * and the theme-switching UI script (lines 140-230).
  */
 
+import { resolveThemeAppearance } from './appearance.js';
 import { DEFAULT_THEME } from './constants.js';
 import { migrateLegacyStorage, getSavedTheme } from './storage.js';
 
@@ -83,7 +84,7 @@ export function buildThemeIconSrc(
  * BaseLayout.astro. It:
  * 1. Migrates legacy storage keys
  * 2. Reads and validates the stored theme
- * 3. Sets the `data-theme` attribute on `<html>`
+ * 3. Sets the `data-theme` and `data-appearance` attributes on `<html>`
  * 4. Sets `window.__INITIAL_THEME__` for downstream scripts
  * 5. Updates the CSS link href if the theme differs from the default
  */
@@ -95,6 +96,7 @@ export function applyInitialTheme(
   const theme = resolveInitialTheme(windowObj, validThemes);
 
   doc.documentElement.setAttribute('data-theme', theme);
+  doc.documentElement.setAttribute('data-appearance', resolveThemeAppearance(theme));
   windowObj.__INITIAL_THEME__ = theme;
 
   if (needsCssUpdate(theme)) {

--- a/packages/theme-selector/src/theme-loader.ts
+++ b/packages/theme-selector/src/theme-loader.ts
@@ -3,6 +3,7 @@
  * Theme CSS loading utilities
  */
 
+import { resolveThemeAppearance } from './appearance.js';
 import { CSS_LINK_ID, DOM_SELECTORS } from './constants.js';
 import { ThemeErrors, logThemeError } from './errors.js';
 
@@ -136,6 +137,8 @@ export function applyThemeClass(doc: Document, themeId: string): void {
 
   // Add the new theme class
   doc.documentElement.classList.add(`theme-${themeId}`);
+
+  doc.documentElement.setAttribute('data-appearance', resolveThemeAppearance(themeId));
 }
 
 /**

--- a/packages/theme-selector/src/theme-loader.ts
+++ b/packages/theme-selector/src/theme-loader.ts
@@ -124,7 +124,7 @@ export function getCurrentThemeFromClasses(element: HTMLElement): string | null 
 }
 
 /**
- * Applies theme class to document element
+ * Applies theme class and root data attributes to the document element.
  */
 export function applyThemeClass(doc: Document, themeId: string): void {
   // Remove existing theme classes in a single batch operation
@@ -138,6 +138,7 @@ export function applyThemeClass(doc: Document, themeId: string): void {
   // Add the new theme class
   doc.documentElement.classList.add(`theme-${themeId}`);
 
+  doc.documentElement.setAttribute('data-theme', themeId);
   doc.documentElement.setAttribute('data-appearance', resolveThemeAppearance(themeId));
 }
 

--- a/packages/theme-selector/test/appearance.test.ts
+++ b/packages/theme-selector/test/appearance.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest';
+import { resolveThemeAppearance } from '../src/appearance.js';
+
+describe('resolveThemeAppearance', () => {
+  it('returns light for known light themes', () => {
+    expect(resolveThemeAppearance('catppuccin-latte')).toBe('light');
+    expect(resolveThemeAppearance('github-light')).toBe('light');
+  });
+
+  it('returns dark for known dark themes', () => {
+    expect(resolveThemeAppearance('catppuccin-mocha')).toBe('dark');
+    expect(resolveThemeAppearance('dracula')).toBe('dark');
+  });
+
+  it('falls back to dark for unknown theme IDs', () => {
+    expect(resolveThemeAppearance('nonexistent')).toBe('dark');
+  });
+
+  it('uses custom appearance map when provided', () => {
+    expect(resolveThemeAppearance('custom', { custom: 'light' })).toBe('light');
+    expect(resolveThemeAppearance('other', { custom: 'light' })).toBe('dark');
+  });
+});

--- a/packages/theme-selector/test/blocking-script.test.ts
+++ b/packages/theme-selector/test/blocking-script.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateBlockingScript } from '../src/blocking-script.js';
-import { DEFAULT_THEME, VALID_THEMES } from '@lgtm-hq/turbo-themes-core';
+import { DEFAULT_THEME, THEME_APPEARANCES, VALID_THEMES } from '@lgtm-hq/turbo-themes-core';
 import { CSS_LINK_ID, STORAGE_KEY, LEGACY_STORAGE_KEYS } from '../src/constants.js';
 
 describe('generateBlockingScript', () => {
@@ -51,6 +51,16 @@ describe('generateBlockingScript', () => {
     it('embeds LEGACY_STORAGE_KEYS from core by default', () => {
       const script = generateBlockingScript();
       expect(script).toContain(JSON.stringify(LEGACY_STORAGE_KEYS));
+    });
+
+    it('embeds THEME_APPEARANCES from core by default', () => {
+      const script = generateBlockingScript();
+      expect(script).toContain(JSON.stringify(THEME_APPEARANCES));
+    });
+
+    it('sets data-appearance in generated script', () => {
+      const script = generateBlockingScript();
+      expect(script).toContain("setAttribute('data-appearance'");
     });
 
     it('respects custom storageKey option', () => {
@@ -98,6 +108,7 @@ describe('generateBlockingScript', () => {
       // Set up minimal DOM
       document.documentElement.setAttribute('data-baseurl', '');
       document.documentElement.removeAttribute('data-theme');
+      document.documentElement.removeAttribute('data-appearance');
       delete (window as Record<string, unknown>).__INITIAL_THEME__;
 
       // Create theme CSS link element
@@ -123,12 +134,22 @@ describe('generateBlockingScript', () => {
     it('sets data-theme to default when localStorage is empty', () => {
       execScript();
       expect(document.documentElement.getAttribute('data-theme')).toBe(DEFAULT_THEME);
+      expect(document.documentElement.getAttribute('data-appearance')).toBe(
+        THEME_APPEARANCES[DEFAULT_THEME],
+      );
     });
 
     it('sets data-theme to stored theme when valid', () => {
       mockLocalStorage[STORAGE_KEY] = 'dracula';
       execScript();
       expect(document.documentElement.getAttribute('data-theme')).toBe('dracula');
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('dark');
+    });
+
+    it('sets data-appearance to light for light themes', () => {
+      mockLocalStorage[STORAGE_KEY] = 'catppuccin-latte';
+      execScript();
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('light');
     });
 
     it('falls back to default when stored theme is invalid', () => {
@@ -178,6 +199,15 @@ describe('generateBlockingScript', () => {
       execScript();
       const link = document.getElementById(CSS_LINK_ID) as HTMLLinkElement;
       expect(link.href).toContain('/my-site/assets/css/themes/turbo/dracula.css');
+    });
+
+    it('falls back to dark appearance for unknown theme with custom appearances', () => {
+      mockLocalStorage[STORAGE_KEY] = 'custom-theme';
+      execScript({
+        validThemes: ['custom-theme'],
+        themeAppearances: {},
+      });
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('dark');
     });
 
     it('handles localStorage exceptions gracefully', () => {

--- a/packages/theme-selector/test/persistence.test.ts
+++ b/packages/theme-selector/test/persistence.test.ts
@@ -266,6 +266,7 @@ describe('persistence', () => {
       // Clean up any elements added during tests
       document.getElementById('turbo-theme-css')?.remove();
       document.documentElement.removeAttribute('data-theme');
+      document.documentElement.removeAttribute('data-appearance');
       document.documentElement.removeAttribute('data-baseurl');
       delete window.__INITIAL_THEME__;
     });
@@ -276,7 +277,16 @@ describe('persistence', () => {
       const result = applyInitialTheme(document, window, ['dracula', 'catppuccin-mocha']);
 
       expect(document.documentElement.getAttribute('data-theme')).toBe('dracula');
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('dark');
       expect(result).toBe('dracula');
+    });
+
+    it('sets data-appearance to light for light themes', () => {
+      mockLocalStorage.getItem = vi.fn(() => 'catppuccin-latte');
+
+      applyInitialTheme(document, window, ['catppuccin-latte', 'catppuccin-mocha']);
+
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('light');
     });
 
     it('sets window.__INITIAL_THEME__', () => {

--- a/packages/theme-selector/test/theme-loader.test.ts
+++ b/packages/theme-selector/test/theme-loader.test.ts
@@ -129,6 +129,18 @@ describe('theme-loader', () => {
       expect(document.documentElement.classList.contains('theme-catppuccin-mocha')).toBe(true);
     });
 
+    it('sets data-appearance on documentElement', () => {
+      applyThemeClass(document, 'catppuccin-latte');
+
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('light');
+    });
+
+    it('falls back to dark appearance for unknown theme', () => {
+      applyThemeClass(document, 'unknown-theme');
+
+      expect(document.documentElement.getAttribute('data-appearance')).toBe('dark');
+    });
+
     it('handles multiple existing theme classes', () => {
       document.documentElement.classList.add('theme-theme1');
       document.documentElement.classList.add('theme-theme2');

--- a/packages/theme-selector/test/theme-loader.test.ts
+++ b/packages/theme-selector/test/theme-loader.test.ts
@@ -129,9 +129,12 @@ describe('theme-loader', () => {
       expect(document.documentElement.classList.contains('theme-catppuccin-mocha')).toBe(true);
     });
 
-    it('sets data-appearance on documentElement', () => {
+    it('sets data-theme and data-appearance on documentElement', () => {
+      document.documentElement.setAttribute('data-theme', 'catppuccin-mocha');
+
       applyThemeClass(document, 'catppuccin-latte');
 
+      expect(document.documentElement.getAttribute('data-theme')).toBe('catppuccin-latte');
       expect(document.documentElement.getAttribute('data-appearance')).toBe('light');
     });
 

--- a/uv.lock
+++ b/uv.lock
@@ -323,11 +323,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Set `data-appearance="light|dark"` on `document.documentElement` alongside `data-theme` when applying a theme. Downstream sites can target `:root[data-appearance='light']` instead of maintaining hardcoded lists of light theme IDs for Shiki, overlays, shadows, and similar CSS.

## Type

- [x] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Conventional Commits

This project uses [Conventional Commits](https://www.conventionalcommits.org/) for
automated releases and changelog generation.

**Commit Title Format:**

```
<type>(<scope>): <description>

[optional body]

[optional footer]
```

**Examples:**

- `feat: add dark mode theme variants`
- `fix: resolve dropdown issue in Safari`
- `docs: update theme selector API documentation`
- `refactor: simplify theme switching logic`
- `feat!: change theme API (BREAKING CHANGE)`

**Breaking Changes:**

- Add `!` after type: `feat!: change API`
- Or add `BREAKING CHANGE:` in footer

## Changes Made

- Add `resolveThemeAppearance()` helper using `THEME_APPEARANCES` with `'dark'` fallback
- Set `data-appearance` in `generateBlockingScript()` (embeds appearance map; optional `themeAppearances` override)
- Set `data-appearance` in `applyThemeClass()` and `applyInitialTheme()` for runtime and non-blocking paths
- Add unit tests for blocking script, theme loader, persistence, and appearance helper
- Update CHANGELOG under `[Unreleased]`
- Suppress four assessed transitive OSV advisories in lockfiles so pre-commit checks pass

## Closes

- Closes #490

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`npm test`)

### Test Coverage

- [x] Coverage maintained or improved
- [x] No decrease in code coverage
- [x] Coverage report reviewed

## Quality Checks

- [x] Linting passes (`npm run lint`)
- [x] Formatting passes (`npm run format`)
- [x] TypeScript build successful (`npm run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

## Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] Comments added to complex code
- [x] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided below

**Breaking Changes:**

<!-- Describe what breaks and how users should migrate -->

**Migration Guide:**

```typescript
// Before

// After
```

## Screenshots / Demos

<!-- Add screenshots, GIFs, or videos demonstrating the changes (especially for UI changes) -->

## Deployment Notes

<!-- Any special notes for deployment, configuration changes, or environment variables -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

## Additional Context

Consumers can replace theme-ID enumerations with:

```css
:root[data-appearance='light'] .code-block span {
  color: var(--shiki-light, var(--astro-code-foreground)) !important;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme system now sets a root-level data-appearance attribute (light|dark) so sites can style by appearance without hardcoding theme IDs.

* **Tests**
  * Added and extended tests to verify appearance resolution, blocking script behavior, persistence, and theme application.

* **Chores**
  * Updated dependency overrides for maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/turbo-themes/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->