### PR TITLE
chore(ci): adopt reusable scorecards and dependency review

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,9 +24,10 @@ Following py-lintro standards:
 ### Security
 
 - `security-codeql.yml` - CodeQL security analysis
-- `security-dependency-review.yml` - Dependency vulnerability scanning
+- `security-dependency-review.yml` - PR dependency review and OSV vulnerability
+  scanning (lgtm-ci reusables)
 - `security-sbom.yml` - Software Bill of Materials generation
-- `security-scorecards.yml` - OpenSSF Scorecard analysis
+- `security-scorecards.yml` - OpenSSF Scorecard analysis (lgtm-ci reusable)
 
 ### Deploy
 

--- a/.github/workflows/TRIGGERS.md
+++ b/.github/workflows/TRIGGERS.md
@@ -11,9 +11,9 @@ turbo-themes, their triggers, and purposes.
 | reusable-sbom                   |             |             |              |           |        | Called       |
 | reporting-lighthouse-ci         | ✅          |             | ✅           |           |        |              |
 | security-codeql                 | ✅          |             | ✅           | ✅ Weekly |        |              |
-| security-dependency-review      |             |             | ✅           |           |        |              |
+| security-dependency-review      | ✅          |             | ✅           | ✅ Weekly | ✅     |              |
 | security-sbom                   | ✅          |             | ✅           |           | ✅     |              |
-| security-scorecards             | ✅          |             |              |           |        |              |
+| security-scorecards             | ✅          |             |              | ✅ Weekly | ✅     |              |
 | quality-theme-sync              | ✅          |             | ✅           |           |        |              |
 | quality-semantic-pr-title       |             |             | ✅           |           |        |              |
 | quality-validate-action-pinning | ✅          |             | ✅           |           |        |              |
@@ -77,8 +77,9 @@ turbo-themes, their triggers, and purposes.
 
 #### security-dependency-review.yml
 
-**Triggers:** Pull requests  
-**Purpose:** Reviews dependencies for security vulnerabilities
+**Triggers:** Pull requests, Merge groups, Push to main, Weekly schedule, Manual  
+**Purpose:** Reviews PR dependency changes (GitHub dependency review) and scans
+dependencies for known vulnerabilities (OSV audit)
 
 #### security-sbom.yml
 
@@ -87,8 +88,8 @@ turbo-themes, their triggers, and purposes.
 
 #### security-scorecards.yml
 
-**Triggers:** Push to main  
-**Purpose:** OpenSSF Scorecard security analysis
+**Triggers:** Push to main, Weekly schedule, Manual  
+**Purpose:** OpenSSF Scorecard security analysis (lgtm-ci reusable)
 
 #### reusable-sbom.yml
 

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -19,6 +19,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Not a required check in checks-turbo-themes; no ruleset lockstep needed.
+  # The reusable itself skips on push/schedule/dispatch events (it only runs
+  # on pull_request and merge_group), so no caller-side if is needed.
+  dependency-review:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    with:
+      job-name: '🛡️ Dependency Review'
+      fail-on-severity: high
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      egress-policy: block
+      egress-preset: scorecard
+      # Complete list, not append: the reusable feeds allowed-endpoints
+      # directly to the harden-runner pre hook at job start, where a partial
+      # list REPLACES the baked-in baseline (preset merging happens later in
+      # resolve-egress-allowlist and cannot widen the already-armed agent).
+      # Full list = scorecard preset + deps.dev metadata resolution.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
+        api.osv.dev:443
+        api.scorecard.dev:443
+        api.securityscorecards.dev:443
+        api.deps.dev:443
+        release-assets.githubusercontent.com:443
+    permissions:
+      # Read repository manifests and lockfiles.
+      contents: read
+      # Read pull-request metadata for dependency review.
+      pull-requests: read
+
   # Org ruleset (checks-turbo-themes): security-audit / 🔐 Security Audit
   security-audit:
     # yamllint disable-line rule:line-length

