### PR TITLE
docs(site): recommend uv for Python installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ projects:
 | Platform                  | Package Manager | Install Command                                   |
 | ------------------------- | --------------- | ------------------------------------------------- |
 | **JavaScript/TypeScript** | npm / bun       | `npm install @lgtm-hq/turbo-themes`               |
-| **Python**                | pip / uv        | `pip install turbo-themes`                        |
+| **Python**                | uv / pip        | `uv pip install turbo-themes`                     |
 | **Ruby**                  | bundler         | `gem "turbo-themes", "~> 0.12"`                   |
 | **Swift**                 | SPM             | Add `https://github.com/lgtm-hq/turbo-themes.git` |
 
@@ -74,9 +74,11 @@ npm install @lgtm-hq/turbo-themes
 ### Python
 
 ```bash
+# Using uv (recommended)
+uv pip install turbo-themes
+
+# Or using pip
 pip install turbo-themes
-# or
-uv add turbo-themes
 ```
 
 ### Ruby (Jekyll)

--- a/apps/site/src/content/docs/integrations/index.md
+++ b/apps/site/src/content/docs/integrations/index.md
@@ -23,10 +23,10 @@ project.
 
 ## Platform Libraries
 
-| Platform                               | Package        | Installation                  |
-| -------------------------------------- | -------------- | ----------------------------- |
-| [Python](/docs/integrations/python/)   | `turbo-themes` | `uv pip install turbo-themes` |
-| [SwiftUI](/docs/integrations/swiftui/) | `TurboThemes`  | Swift Package                 |
+| Platform                               | Package        | Installation                                  |
+| -------------------------------------- | -------------- | --------------------------------------------- |
+| [Python](/docs/integrations/python/)   | `turbo-themes` | `uv pip install` / `pip install turbo-themes` |
+| [SwiftUI](/docs/integrations/swiftui/) | `TurboThemes`  | Swift Package                                 |
 
 ## How Integrations Work
 

--- a/apps/site/src/content/docs/integrations/index.md
+++ b/apps/site/src/content/docs/integrations/index.md
@@ -23,10 +23,10 @@ project.
 
 ## Platform Libraries
 
-| Platform                               | Package        | Installation               |
-| -------------------------------------- | -------------- | -------------------------- |
-| [Python](/docs/integrations/python/)   | `turbo-themes` | `pip install turbo-themes` |
-| [SwiftUI](/docs/integrations/swiftui/) | `TurboThemes`  | Swift Package              |
+| Platform                               | Package        | Installation                  |
+| -------------------------------------- | -------------- | ----------------------------- |
+| [Python](/docs/integrations/python/)   | `turbo-themes` | `uv pip install turbo-themes` |
+| [SwiftUI](/docs/integrations/swiftui/) | `TurboThemes`  | Swift Package                 |
 
 ## How Integrations Work
 

--- a/apps/site/src/content/docs/integrations/python.md
+++ b/apps/site/src/content/docs/integrations/python.md
@@ -14,6 +14,10 @@ Use Turbo Themes design tokens in Python applications.
 ## Installation
 
 ```bash
+# Using uv (recommended)
+uv pip install turbo-themes
+
+# Or using pip
 pip install turbo-themes
 ```
 

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -12,7 +12,11 @@ const installNpm = `npm install turbo-themes`;
 const installCdn = `<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
 <link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css" />`;
 
-const installPython = `pip install turbo-themes`;
+const installPython = `# Using uv (recommended)
+uv pip install turbo-themes
+
+# Or using pip
+pip install turbo-themes`;
 
 const installRuby = `gem "turbo-themes"`;
 

--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -3,6 +3,10 @@
 1. Install:
 
    ```bash
+   # Using uv (recommended)
+   uv pip install turbo-themes
+
+   # Or using pip
    pip install turbo-themes
    ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Update Python install instructions across the site, docs, and README to recommend `uv pip install turbo-themes`, keeping plain `pip` as a documented alternative.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [x] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Homepage `installPython` constant now shows uv as recommended + pip fallback
- Updated integrations docs (site content + `docs/integrations/python.md`) and README quickstart/table

## Closes

- Closes #266

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Python installation instructions across the README, site docs, homepage, and a standalone docs file to recommend `uv pip install turbo-themes` as the primary method, with plain `pip install` documented as an alternative.

- **README.md**: Install table and quickstart block updated — `uv pip install` is now listed first (recommended), with `pip install` as the fallback; the previous `uv add` alternative is removed.
- **Site docs (`python.md`, `index.md`, `index.astro`)**: All Python install blocks and the platform table now follow the same uv-first, pip-fallback pattern.
- **`docs/integrations/python.md`**: Quickstart install step updated to match.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no logic or runtime code is affected.

All five changed files are Markdown or a string constant in an Astro page — no executable logic is touched. The updates are internally consistent across every location, and the only finding is a minor truncation of the uv command in the integrations table (missing the package name), which is trivially fixable and has no runtime impact.

apps/site/src/content/docs/integrations/index.md — the platform table cell truncates `uv pip install turbo-themes` to `uv pip install`, omitting the package name.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updated Python install table and quickstart block to recommend uv pip install over the previous uv add / pip alternatives; changes are consistent and accurate. |
| apps/site/src/content/docs/integrations/index.md | Platform table updated to include pip fallback, but the uv command is truncated to `uv pip install` (missing the package name `turbo-themes`). |
| apps/site/src/content/docs/integrations/python.md | Added uv (recommended) and pip alternative install blocks; content is correct and consistent with other changed files. |
| apps/site/src/pages/index.astro | installPython constant updated to a multi-line string showing both uv and pip; straightforward and correct. |
| docs/integrations/python.md | Brief quickstart doc updated with uv recommended / pip fallback pattern; changes are accurate. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wants to install turbo-themes Python package] --> B{Have uv?}
    B -- Yes --> C["uv pip install turbo-themes\n(recommended)"]
    B -- No --> D["pip install turbo-themes\n(fallback)"]
    B -- Poetry project --> E["poetry add turbo-themes"]
    C --> F[Package installed]
    D --> F
    E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User wants to install turbo-themes Python package] --> B{Have uv?}
    B -- Yes --> C["uv pip install turbo-themes\n(recommended)"]
    B -- No --> D["pip install turbo-themes\n(fallback)"]
    B -- Poetry project --> E["poetry add turbo-themes"]
    C --> F[Package installed]
    D --> F
    E --> F
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(integrations): add pip install alte..."](https://github.com/lgtm-hq/turbo-themes/commit/016faf2960b202012fbf0323ef36737e4eb7b4bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45107460)</sub>

<!-- /greptile_comment -->