### PR TITLE
refactor(test): replace as-any DOM mocks with typed test doubles

### DIFF
--- a/packages/theme-selector/test/flavor-selector/test-setup.ts
+++ b/packages/theme-selector/test/flavor-selector/test-setup.ts
@@ -2,7 +2,6 @@
  * Shared test setup for flavor-selector tests.
  * Provides common imports, mock setup, and helper functions.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { vi } from 'vitest';
 import {
   setupDocumentMocks,
@@ -20,16 +19,53 @@ export {
 
 export { wireFlavorSelector } from '../../src/index.js';
 
+// ============================================================================
+// Typed mock shapes
+// ============================================================================
+
+/**
+ * Typed shape of the mock button created by createTrackedButton.
+ */
+export interface MockButton {
+  type: string;
+  className: string;
+  setAttribute: ReturnType<typeof vi.fn>;
+  getAttribute: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  appendChild: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
+  click: ReturnType<typeof vi.fn>;
+  classList: {
+    add: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    contains: ReturnType<typeof vi.fn>;
+  };
+}
+
+/**
+ * Typed shape of the mock link element yielded to linkHandler callbacks.
+ * The onload property uses a getter/setter internally; this interface
+ * describes the observable surface that linkHandler consumers interact with.
+ */
+export interface MockLinkEl {
+  id: string;
+  rel: string;
+  type: string;
+  href: string;
+  setAttribute: ReturnType<typeof vi.fn>;
+  readonly onload: (() => void) | null;
+}
+
 /**
  * Creates a tracked button element for testing.
  * Returns button and tracks it in the provided array.
  */
 export const createTrackedButton = (
-  createdButtons: any[],
+  createdButtons: MockButton[],
   themeIdOverride?: string
-) => {
+): MockButton => {
   let themeId = themeIdOverride ?? `theme-${createdButtons.length}`;
-  const btn = {
+  const btn: MockButton = {
     type: '',
     className: '',
     setAttribute: vi.fn((attr: string, value: string) => {
@@ -86,11 +122,11 @@ export const createMockTriggerElement = (
  * Creates a standard createElement mock for tracking elements.
  */
 export const createElementMock = (
-  createdButtons: any[],
+  createdButtons: MockButton[],
   mocks: ReturnType<typeof setupDocumentMocks>,
   options?: {
     themeIdOverride?: string;
-    linkHandler?: (link: any) => void;
+    linkHandler?: (link: MockLinkEl) => void;
   }
 ) => {
   return vi.fn((tag: string) => {
@@ -109,11 +145,13 @@ export const createElementMock = (
           onloadHandler = handler;
           setTimeout(() => onloadHandler?.(), 0);
         },
-        get onload() {
+        get onload(): (() => void) | null {
           return onloadHandler;
         },
       };
-      options?.linkHandler?.(link);
+      // as unknown as MockLinkEl: the getter/setter pair exposes a compatible
+      // read-only surface; narrowing through unknown avoids an unjustified any cast.
+      options?.linkHandler?.(link as unknown as MockLinkEl);
       return link;
     }
     if (tag === 'div') {
@@ -146,7 +184,7 @@ export const createElementMock = (
  */
 export interface KeyboardNavTestContext {
   /** Array of created theme buttons */
-  createdButtons: any[];
+  createdButtons: MockButton[];
   /** Mock dropdown element */
   mockDropdown: ReturnType<typeof createMockDropdownElement>;
   /** Mock trigger element */
@@ -162,7 +200,7 @@ export interface KeyboardNavTestContext {
    * Get the keydown handler registered on the trigger.
    * Returns undefined if no handler was registered.
    */
-  getKeydownHandler: () => ((event: any) => void) | undefined;
+  getKeydownHandler: () => ((event: KeyboardEvent) => void) | undefined;
 }
 
 /**
@@ -174,7 +212,7 @@ export interface KeyboardNavTestOptions {
   /** Override theme ID for created buttons */
   themeIdOverride?: string;
   /** Custom link handler callback */
-  linkHandler?: (link: any) => void;
+  linkHandler?: (link: MockLinkEl) => void;
 }
 
 /**
@@ -204,7 +242,7 @@ export function setupKeyboardNavTest(
   options: KeyboardNavTestOptions = {}
 ): KeyboardNavTestContext {
   const mocks = baseMocks ?? setupDocumentMocks();
-  const createdButtons: any[] = [];
+  const createdButtons: MockButton[] = [];
   const mockDropdown = createMockDropdownElement(options.dropdownActive ?? false);
   const mockTrigger = createMockTriggerElement(mocks, mockDropdown);
 
@@ -228,10 +266,11 @@ export function setupKeyboardNavTest(
   });
 
   // Helper to get the keydown handler
-  const getKeydownHandler = (): ((event: any) => void) | undefined => {
-    return mockTrigger.addEventListener.mock.calls.find(
-      (c: any[]) => c[0] === 'keydown'
-    )?.[1] as ((event: any) => void) | undefined;
+  const getKeydownHandler = (): ((event: KeyboardEvent) => void) | undefined => {
+    const calls = mockTrigger.addEventListener.mock.calls as [string, ...unknown[]][];
+    return calls.find((c) => c[0] === 'keydown')?.[1] as
+      | ((event: KeyboardEvent) => void)
+      | undefined;
   };
 
   // Helper to fire keydown events
@@ -239,7 +278,7 @@ export function setupKeyboardNavTest(
     const handler = getKeydownHandler();
     const preventDefault = vi.fn();
     if (handler) {
-      handler({ key, preventDefault } as any);
+      handler({ key, preventDefault } as unknown as KeyboardEvent);
     }
     return { preventDefault };
   };

--- a/packages/theme-selector/test/init-theme.test.ts
+++ b/packages/theme-selector/test/init-theme.test.ts
@@ -2,7 +2,6 @@
  * Tests for initTheme function.
  * Tests theme initialization, localStorage integration, and CSS loading.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { initTheme } from '../src/index';
 import {
@@ -10,6 +9,13 @@ import {
   mockThemeLoading,
   setupThemeLinkAutoLoad,
 } from '../../../test/helpers/mocks.js';
+
+/** Typed mock for the trigger-icon element used in applyTheme tests. */
+interface MockTriggerIconEl {
+  firstChild: ChildNode | null;
+  removeChild: ReturnType<typeof vi.fn>;
+  appendChild: ReturnType<typeof vi.fn>;
+}
 
 describe('initTheme', () => {
   let mocks: ReturnType<typeof setupDocumentMocks>;
@@ -105,7 +111,7 @@ describe('initTheme', () => {
   });
 
   it('falls back to text icon when theme has no icon', async () => {
-    const triggerIconEl: any = {
+    const triggerIconEl: MockTriggerIconEl = {
       firstChild: null,
       removeChild: vi.fn(),
       appendChild: vi.fn(),
@@ -141,13 +147,16 @@ describe('initTheme', () => {
   });
 
   it('handles URL constructor error (cssFile) without throwing', async () => {
-    const OriginalURL = globalThis.URL as any;
-    (globalThis as any).URL = vi.fn((input: any, base?: any) => {
-      if (typeof input === 'string' && input.includes('assets/css/themes')) {
-        throw new Error('bad url');
-      }
-      return new OriginalURL(input, base);
-    }) as any;
+    const OriginalURL = URL;
+    vi.stubGlobal(
+      'URL',
+      vi.fn((input: string, base?: string) => {
+        if (typeof input === 'string' && input.includes('assets/css/themes')) {
+          throw new Error('bad url');
+        }
+        return new OriginalURL(input, base);
+      })
+    );
 
     Object.defineProperty(document, 'getElementById', {
       value: vi.fn((id) => {
@@ -161,11 +170,11 @@ describe('initTheme', () => {
     mockThemeLoading();
     await expect(initTheme(document, window)).resolves.not.toThrow();
 
-    (globalThis as any).URL = OriginalURL;
+    vi.unstubAllGlobals();
   });
 
   it('handles icon URL constructor error in applyTheme', async () => {
-    const triggerIconEl: any = {
+    const triggerIconEl: MockTriggerIconEl = {
       firstChild: null,
       removeChild: vi.fn(),
       appendChild: vi.fn(),
@@ -179,24 +188,27 @@ describe('initTheme', () => {
       writable: true,
     });
 
-    const OriginalURL = globalThis.URL as any;
-    (globalThis as any).URL = vi.fn((input: any, base?: any) => {
-      if (typeof input === 'string' && input.includes('assets/img')) {
-        throw new Error('bad url');
-      }
-      return new OriginalURL(input, base);
-    }) as any;
+    const OriginalURL = URL;
+    vi.stubGlobal(
+      'URL',
+      vi.fn((input: string, base?: string) => {
+        if (typeof input === 'string' && input.includes('assets/img')) {
+          throw new Error('bad url');
+        }
+        return new OriginalURL(input, base);
+      })
+    );
 
     mocks.mockLocalStorage.getItem.mockReturnValue('catppuccin-frappe');
-    await expect(initTheme(document as any, window as any)).resolves.not.toThrow();
+    await expect(initTheme(document, window)).resolves.not.toThrow();
 
-    (globalThis as any).URL = OriginalURL;
+    vi.unstubAllGlobals();
   });
 
   it('uses text fallback for themes without icons', async () => {
     mocks.mockLocalStorage.getItem.mockReturnValue('catppuccin-latte');
     setupThemeLinkAutoLoad();
-    await initTheme(document as any, window as any);
+    await initTheme(document, window);
 
     expect(document.documentElement.classList.add).toHaveBeenCalledWith('theme-catppuccin-latte');
   });

--- a/packages/theme-selector/test/navbar.test.ts
+++ b/packages/theme-selector/test/navbar.test.ts
@@ -2,10 +2,22 @@
  * Tests for initNavbar function.
  * Tests navbar highlighting, path matching, and reports dropdown handling.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { initNavbar } from '../src/index';
 import { setupDocumentMocks } from '../../../test/helpers/mocks.js';
+
+/** Typed mock for navbar anchor items returned by querySelectorAll. */
+interface MockNavItem {
+  href?: string;
+  classList: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
+  setAttribute: ReturnType<typeof vi.fn>;
+  removeAttribute: ReturnType<typeof vi.fn>;
+}
+
+/** Typed mock for the reports-dropdown link element. */
+interface MockReportsLink {
+  classList: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
+}
 
 describe('initNavbar', () => {
   beforeEach(() => {
@@ -26,12 +38,12 @@ describe('initNavbar', () => {
   });
 
   it('highlights navbar item matching current path', () => {
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       href: 'http://localhost/components/',
       classList: { add: vi.fn(), remove: vi.fn() },
       setAttribute: vi.fn(),
       removeAttribute: vi.fn(),
-    } as any;
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -46,11 +58,12 @@ describe('initNavbar', () => {
   });
 
   it('removes active class from non-matching navbar items', () => {
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       href: 'http://localhost/forms/',
       classList: { add: vi.fn(), remove: vi.fn() },
+      setAttribute: vi.fn(),
       removeAttribute: vi.fn(),
-    } as any;
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -70,12 +83,12 @@ describe('initNavbar', () => {
       writable: true,
     });
 
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       href: 'http://localhost/components/',
       classList: { add: vi.fn(), remove: vi.fn() },
       setAttribute: vi.fn(),
       removeAttribute: vi.fn(),
-    } as any;
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -94,12 +107,12 @@ describe('initNavbar', () => {
       writable: true,
     });
 
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       href: 'http://localhost/',
       classList: { add: vi.fn(), remove: vi.fn() },
       setAttribute: vi.fn(),
       removeAttribute: vi.fn(),
-    } as any;
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -113,10 +126,12 @@ describe('initNavbar', () => {
   });
 
   it('handles invalid URLs gracefully', () => {
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       href: 'invalid-url',
       classList: { add: vi.fn(), remove: vi.fn() },
-    } as any;
+      setAttribute: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -129,9 +144,11 @@ describe('initNavbar', () => {
   });
 
   it('handles navbar items without href', () => {
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       classList: { add: vi.fn(), remove: vi.fn() },
-    } as any;
+      setAttribute: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -150,12 +167,12 @@ describe('initNavbar', () => {
       writable: true,
     });
 
-    const mockNavbarItem = {
+    const mockNavbarItem: MockNavItem = {
       href: 'http://localhost/components/',
       classList: { add: vi.fn(), remove: vi.fn() },
       setAttribute: vi.fn(),
       removeAttribute: vi.fn(),
-    } as any;
+    };
 
     Object.defineProperty(document, 'querySelectorAll', {
       value: vi.fn(() => [mockNavbarItem]),
@@ -178,9 +195,9 @@ describe('initNavbar', () => {
           writable: true,
         });
 
-        const mockReportsLink = {
+        const mockReportsLink: MockReportsLink = {
           classList: { add: vi.fn(), remove: vi.fn() },
-        } as any;
+        };
 
         Object.defineProperty(document, 'querySelectorAll', {
           value: vi.fn(() => []),
@@ -208,9 +225,9 @@ describe('initNavbar', () => {
         writable: true,
       });
 
-      const mockReportsLink = {
+      const mockReportsLink: MockReportsLink = {
         classList: { add: vi.fn(), remove: vi.fn() },
-      } as any;
+      };
 
       Object.defineProperty(document, 'querySelectorAll', {
         value: vi.fn(() => []),
@@ -237,9 +254,9 @@ describe('initNavbar', () => {
         writable: true,
       });
 
-      const mockReportsLink = {
+      const mockReportsLink: MockReportsLink = {
         classList: { add: vi.fn(), remove: vi.fn() },
-      } as any;
+      };
 
       Object.defineProperty(document, 'querySelectorAll', {
         value: vi.fn(() => []),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove unjustified `any` / `as any` DOM mocks in the theme-selector test suite and replace them with typed test doubles so mocks stay aligned with real DOM shapes.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [x] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [x] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Typed mock interfaces in `flavor-selector/test-setup.ts`, `navbar.test.ts`, and `init-theme.test.ts`
- Replaced `as any` casts and file-level eslint-disable comments with constrained typed doubles / `vi.stubGlobal`

## Closes

- Closes #538

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass locally (`bun run test`)

### Test Coverage

- [x] Coverage maintained or improved
- [x] No decrease in code coverage

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type safety across theme selector, navigation, and theme initialization test coverage.
  * Added typed mock elements for buttons, links, navigation items, and trigger icons.
  * Updated keyboard navigation tests to use typed keyboard events.
  * Made URL mocking and cleanup more reliable in theme initialization tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces `as any` casts and file-level `eslint-disable @typescript-eslint/no-explicit-any` comments across three test files with purpose-built typed mock interfaces (`MockButton`, `MockLinkEl`, `MockTriggerIconEl`, `MockNavItem`). URL-global mocking is upgraded from manual `globalThis.URL` reassignment to `vi.stubGlobal`/`vi.unstubAllGlobals()`.

- New typed interfaces are defined close to their usage and accurately reflect the observable surface of each mock, with the `link as unknown as MockLinkEl` two-hop cast commented to explain the getter/setter incompatibility.
- `navbar.test.ts` mocks are consistently completed with `setAttribute` and `removeAttribute` to satisfy `MockNavItem`, matching what production code can call on matched and unmatched items.
- URL stub cleanup is moved to `vi.unstubAllGlobals()` — an improvement over raw property reassignment — but placement at the end of the test body (rather than in `beforeEach`/`afterEach`) still risks global state leaking across tests when an assertion throws.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge for its typing goals; the URL stub cleanup gap in init-theme.test.ts is a pre-existing concern that this PR partially addresses but does not fully resolve.

The type safety improvements are solid across all three files. The one outstanding concern — vi.unstubAllGlobals() placed at the end of each URL-stub test body rather than in beforeEach — means a failed assertion can leave the global URL constructor replaced for every test that runs afterward, making failures non-deterministic and hard to diagnose. This was flagged in a previous review pass and is still unaddressed.

packages/theme-selector/test/init-theme.test.ts — the two URL-stub tests need their cleanup moved to beforeEach/afterEach to make teardown unconditional.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/theme-selector/test/flavor-selector/test-setup.ts | Introduces MockButton and MockLinkEl interfaces; replaces all any[] / (link: any) / (event: any) with typed equivalents; the link→MockLinkEl two-hop cast is correctly justified by the getter/setter shape mismatch. |
| packages/theme-selector/test/init-theme.test.ts | Adds MockTriggerIconEl interface and uses vi.stubGlobal for URL mocking; cleanup via vi.unstubAllGlobals() is still placed at the end of the test body rather than in beforeEach, so a failing assertion can leave the URL stub active for subsequent tests. |
| packages/theme-selector/test/navbar.test.ts | Adds MockNavItem and MockReportsLink interfaces; setAttribute added to mocks previously missing it, making shapes complete and consistent across all test cases. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[beforeEach] -->|vi.clearAllMocks| B[mocks reset]
    B --> C{Test body}

    C -->|URL stub tests| D[vi.stubGlobal URL]
    D --> E[assertion]
    E -->|passes| F[vi.unstubAllGlobals]
    E -->|fails / throws| G[cleanup skipped ⚠️]
    G --> H[URL stub leaks into next test]

    C -->|other tests| I[no global stubs]
    I --> J[clean exit]

    F --> K[next test]
    H --> K
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[beforeEach] -->|vi.clearAllMocks| B[mocks reset]
    B --> C{Test body}

    C -->|URL stub tests| D[vi.stubGlobal URL]
    D --> E[assertion]
    E -->|passes| F[vi.unstubAllGlobals]
    E -->|fails / throws| G[cleanup skipped ⚠️]
    G --> H[URL stub leaks into next test]

    C -->|other tests| I[no global stubs]
    I --> J[clean exit]

    F --> K[next test]
    H --> K
    J --> K
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/theme-selector/test/init-theme.test.ts`, line 20-26 ([link](https://github.com/lgtm-hq/turbo-themes/blob/3b3caa86c59120eb68b023089393e223ca4f1ebd/packages/theme-selector/test/init-theme.test.ts#L20-L26)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Global stub not cleaned up on test failure**

   Both tests that call `vi.stubGlobal('URL', ...)` place `vi.unstubAllGlobals()` as the very last statement of the test body. `vi.clearAllMocks()` in `beforeEach` does not restore stubbed globals. If the assertion on line 171 (`resolves.not.toThrow()`) were to fail, the `URL` stub from the first test survives into the second test, which then executes `const OriginalURL = URL` — capturing the already-stubbed constructor. The second stub would wrap the first, and `vi.unstubAllGlobals()` may not fully restore the real `URL`, corrupting the global for all subsequent tests in the suite.

   Adding `vi.unstubAllGlobals()` to `beforeEach` (alongside `vi.clearAllMocks()`) ensures the global is always clean regardless of prior test outcomes.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftheme-selector%2Ftest%2Finit-theme.test.ts%0ALine%3A%2020-26%0A%0AComment%3A%0A**Global%20stub%20not%20cleaned%20up%20on%20test%20failure**%0A%0ABoth%20tests%20that%20call%20%60vi.stubGlobal%28'URL'%2C%20...%29%60%20place%20%60vi.unstubAllGlobals%28%29%60%20as%20the%20very%20last%20statement%20of%20the%20test%20body.%20%60vi.clearAllMocks%28%29%60%20in%20%60beforeEach%60%20does%20not%20restore%20stubbed%20globals.%20If%20the%20assertion%20on%20line%20171%20%28%60resolves.not.toThrow%28%29%60%29%20were%20to%20fail%2C%20the%20%60URL%60%20stub%20from%20the%20first%20test%20survives%20into%20the%20second%20test%2C%20which%20then%20executes%20%60const%20OriginalURL%20%3D%20URL%60%20%E2%80%94%20capturing%20the%20already-stubbed%20constructor.%20The%20second%20stub%20would%20wrap%20the%20first%2C%20and%20%60vi.unstubAllGlobals%28%29%60%20may%20not%20fully%20restore%20the%20real%20%60URL%60%2C%20corrupting%20the%20global%20for%20all%20subsequent%20tests%20in%20the%20suite.%0A%0AAdding%20%60vi.unstubAllGlobals%28%29%60%20to%20%60beforeEach%60%20%28alongside%20%60vi.clearAllMocks%28%29%60%29%20ensures%20the%20global%20is%20always%20clean%20regardless%20of%20prior%20test%20outcomes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftheme-selector%2Ftest%2Finit-theme.test.ts%0ALine%3A%2020-26%0A%0AComment%3A%0A**Global%20stub%20not%20cleaned%20up%20on%20test%20failure**%0A%0ABoth%20tests%20that%20call%20%60vi.stubGlobal%28'URL'%2C%20...%29%60%20place%20%60vi.unstubAllGlobals%28%29%60%20as%20the%20very%20last%20statement%20of%20the%20test%20body.%20%60vi.clearAllMocks%28%29%60%20in%20%60beforeEach%60%20does%20not%20restore%20stubbed%20globals.%20If%20the%20assertion%20on%20line%20171%20%28%60resolves.not.toThrow%28%29%60%29%20were%20to%20fail%2C%20the%20%60URL%60%20stub%20from%20the%20first%20test%20survives%20into%20the%20second%20test%2C%20which%20then%20executes%20%60const%20OriginalURL%20%3D%20URL%60%20%E2%80%94%20capturing%20the%20already-stubbed%20constructor.%20The%20second%20stub%20would%20wrap%20the%20first%2C%20and%20%60vi.unstubAllGlobals%28%29%60%20may%20not%20fully%20restore%20the%20real%20%60URL%60%2C%20corrupting%20the%20global%20for%20all%20subsequent%20tests%20in%20the%20suite.%0A%0AAdding%20%60vi.unstubAllGlobals%28%29%60%20to%20%60beforeEach%60%20%28alongside%20%60vi.clearAllMocks%28%29%60%29%20ensures%20the%20global%20is%20always%20clean%20regardless%20of%20prior%20test%20outcomes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F538-typed-dom-mocks-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F538-typed-dom-mocks-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftheme-selector%2Ftest%2Finit-theme.test.ts%0ALine%3A%2020-26%0A%0AComment%3A%0A**Global%20stub%20not%20cleaned%20up%20on%20test%20failure**%0A%0ABoth%20tests%20that%20call%20%60vi.stubGlobal%28'URL'%2C%20...%29%60%20place%20%60vi.unstubAllGlobals%28%29%60%20as%20the%20very%20last%20statement%20of%20the%20test%20body.%20%60vi.clearAllMocks%28%29%60%20in%20%60beforeEach%60%20does%20not%20restore%20stubbed%20globals.%20If%20the%20assertion%20on%20line%20171%20%28%60resolves.not.toThrow%28%29%60%29%20were%20to%20fail%2C%20the%20%60URL%60%20stub%20from%20the%20first%20test%20survives%20into%20the%20second%20test%2C%20which%20then%20executes%20%60const%20OriginalURL%20%3D%20URL%60%20%E2%80%94%20capturing%20the%20already-stubbed%20constructor.%20The%20second%20stub%20would%20wrap%20the%20first%2C%20and%20%60vi.unstubAllGlobals%28%29%60%20may%20not%20fully%20restore%20the%20real%20%60URL%60%2C%20corrupting%20the%20global%20for%20all%20subsequent%20tests%20in%20the%20suite.%0A%0AAdding%20%60vi.unstubAllGlobals%28%29%60%20to%20%60beforeEach%60%20%28alongside%20%60vi.clearAllMocks%28%29%60%29%20ensures%20the%20global%20is%20always%20clean%20regardless%20of%20prior%20test%20outcomes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `packages/theme-selector/test/init-theme.test.ts`, line 23-26 ([link](https://github.com/lgtm-hq/turbo-themes/blob/3b3caa86c59120eb68b023089393e223ca4f1ebd/packages/theme-selector/test/init-theme.test.ts#L23-L26)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Add `vi.unstubAllGlobals()` to `beforeEach` so a failing test cannot leave a `URL` stub active for subsequent tests. The cleanup at the end of each test body can then be removed since `beforeEach` guarantees a clean slate.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftheme-selector%2Ftest%2Finit-theme.test.ts%0ALine%3A%2023-26%0A%0AComment%3A%0AAdd%20%60vi.unstubAllGlobals%28%29%60%20to%20%60beforeEach%60%20so%20a%20failing%20test%20cannot%20leave%20a%20%60URL%60%20stub%20active%20for%20subsequent%20tests.%20The%20cleanup%20at%20the%20end%20of%20each%20test%20body%20can%20then%20be%20removed%20since%20%60beforeEach%60%20guarantees%20a%20clean%20slate.%0A%0A%60%60%60suggestion%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.clearAllMocks%28%29%3B%0A%20%20%20%20vi.unstubAllGlobals%28%29%3B%0A%20%20%20%20mocks%20%3D%20setupDocumentMocks%28%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftheme-selector%2Ftest%2Finit-theme.test.ts%0ALine%3A%2023-26%0A%0AComment%3A%0AAdd%20%60vi.unstubAllGlobals%28%29%60%20to%20%60beforeEach%60%20so%20a%20failing%20test%20cannot%20leave%20a%20%60URL%60%20stub%20active%20for%20subsequent%20tests.%20The%20cleanup%20at%20the%20end%20of%20each%20test%20body%20can%20then%20be%20removed%20since%20%60beforeEach%60%20guarantees%20a%20clean%20slate.%0A%0A%60%60%60suggestion%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.clearAllMocks%28%29%3B%0A%20%20%20%20vi.unstubAllGlobals%28%29%3B%0A%20%20%20%20mocks%20%3D%20setupDocumentMocks%28%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F538-typed-dom-mocks-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F538-typed-dom-mocks-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftheme-selector%2Ftest%2Finit-theme.test.ts%0ALine%3A%2023-26%0A%0AComment%3A%0AAdd%20%60vi.unstubAllGlobals%28%29%60%20to%20%60beforeEach%60%20so%20a%20failing%20test%20cannot%20leave%20a%20%60URL%60%20stub%20active%20for%20subsequent%20tests.%20The%20cleanup%20at%20the%20end%20of%20each%20test%20body%20can%20then%20be%20removed%20since%20%60beforeEach%60%20guarantees%20a%20clean%20slate.%0A%0A%60%60%60suggestion%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.clearAllMocks%28%29%3B%0A%20%20%20%20vi.unstubAllGlobals%28%29%3B%0A%20%20%20%20mocks%20%3D%20setupDocumentMocks%28%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(test): replace as-any DOM mocks..."](https://github.com/lgtm-hq/turbo-themes/commit/6eed76583114143730b478fd395beb422632cc7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45107447)</sub>

<!-- /greptile_comment -->