--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -2,53 +2,66 @@
 name: Security - OpenSSF Scorecard Analysis
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: scorecard
   cancel-in-progress: false
 
 jobs:
-  analysis:
-    name: 🛡️ OpenSSF Security Scorecard
+  # Not a required check in checks-turbo-themes; no ruleset lockstep needed.
+  scorecards:
+    # lgtm-ci owns the scorecard scan; this repo stays a thin caller.
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    with:
+      job-name: '🏆 OpenSSF Scorecard'
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      # publish_results:true enforces an allowlist of actions that excludes
+      # lgtm-ci local composites (resolve-egress-allowlist / harden-runner).
+      # That makes every main push fail with "job has unallowed step". Keep
+      # SARIF upload to the Security tab; skip the public Scorecard API until
+      # the reusable workflow only uses allowlisted actions.
+      publish-results: false
+      egress-policy: block
+      egress-preset: scorecard
+      # Complete list, not append: the reusable feeds allowed-endpoints
+      # directly to the harden-runner pre hook at job start, where a partial
+      # list REPLACES the baked-in baseline (preset merging happens later in
+      # resolve-egress-allowlist and cannot widen the already-armed agent).
+      # Full list = scorecard reusable default + StepSecurity/sigstore/OSSF
+      # hosts used by this job.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
+        api.osv.dev:443
+        api.scorecard.dev:443
+        api.securityscorecards.dev:443
+        agent.api.stepsecurity.io:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        release-assets.githubusercontent.com:443
+        oss-fuzz-build-logs.storage.googleapis.com:443
+        ossf.github.io:443
+        www.bestpractices.dev:443
     permissions:
+      # Elevated only where the reusable scorecards job requires: publish the
+      # SARIF to the Security tab (security-events) and sign results via OIDC
+      # (id-token). Everything else stays contents: read.
       contents: read
       security-events: write
       id-token: write
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.deps.dev:443
-            api.github.com:443
-            api.osv.dev:443
-            api.scorecard.dev:443
-            codeload.github.com:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            objects.githubusercontent.com:443
-            pkg-containers.githubusercontent.com:443
-            oss-fuzz-build-logs.storage.googleapis.com:443
-            rekor.sigstore.dev:443
-            tuf-repo-cdn.sigstore.dev:443
-            www.bestpractices.dev:443
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-      - uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
-        with:
-          sarif_file: results.sarif

--- a/test/validate-action-shas.test.ts
+++ b/test/validate-action-shas.test.ts
@@ -53,9 +53,11 @@ describe('validate-action-shas.sh', () => {
       env: { ...process.env, GITHUB_TOKEN: '' },
     });
 
-    // Should find actions in our workflows
+    // Should find actions in our workflows. github/codeql-action is no longer
+    // pinned directly (it lives inside the lgtm-ci reusables); assert on the
+    // SHA-pinned lgtm-ci reusable workflows instead.
     expect(result).toContain('actions/checkout');
-    expect(result).toContain('github/codeql-action');
+    expect(result).toContain('lgtm-hq/lgtm-ci');
 
     // Should show summary statistics
     expect(result).toMatch(/Total unique SHAs found: \d+/);


### PR DESCRIPTION
## Summary

Wires the two remaining clean lgtm-ci mappings noted as out of scope in #525/#526: `security-scorecards.yml` becomes a thin caller of `reusable-scorecards.yml`, and `security-dependency-review.yml` gains a `dependency-review` job calling `reusable-dependency-review.yml`. Both are SHA-pinned to `66cad82ead0e5d119928c895c7d7da9c837989e5` (v0.52.3) with matching `tooling-ref`.

## Type

- [x] 🔨 Chore (`chore:`)

## Changes Made

