### PR TITLE
fix(ci): pin setup-node comments to exact v6.4.0

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -34,7 +34,7 @@ runs:
         echo "Bun version: $(bun --version)"
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         # Note: Bun handles caching, but Node.js is needed for npm publish compatibility

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -73,7 +73,7 @@ jobs:
           bun-version: '1.3.13'
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Summary

Changes the `actions/setup-node` pin comments in `release-auto-tag.yml` and `.github/actions/setup-env/action.yml` from floating `# v6` to exact `# v6.4.0`, matching the pinned SHA `48b55a0` (same convention `release-version-pr.yml` already uses).

## Problem

The action-pinning validator resolves the commented tag and compares it to the pinned SHA. The `v6` tag has advanced to v6.5.0 (`2497097`), so these two floating comments now fail `validate / Validate Action Pinning` on every workflow-touching PR — first observed blocking #545.

## Solution

Comment-only change to the exact pinned version; no behavior change. Renovate manages future bumps.

Fixes #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release and environment setup processes to use a fixed Node.js setup action version for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CI linting failure by updating two comment-only annotations on `actions/setup-node` pins from the floating `# v6` label to the exact `# v6.4.0`, bringing them in line with the pinned SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` and the convention already used across all other `setup-node` references in the repo.

- Updates `.github/actions/setup-env/action.yml` and `.github/workflows/release-auto-tag.yml` — the two remaining files that still carried the floating `# v6` comment.
- No functional or behavioral change; the SHA is unchanged and Renovate continues to manage future bumps.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only edits with no executable impact.

Both changes are single-line comment updates; the pinned SHA is identical before and after, and the new comments now match every other setup-node reference in the repository.

No files require special attention. As a side note, setup-uv in action.yml line 64 still uses a floating # v7.6 comment (no patch version), which is a pre-existing inconsistency outside the scope of this PR but could trigger the same validator in the future.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/setup-env/action.yml | Comment-only change: updates `# v6` to `# v6.4.0` on the `actions/setup-node` pin to match the pinned SHA `48b55a0`. |
| .github/workflows/release-auto-tag.yml | Comment-only change: updates `# v6` to `# v6.4.0` on the `actions/setup-node` pin to match the pinned SHA `48b55a0`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR touches .github/workflows/** or .github/actions/**"] --> B["quality-validate-action-pinning.yml triggers"]
    B --> C["reusable-validate-action-pinning resolves comment tag"]
    C --> D{"Comment tag matches\npinned SHA?"}
    D -- "Before PR\n# v6 → resolves to v6.5.0\nSHA: 2497097\n≠ 48b55a0" --> E["❌ Validation FAILS"]
    D -- "After PR\n# v6.4.0 → resolves to v6.4.0\nSHA: 48b55a0\n= 48b55a0" --> F["✅ Validation PASSES"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["PR touches .github/workflows/** or .github/actions/**"] --> B["quality-validate-action-pinning.yml triggers"]
    B --> C["reusable-validate-action-pinning resolves comment tag"]
    C --> D{"Comment tag matches\npinned SHA?"}
    D -- "Before PR\n# v6 → resolves to v6.5.0\nSHA: 2497097\n≠ 48b55a0" --> E["❌ Validation FAILS"]
    D -- "After PR\n# v6.4.0 → resolves to v6.4.0\nSHA: 48b55a0\n= 48b55a0" --> F["✅ Validation PASSES"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin setup-node comments to exac..."](https://github.com/lgtm-hq/turbo-themes/commit/43667c6e088ff79a3e024e6b2f20dfa29e6eba8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45093841)</sub>

<!-- /greptile_comment -->