### PR TITLE
fix(ci): re-enable scorecard publish-results on lgtm-ci v0.52.4

### DIFF
--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -19,16 +19,12 @@ jobs:
   scorecards:
     # lgtm-ci owns the scorecard scan; this repo stays a thin caller.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
     with:
       job-name: '🏆 OpenSSF Scorecard'
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
-      # publish_results:true enforces an allowlist of actions that excludes
-      # lgtm-ci local composites (resolve-egress-allowlist / harden-runner).
-      # That makes every main push fail with "job has unallowed step". Keep
-      # SARIF upload to the Security tab; skip the public Scorecard API until
-      # the reusable workflow only uses allowlisted actions.
-      publish-results: false
+      # Re-enabled at v0.52.4: the reusable job now contains only
+      # publish-allowlisted actions (lgtm-ci#518).
+      publish-results: true
       egress-policy: block
       egress-preset: scorecard
       # Complete list, not append: the reusable feeds allowed-endpoints


### PR DESCRIPTION
## Summary

lgtm-ci v0.52.4 ships lgtm-ci#518: `reusable-scorecards.yml`'s job now contains only actions on ossf/scorecard-action's publish allowlist, so `publish-results: true` no longer fails with "job has unallowed step".

## Changes

- Bump lgtm-ci pin `66cad82` (v0.52.3) → `768a6b7` (v0.52.4)
- `publish-results: true` — restores public Scorecard API/badge updates
- Drop `tooling-ref` (deprecated no-op as of v0.52.4)

Follow-up to lgtm-hq/lgtm-ci#535.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores public Scorecard publishing for the security scorecards workflow. The main changes are:

- Bumps the lgtm-ci reusable scorecards workflow to v0.52.4.
- Removes the old `tooling-ref` input from the caller.
- Changes `publish-results` back to `true`.
</details>

<h3>Confidence Score: 4/5</h3>

The workflow looks mostly safe, with small follow-ups around reusable input compatibility and manual publishing behavior.

- The changed caller may rely on v0.52.4 treating `tooling-ref` as optional.
- `workflow_dispatch` can reach the new publishing path unless the reusable workflow limits publishing to the default branch.
- The existing egress allowlist includes the Scorecard and GitHub endpoints used by the changed publish path.

.github/workflows/security-scorecards.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/security-scorecards.yml | Updates the reusable scorecards workflow pin, removes `tooling-ref`, and re-enables public result publishing. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsecurity-scorecards.yml%3A24%0A**Missing%20Reusable%20Workflow%20Input**%0A%0AIf%20the%20v0.52.4%20reusable%20scorecards%20workflow%20still%20requires%20%60tooling-ref%60%2C%20this%20caller%20now%20omits%20it%20and%20GitHub%20Actions%20rejects%20the%20job%20before%20it%20starts.%20That%20would%20break%20the%20scheduled%20and%20main-branch%20scorecard%20workflow%20instead%20of%20publishing%20results.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fsecurity-scorecards.yml%3A27%0A**Manual%20Runs%20Can%20Publish%20Results**%0A%0AThis%20workflow%20still%20has%20%60workflow_dispatch%60%2C%20so%20enabling%20%60publish-results%60%20can%20publish%20Scorecard%20results%20from%20a%20manually%20selected%20non-%60main%60%20ref%20if%20the%20reusable%20workflow%20does%20not%20guard%20publishing%20to%20the%20default%20branch.%20That%20can%20update%20the%20public%20Scorecard%20API%20or%20badge%20with%20results%20from%20an%20unintended%20branch.%0A%0A&pr=532&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsecurity-scorecards.yml%3A24%0A**Missing%20Reusable%20Workflow%20Input**%0A%0AIf%20the%20v0.52.4%20reusable%20scorecards%20workflow%20still%20requires%20%60tooling-ref%60%2C%20this%20caller%20now%20omits%20it%20and%20GitHub%20Actions%20rejects%20the%20job%20before%20it%20starts.%20That%20would%20break%20the%20scheduled%20and%20main-branch%20scorecard%20workflow%20instead%20of%20publishing%20results.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fsecurity-scorecards.yml%3A27%0A**Manual%20Runs%20Can%20Publish%20Results**%0A%0AThis%20workflow%20still%20has%20%60workflow_dispatch%60%2C%20so%20enabling%20%60publish-results%60%20can%20publish%20Scorecard%20results%20from%20a%20manually%20selected%20non-%60main%60%20ref%20if%20the%20reusable%20workflow%20does%20not%20guard%20publishing%20to%20the%20default%20branch.%20That%20can%20update%20the%20public%20Scorecard%20API%20or%20badge%20with%20results%20from%20an%20unintended%20branch.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=532&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22fix%2Fscorecards-publish-results%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fscorecards-publish-results%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsecurity-scorecards.yml%3A24%0A**Missing%20Reusable%20Workflow%20Input**%0A%0AIf%20the%20v0.52.4%20reusable%20scorecards%20workflow%20still%20requires%20%60tooling-ref%60%2C%20this%20caller%20now%20omits%20it%20and%20GitHub%20Actions%20rejects%20the%20job%20before%20it%20starts.%20That%20would%20break%20the%20scheduled%20and%20main-branch%20scorecard%20workflow%20instead%20of%20publishing%20results.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fsecurity-scorecards.yml%3A27%0A**Manual%20Runs%20Can%20Publish%20Results**%0A%0AThis%20workflow%20still%20has%20%60workflow_dispatch%60%2C%20so%20enabling%20%60publish-results%60%20can%20publish%20Scorecard%20results%20from%20a%20manually%20selected%20non-%60main%60%20ref%20if%20the%20reusable%20workflow%20does%20not%20guard%20publishing%20to%20the%20default%20branch.%20That%20can%20update%20the%20public%20Scorecard%20API%20or%20badge%20with%20results%20from%20an%20unintended%20branch.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=532&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): re-enable scorecard publish-res..."](https://github.com/lgtm-hq/turbo-themes/commit/c29e1b4d9027102fa63bff165cade03b3f982428) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43647971)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->