### PR TITLE
chore(ci): adopt canonical emoji check names

### DIFF
--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -16,12 +16,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Org ruleset (checks-turbo-themes): quality / 🔍 Code Quality & Linting
+  # Org ruleset (checks-turbo-themes): quality / 🛠️ Lintro Code Quality
   quality:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      job-name: '🔍 Code Quality & Linting'
+      job-name: '🛠️ Lintro Code Quality'
       # py-lintro 0.61.0 pinned to immutable digest for reproducibility
       # yamllint disable-line rule:line-length
       lintro-image: ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887

--- a/.github/workflows/quality-semantic-pr-title.yml
+++ b/.github/workflows/quality-semantic-pr-title.yml
@@ -14,14 +14,14 @@ concurrency:
 
 jobs:
   # Org ruleset (checks-turbo-themes):
-  # semantic-title / ✅ Validate Conventional Commits
+  # semantic-title / 📝 Validate PR Title
   # The reusable no-ops at step level on merge_group (title was already
   # validated on the pull_request event) so the required check still reports.
   semantic-title:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      job-name: '✅ Validate Conventional Commits'
+      job-name: '📝 Validate PR Title'
       types: |
         chore
         ci

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Org ruleset (checks-turbo-themes): codeql / 🔍 CodeQL Security Analysis
+  # Org ruleset (checks-turbo-themes): codeql / 🔬 CodeQL Analysis
   codeql:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
@@ -26,7 +26,7 @@ jobs:
       languages: javascript-typescript
       build-mode: none
       category: '/language:all'
-      job-name: '🔍 CodeQL Security Analysis'
+      job-name: '🔬 CodeQL Analysis'
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -16,13 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Org ruleset (checks-turbo-themes): sbom / SBOM & Supply Chain
+  # Org ruleset (checks-turbo-themes): sbom / 📋 SBOM & Supply Chain
   # Release-asset SBOMs (multi-format + cosign signatures) are still produced
   # by the local reusable-sbom.yml called from the publish workflows.
   sbom:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
+      job-name: '📋 SBOM & Supply Chain'
       target: .
       target-type: dir
       sbom-format: cyclonedx-json


### PR DESCRIPTION
## Summary

Aligns turbo-themes' required check names to the org canon defined in lgtm-hq/lgtm-ci#514. All four renames are `job-name` inputs on reusable-workflow calls introduced in the adoption PR #526 — caller job ids are already canonical, so only the display names (and their ruleset comments) change. Repo-specific E2E/build/examples check names are already emoji'd and unchanged; `security-audit / 🔐 Security Audit` already matches canon.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [x] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [x] 🔨 Chore (`chore:`)

## Changes Made

- `.github/workflows/quality-lintro.yml`: `job-name` → `🛠️ Lintro Code Quality`
- `.github/workflows/security-codeql.yml`: `job-name` → `🔬 CodeQL Analysis`
- `.github/workflows/quality-semantic-pr-title.yml`: `job-name` → `📝 Validate PR Title`
- `.github/workflows/security-sbom.yml`: add explicit `job-name: '📋 SBOM & Supply Chain'` (previously relied on the reusable's non-emoji default `SBOM & Supply Chain`)
- Updated the `Org ruleset (checks-turbo-themes)` comments in each caller to the canonical names

## Ruleset lockstep

The `checks-turbo-themes` org ruleset was already updated today to the post-adoption canonical names, so this PR brings the emitted check names into lockstep with the required contexts:

| Required context (ruleset, canon) | Old check name | New check name |
| --- | --- | --- |
| `quality / 🛠️ Lintro Code Quality` | `quality / 🔍 Code Quality & Linting` | `quality / 🛠️ Lintro Code Quality` |
| `codeql / 🔬 CodeQL Analysis` | `codeql / 🔍 CodeQL Security Analysis` | `codeql / 🔬 CodeQL Analysis` |
| `semantic-title / 📝 Validate PR Title` | `semantic-title / ✅ Validate Conventional Commits` | `semantic-title / 📝 Validate PR Title` |
| `sbom / 📋 SBOM & Supply Chain` | `sbom / SBOM & Supply Chain` | `sbom / 📋 SBOM & Supply Chain` |

Unchanged (already canonical): `security-audit / 🔐 Security Audit`, repo-specific E2E/build/examples checks.

## Related Issues

Closes #527. Relates to #526 and lgtm-hq/lgtm-ci#514.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed (verified `job-name` inputs exist on the pinned reusables at v0.52.3, including `reusable-sbom.yml`'s `job-name` input with default `SBOM & Supply Chain`)
- [ ] All tests pass locally (`npm test`) — n/a, workflow YAML only

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] No new warnings or errors
- [ ] TypeScript build — n/a, no source changes

## Documentation

- [x] No doc updates needed — `docs/CI-REQUIREMENTS.md` does not reference check display names

## Breaking Changes

- [ ] This PR contains breaking changes

## Deployment Notes

Ruleset was updated first; PR checks on this branch already report under the new canonical names, so required contexts go green on this PR itself.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns CI check display names with the canonical ruleset names.

- Renames the Lintro, CodeQL, and semantic-title reusable workflow `job-name` values.
- Adds an explicit emoji-prefixed SBOM `job-name` value.
- Updates the matching ruleset comments in the four workflow callers.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed workflow names.
- The workflow triggers, permissions, and scan settings are unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/quality-lintro.yml | Renames the Lintro reusable workflow display name and matching ruleset comment. |
| .github/workflows/quality-semantic-pr-title.yml | Renames the semantic PR title reusable workflow display name and matching ruleset comment. |
| .github/workflows/security-codeql.yml | Renames the CodeQL reusable workflow display name and matching ruleset comment. |
| .github/workflows/security-sbom.yml | Adds an explicit SBOM reusable workflow display name and updates the ruleset comment. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): adopt canonical emoji check n..."](https://github.com/lgtm-hq/turbo-themes/commit/baef77122cfaf312c107cb7753b4589da7bbe496) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43532790)</sub>

<!-- /greptile_comment -->