### PR TITLE
fix(css): export turbo-themes-all.css as ./css/themes-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
       "types": "./packages/css/dist/turbo-core.css.d.ts",
       "default": "./packages/css/dist/turbo-core.css"
     },
+    "./css/themes-all": {
+      "types": "./packages/css/dist/turbo-themes-all.css.d.ts",
+      "default": "./packages/css/dist/turbo-themes-all.css"
+    },
     "./css/base": {
       "types": "./packages/css/dist/turbo-base.css.d.ts",
       "default": "./packages/css/dist/turbo-base.css"

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -71,15 +71,27 @@ import '@lgtm-hq/turbo-themes-css/turbo-base.css';
 import '@lgtm-hq/turbo-themes-css/themes/catppuccin-mocha.css';
 ```
 
+### Option 4: Framework Integration (e.g. Starlight, Docusaurus)
+
+When the host framework provides its own `:root` design tokens, use only the scoped
+theme selectors — no `:root` defaults:
+
+```js
+import '@lgtm-hq/turbo-themes/css/themes-all';
+```
+
+See [ADR-0005](../../docs/adr/0005-css-only-theme-switching.md) for details.
+
 ## Available Files
 
-| File               | Size  | Description                                        |
-| ------------------ | ----- | -------------------------------------------------- |
-| `turbo.css`        | ~20KB | Combined bundle with all themes                    |
-| `turbo-core.css`   | ~2KB  | Default CSS variables in `:root`                   |
-| `turbo-base.css`   | ~4KB  | Optional semantic styles (typography, forms, etc.) |
-| `turbo-syntax.css` | ~3KB  | Syntax highlighting styles for code blocks         |
-| `themes/<id>.css`  | ~2KB  | Individual theme files                             |
+| File                   | Size  | Description                                            |
+| ---------------------- | ----- | ------------------------------------------------------ |
+| `turbo.css`            | ~20KB | Combined bundle with all themes                        |
+| `turbo-core.css`       | ~2KB  | Default CSS variables in `:root`                       |
+| `turbo-base.css`       | ~4KB  | Optional semantic styles (typography, forms, etc.)     |
+| `turbo-syntax.css`     | ~3KB  | Syntax highlighting styles for code blocks             |
+| `themes/<id>.css`      | ~2KB  | Individual theme files                                 |
+| `turbo-themes-all.css` | ~82KB | All themes, `[data-theme]` selectors only (no `:root`) |
 
 ## Available Themes
 


### PR DESCRIPTION
## Summary

Exposes the FOUC-free all-themes bundle (`turbo-themes-all.css`, `[data-theme]` selectors only, no `:root` defaults) via the root `exports` map as `./css/themes-all`, so framework integrations (Starlight, Docusaurus) can `import '@lgtm-hq/turbo-themes/css/themes-all'` without deep dist paths. Adds the file to the css package README's Available Files table plus a Framework Integration section linking ADR-0005.

The `.css.d.ts` shim is already produced automatically — `scripts/generate-css-dts.mjs` shims every CSS file in `packages/css/dist`, where `build.mjs` writes `turbo-themes-all.css`.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Closes

- Closes #511

## Testing

- `bun run build` produces `packages/css/dist/turbo-themes-all.css` + `.css.d.ts`
- Subpath resolves from the exports map; file contains no `:root` selector block
- `uv run lintro chk` clean; `bun run test` green (2263 passed)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR exposes the all-themes CSS bundle through the root package exports.

- Adds `./css/themes-all` for framework imports.
- Points the export at the generated CSS file and type shim.
- Documents the framework import path in the CSS README.
- Adds `turbo-themes-all.css` to the available files table.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds the `./css/themes-all` export using the same shape as the existing CSS exports. |
| packages/css/README.md | Documents framework usage for the new all-themes CSS import path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(css): export turbo-themes-all.css as..."](https://github.com/lgtm-hq/turbo-themes/commit/602b13a444d1d728dd0cfb0843813f9b98a43a49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43303359)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a package export for the complete theme CSS bundle.
  * The bundle provides theme selectors without overriding framework-level defaults.

* **Documentation**
  * Added guidance for integrating themes with frameworks that provide their own design tokens.
  * Documented the new `turbo-themes-all.css` file in the available files list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->