### PR TITLE
fix(ci): sign release version PR commits via GitHub API

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -100,6 +100,7 @@ jobs:
           HUSKY: '0'
         with:
           token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           commit-message: 'chore(release): version ${{ steps.version.outputs.next_version }}'
           title: ${{ steps.version.outputs.pr_title }}
           body-path: ${{ steps.version.outputs.pr_body_file }}


### PR DESCRIPTION
## Summary

Adds `sign-commits: true` to the `create-pull-request` step in `release-version-pr.yml` so release version PR commits are created through GitHub's GraphQL API and automatically signed (verified as the release app).

## Problem

The `main` ruleset requires verified signatures, but `peter-evans/create-pull-request` commits via the git CLI on the runner, producing unsigned commits. Every release PR therefore fails merge-queue entry with `Pull request Commits must have verified signatures` while all checks show green — observed on #508 and #543, each of which needed a manual re-sign + force-push to land.

## Solution

One-line change: `sign-commits: true`. The pinned v8 of the action supports it; commits made via the API are signed by GitHub with no key management.

Fixes #544

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `sign-commits: true` to the `peter-evans/create-pull-request` step so release PR commits are created through GitHub's GraphQL API and automatically verified, satisfying the `main` ruleset's required-signature rule.

- The one-line change is placed correctly within the `with:` block and is fully supported by the pinned v8 release of the action.
- The job already holds `contents: write` permission, which the GraphQL `createCommitOnBranch` mutation requires; no permission changes are needed.
- When a GitHub App token is supplied alongside `sign-commits: true`, commits are signed on behalf of the app — matching the release identity already used throughout the workflow.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single-line addition uses a documented, supported option on the already-pinned v8 action with no side effects on other workflow steps.

The change is minimal and targeted: one new input on a single action step. The sign-commits: true option is confirmed supported by peter-evans/create-pull-request v8, the job already has contents: write (needed for the GraphQL commit mutation), and the GitHub App token already in use is exactly what provides the app-identity signing. No permissions, secrets, or other steps need to change.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-version-pr.yml | Adds sign-commits: true to create-pull-request v8; feature is supported by the pinned action version, required permissions are already present, and the GitHub App token provides the correct signing identity. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Runner as GitHub Actions Runner
    participant App as GitHub App (release bot)
    participant API as GitHub GraphQL API
    participant Repo as Repository (main)

    Runner->>App: Generate installation token
    App-->>Runner: token

    Runner->>Runner: Checkout, compute next version

    Note over Runner,API: Before this PR — git CLI commit (unsigned)
    Runner->>Repo: git push (unsigned commit) ❌ fails ruleset

    Note over Runner,API: After this PR — sign-commits: true
    Runner->>API: createCommitOnBranch mutation (token)
    API->>API: Sign commit as App bot ✅
    API-->>Repo: Verified commit on release branch

    Runner->>API: Open / update PR
    API-->>Runner: pull-request-number

    Runner->>API: gh pr merge --auto --squash
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Runner as GitHub Actions Runner
    participant App as GitHub App (release bot)
    participant API as GitHub GraphQL API
    participant Repo as Repository (main)

    Runner->>App: Generate installation token
    App-->>Runner: token

    Runner->>Runner: Checkout, compute next version

    Note over Runner,API: Before this PR — git CLI commit (unsigned)
    Runner->>Repo: git push (unsigned commit) ❌ fails ruleset

    Note over Runner,API: After this PR — sign-commits: true
    Runner->>API: createCommitOnBranch mutation (token)
    API->>API: Sign commit as App bot ✅
    API-->>Repo: Verified commit on release branch

    Runner->>API: Open / update PR
    API-->>Runner: pull-request-number

    Runner->>API: gh pr merge --auto --squash
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): sign release version PR commits..."](https://github.com/lgtm-hq/turbo-themes/commit/2accc618784b5b6817350d180d179ed2c8c5af19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45090164)</sub>

<!-- /greptile_comment -->