- **`security-scorecards.yml`**: replaced the hand-rolled scorecard job with a `reusable-scorecards.yml` caller. Triggers preserved (weekly schedule + `workflow_dispatch`) plus `push: main` added — the OpenSSF-recommended setup and what sibling repos (ai-skills) use. Job permissions limited to `contents: read`, `security-events: write`, `id-token: write`.
- **`publish-results: false`** (behavior change): at this pin, `publish_results: true` trips the ossf/scorecard-action publish allowlist because the reusable uses lgtm-ci local composites ("job has unallowed step") — same as documented in ai-skills' caller. SARIF upload to the Security tab is retained; public Scorecard API publishing is paused until the reusable only uses allowlisted actions.
- **`security-dependency-review.yml`**: added a `dependency-review` job calling `reusable-dependency-review.yml` (`fail-on-severity: high`) alongside the existing `security-audit` (OSV) job. The reusable runs on `pull_request` and `merge_group` and self-skips on the workflow's push/schedule/dispatch events, so no caller-side `if` is needed.
- **Egress**: `egress-policy: block` with complete `allowed-endpoints` lists in `replace` mode (harden-runner's pre hook only sees the literal input; a partial list would replace the baked-in baseline). Scorecards list = reusable default + StepSecurity/sigstore/OSSF hosts; dependency-review list = scorecard preset + `api.deps.dev`.
- **Check names** (emoji canon, lgtm-ci#514 repo-specific style): `scorecards / 🏆 OpenSSF Scorecard` and `dependency-review / 🛡️ Dependency Review`. Neither is a required check in `checks-turbo-themes`, so no ruleset lockstep is needed; names noted here for the registry.
- Docs: updated `.github/workflows/README.md` and `TRIGGERS.md` entries for both workflows.

## Not in scope (documented exceptions remain)

- Build matrix: monolithic `build.sh` + artifact handoff stays bespoke.
- Release flow: multi-ecosystem release workflows stay bespoke.

## Related Issues

Closes #529. Relates to #525, #526, lgtm-hq/lgtm-ci#510, lgtm-hq/lgtm-ci#514.

## Quality Checks

- [x] Linting passes (`uv run lintro check` — 0 issues on changed files)
- [x] YAML parses; workflow shapes mirror the ai-skills reference callers at the same pin

## Testing

- [ ] Manual testing performed — dependency-review will run on this PR; scorecards runs post-merge on main (verify the first main run)

## Additional Context

The pre-existing `security-audit` job (org ruleset check `security-audit / 🔐 Security Audit`) is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added automated dependency review checks for pull requests and merge groups, with high-severity findings able to block changes.
  - Updated Scorecard checks to run on pushes to the main branch, weekly, or manually.
  - Improved security workflow configuration with restricted network access and explicit permissions.

- **Documentation**
  - Updated workflow documentation to reflect the expanded triggers, dependency scanning, and Scorecard validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the remaining security checks onto pinned lgtm-ci reusable workflows. The main changes are:

- Scorecards now runs through the reusable Scorecards workflow.
- Dependency Review now runs through the reusable dependency-review workflow.
- Security workflow triggers and permissions were updated.
- Workflow docs and SHA-validation tests were adjusted for the reusable calls.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/security-scorecards.yml | Replaces the inline Scorecards job with a pinned reusable workflow caller and scoped job permissions. |
| .github/workflows/security-dependency-review.yml | Adds a pinned reusable Dependency Review job alongside the existing security audit job. |
| test/validate-action-shas.test.ts | Updates the pin-validation test to assert the pinned lgtm-ci reusable workflow reference. |
| .github/workflows/README.md | Updates workflow descriptions to reflect the lgtm-ci reusable security checks. |
| .github/workflows/TRIGGERS.md | Updates the trigger documentation for Scorecards and Dependency Review. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): update SHA validation test for..."](https://github.com/lgtm-hq/turbo-themes/commit/3416694cce10fe5b83dcc3a6d1f81af8f463df2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43538999)</sub>

<!-- /greptile_comment -->