### PR TITLE
fix(site): wire DocsLayout headings/showToc and render on-page TOC

### DIFF
--- a/apps/site/src/components/docs/DocsToc.astro
+++ b/apps/site/src/components/docs/DocsToc.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * "On this page" table of contents for documentation pages.
+ * Renders heading anchors (depth 2–3) when showToc is enabled.
+ */
+import type { MarkdownHeading } from 'astro';
+
+interface Props {
+  headings: MarkdownHeading[];
+  showToc: boolean;
+}
+
+const { headings, showToc } = Astro.props;
+
+const tocHeadings = headings.filter(h => h.depth === 2 || h.depth === 3);
+---
+
+{showToc && tocHeadings.length > 0 && (
+  <nav class="docs-toc" aria-label="On this page" data-testid="docs-toc">
+    <h2 class="docs-toc-title">On this page</h2>
+    <ul class="docs-toc-list">
+      {tocHeadings.map(heading => (
+        <li class={`docs-toc-item docs-toc-depth-${heading.depth}`}>
+          <a href={`#${heading.slug}`} class="docs-toc-link">
+            {heading.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}

--- a/apps/site/src/components/docs/DocsToc.astro
+++ b/apps/site/src/components/docs/DocsToc.astro
@@ -17,7 +17,7 @@ const tocHeadings = headings.filter(h => h.depth === 2 || h.depth === 3);
 
 {showToc && tocHeadings.length > 0 && (
   <nav class="docs-toc" aria-label="On this page" data-testid="docs-toc">
-    <h2 class="docs-toc-title">On this page</h2>
+    <h2 class="docs-toc-title" aria-hidden="true">On this page</h2>
     <ul class="docs-toc-list">
       {tocHeadings.map(heading => (
         <li class={`docs-toc-item docs-toc-depth-${heading.depth}`}>

--- a/apps/site/src/content/docs/installation/index.md
+++ b/apps/site/src/content/docs/installation/index.md
@@ -5,6 +5,7 @@ description:
   packages.
 category: installation
 order: 1
+toc: false
 prev: getting-started/concepts
 next: installation/npm
 ---

--- a/apps/site/src/layouts/DocsLayout.astro
+++ b/apps/site/src/layouts/DocsLayout.astro
@@ -4,9 +4,11 @@
  * Left: Sidebar navigation (collapsible)
  * Right: Main content
  */
+import type { MarkdownHeading } from 'astro';
 import BaseLayout from './BaseLayout.astro';
 import DocsSidebar from '../components/docs/DocsSidebar.astro';
 import Breadcrumbs from '../components/docs/Breadcrumbs.astro';
+import DocsToc from '../components/docs/DocsToc.astro';
 import PrevNext from '../components/docs/PrevNext.astro';
 
 interface Props {
@@ -15,6 +17,8 @@ interface Props {
   category: string;
   categoryLabel: string;
   slug: string;
+  headings?: MarkdownHeading[];
+  showToc?: boolean;
   prev?: string;
   next?: string;
   lastUpdated?: Date;
@@ -26,6 +30,8 @@ const {
   category,
   categoryLabel,
   slug,
+  headings = [],
+  showToc = true,
   prev,
   next,
   lastUpdated
@@ -56,35 +62,39 @@ const {
     <DocsSidebar currentSlug={slug} />
 
     <main class="docs-main">
-      <article class="docs-content" data-pagefind-body>
-        <Breadcrumbs
-          category={category}
-          categoryLabel={categoryLabel}
-          title={title}
-        />
+      <div class="docs-main-inner">
+        <article class="docs-content" data-pagefind-body>
+          <Breadcrumbs
+            category={category}
+            categoryLabel={categoryLabel}
+            title={title}
+          />
 
-        <header class="docs-header">
-          <h1 class="docs-title">{title}</h1>
-          {description && (
-            <p class="docs-description">{description}</p>
-          )}
-          {lastUpdated && (
-            <p class="docs-meta">
-              Last updated: {lastUpdated.toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric'
-              })}
-            </p>
-          )}
-        </header>
+          <header class="docs-header">
+            <h1 class="docs-title">{title}</h1>
+            {description && (
+              <p class="docs-description">{description}</p>
+            )}
+            {lastUpdated && (
+              <p class="docs-meta">
+                Last updated: {lastUpdated.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric'
+                })}
+              </p>
+            )}
+          </header>
 
-        <div class="docs-body prose">
-          <slot />
-        </div>
+          <div class="docs-body prose">
+            <slot />
+          </div>
 
-        <PrevNext prev={prev} next={next} />
-      </article>
+          <PrevNext prev={prev} next={next} />
+        </article>
+
+        <DocsToc headings={headings} showToc={showToc} />
+      </div>
     </main>
   </div>
 </BaseLayout>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -2386,6 +2386,81 @@ html:root .footer-links a:hover {
 }
 
 /* ==========================================================================
+   Docs TOC (On this page)
+   ========================================================================== */
+
+.docs-main-inner {
+  display: flex;
+  gap: var(--space-2xl);
+  align-items: flex-start;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.docs-main-inner .docs-content {
+  flex: 1;
+  min-width: 0;
+  max-width: 800px;
+}
+
+.docs-toc {
+  flex-shrink: 0;
+  width: 220px;
+  position: sticky;
+  top: calc(64px + var(--space-xl));
+  max-height: calc(100vh - 64px - var(--space-xl) * 2);
+  overflow-y: auto;
+  padding-left: var(--space-md);
+  border-left: 2px solid var(--turbo-border-default);
+  display: none;
+}
+
+.docs-toc-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--turbo-text-tertiary);
+  margin: 0 0 var(--space-sm);
+}
+
+.docs-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.docs-toc-item {
+  line-height: 1.4;
+}
+
+.docs-toc-depth-3 {
+  padding-left: var(--space-md);
+}
+
+.docs-toc-link {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--turbo-text-secondary);
+  text-decoration: none;
+  padding: 3px 0;
+  transition: color var(--transition-fast);
+}
+
+.docs-toc-link:hover {
+  color: var(--turbo-brand-primary);
+}
+
+@media (min-width: 1280px) {
+  .docs-toc {
+    display: block;
+  }
+}
+
+/* ==========================================================================
    Breadcrumbs
    ========================================================================== */
 

--- a/e2e/docs-toc.spec.ts
+++ b/e2e/docs-toc.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from './fixtures';
+
+/**
+ * Docs TOC ("On this page") tests.
+ *
+ * Verifies that the table of contents renders on docs pages when `toc: true`
+ * (the default) and is absent when `toc: false` is set in frontmatter.
+ */
+
+test.describe('Docs TOC @smoke', () => {
+  test('shows "On this page" TOC on a page with toc enabled and headings', async ({
+    page,
+  }) => {
+    // getting-started/concepts has several h2/h3 headings and toc defaults to true
+    await page.goto('/docs/getting-started/concepts/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const toc = page.getByTestId('docs-toc');
+    await expect(toc).toBeVisible();
+
+    const tocTitle = toc.locator('.docs-toc-title');
+    await expect(tocTitle).toHaveText('On this page');
+
+    // Should contain at least one link to a heading anchor
+    const links = toc.locator('.docs-toc-link');
+    await expect(links.first()).toBeVisible();
+    const href = await links.first().getAttribute('href');
+    expect(href).toMatch(/^#/);
+  });
+
+  test('does not render TOC on a page with toc: false', async ({ page }) => {
+    // installation/index has toc: false in frontmatter
+    await page.goto('/docs/installation/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const toc = page.getByTestId('docs-toc');
+    await expect(toc).not.toBeAttached();
+  });
+});

--- a/e2e/docs-toc.spec.ts
+++ b/e2e/docs-toc.spec.ts
@@ -16,6 +16,8 @@ test.describe('Docs TOC @smoke', () => {
     await page.waitForLoadState('domcontentloaded');
 
     const toc = page.getByTestId('docs-toc');
+    // .docs-toc is hidden below 1280 px; the desktop Playwright project uses
+    // viewport { width: 1280, height: 800 } which satisfies min-width: 1280px.
     await expect(toc).toBeVisible();
 
     const tocTitle = toc.locator('.docs-toc-title');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`DocsLayout` was silently dropping `headings` / `showToc` props from the docs slug page, so frontmatter `toc` never rendered an on-page TOC. This wires the props through and adds a `DocsToc` component.

## Type

- [ ] ✨ Feature (`feat:`)
- [x] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [x] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Declared `headings` / `showToc` on `DocsLayout.astro` and render `DocsToc`
- Added `DocsToc.astro` + site CSS for the on-page TOC
- Added Playwright smoke coverage for TOC visibility

## Closes

- Closes #517

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `DocsLayout` silently dropping `headings` and `showToc` props, wires them through to a new `DocsToc` component, and adds Playwright smoke coverage. The content schema already defined `toc: z.boolean().default(true)`, so the frontmatter opt-out on `installation/index.md` is all that was needed to suppress the TOC there.

- **`DocsLayout.astro`** — adds `headings`/`showToc` to the `Props` interface with safe defaults and renders `DocsToc` inside a new `docs-main-inner` flex wrapper.
- **`DocsToc.astro`** — filters to depth-2/3 headings, guards on both `showToc` and a non-empty list, and marks the `<h2>` title `aria-hidden="true"` so it doesn't pollute the heading outline.
- **`assets/css/site.css`** — introduces `.docs-main-inner` flex layout and TOC styles, but the more-specific `.docs-main-inner .docs-content` rule drops `margin: 0 auto`, causing a centering regression on pages where the TOC is absent.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the content centering regression on toc:false pages.

The new .docs-main-inner .docs-content flex rule removes margin: 0 auto from the base .docs-content rule. On any page where the TOC is not rendered — such as installation/index.md — the article content will be left-aligned inside the 1100 px container instead of centred, producing a noticeable blank gap on the right on wide viewports.

assets/css/site.css — the .docs-main-inner .docs-content rule needs margin-inline: auto to restore centred layout on pages without a TOC.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/components/docs/DocsToc.astro | New component rendering depth-2/3 headings as an on-page TOC; correctly guards on both showToc and non-empty headings list; uses aria-hidden on the h2 title. |
| apps/site/src/layouts/DocsLayout.astro | Wires headings/showToc props through to DocsToc and wraps content in a new docs-main-inner flex container; props typed and defaulted correctly. |
| assets/css/site.css | Adds TOC layout CSS; .docs-main-inner .docs-content overrides the base .docs-content centering (margin: 0 auto) without re-applying it, causing content to be left-aligned on pages where the TOC is absent. |
| e2e/docs-toc.spec.ts | Smoke tests for TOC visibility and absence; correctly uses not.toBeAttached() for the toc:false case; explicit comment documents the viewport/breakpoint dependency. |
| apps/site/src/content/docs/installation/index.md | Adds toc: false to frontmatter to opt this overview page out of the on-page TOC; matches the e2e test fixture expectation. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Slug as [...slug].astro
    participant DL as DocsLayout.astro
    participant Toc as DocsToc.astro

    Slug->>Slug: render(doc) to get Content and headings
    Slug->>DL: headings, showToc from doc.data.toc
    DL->>DL: showToc defaults to true if omitted
    DL->>Toc: headings, showToc
    Toc->>Toc: filter depth 2 and 3
    alt "showToc and tocHeadings.length > 0"
        Toc-->>DL: renders nav.docs-toc
    else toc false or no headings
        Toc-->>DL: renders nothing
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Slug as [...slug].astro
    participant DL as DocsLayout.astro
    participant Toc as DocsToc.astro

    Slug->>Slug: render(doc) to get Content and headings
    Slug->>DL: headings, showToc from doc.data.toc
    DL->>DL: showToc defaults to true if omitted
    DL->>Toc: headings, showToc
    Toc->>Toc: filter depth 2 and 3
    alt "showToc and tocHeadings.length > 0"
        Toc-->>DL: renders nav.docs-toc
    else toc false or no headings
        Toc-->>DL: renders nothing
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(a11y): hide TOC heading from documen..."](https://github.com/lgtm-hq/turbo-themes/commit/9cbde550a052d58e76832da27907b2390282f1e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45107463)</sub>

<!-- /greptile_comment -->