### PR TITLE
docs(security): add Content Security Policy guide

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,12 @@ prevent potential exploitation while we work on a fix.
 - Never commit sensitive data (API keys, passwords, etc.)
 - Follow secure coding practices
 
+## Content Security Policy
+
+For guidance on CSP headers when deploying turbo-themes — including Google Fonts
+allowlisting, inline-script nonce/hash handling, CDN origins, and platform-specific
+examples — see **[docs/SECURITY-CSP.md](docs/SECURITY-CSP.md)**.
+
 ## Contact
 
 - **Primary**: `turbocoder13@gmail.com`

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -36,6 +36,8 @@ Content-Security-Policy:
   script-src 'self' 'nonce-{random}';
   img-src 'self' data:;
   connect-src 'self';
+  base-uri 'self';
+  object-src 'none';
 ```
 
 Replace `{random}` with a cryptographically-random, base64-encoded value that is unique
@@ -112,12 +114,15 @@ ones, because the nonce travels in the HTTP header and in the `nonce` attribute 
        response.headers.set(
          'Content-Security-Policy',
          [
-           "default-src 'self'",
+         "default-src 'self'",
            "style-src 'self' https://fonts.googleapis.com",
            "font-src 'self' https://fonts.gstatic.com",
            `script-src 'self' 'nonce-${nonce}'`,
            "img-src 'self' data:",
-         ].join('; ')
+           "connect-src 'self'",
+           "base-uri 'self'",
+           "object-src 'none'",
+           ].join('; ')
        );
        return response;
      });
@@ -212,6 +217,9 @@ Content-Security-Policy:
   font-src 'self' https://fonts.gstatic.com;
   script-src 'self' 'nonce-{random}';
   img-src 'self' data:;
+  connect-src 'self';
+  base-uri 'self';
+  object-src 'none';
 ```
 
 CDN origins are broad by design — if you want a tighter policy, self-host the CSS file
@@ -223,24 +231,32 @@ and remove the CDN entry.
 
 ### Nginx
 
+For static sites served by Nginx, use precomputed `'sha256-...'` hashes (see
+[Hash-based CSP](#hash-based-csp-static-builds)):
+
 ```nginx
 server {
     # ... other config ...
 
-    # Generate a per-request nonce with a Lua or njs module, or use a static
-    # hash for pre-built sites:
     add_header Content-Security-Policy
         "default-src 'self'; \
          style-src 'self' https://fonts.googleapis.com; \
          font-src 'self' https://fonts.gstatic.com; \
-         script-src 'self' 'nonce-$request_id'; \
-         img-src 'self' data:;"
+         script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; \
+         img-src 'self' data:; \
+         connect-src 'self'; \
+         base-uri 'self'; \
+         object-src 'none';"
         always;
 }
 ```
 
-> For static deployments where you cannot inject a nonce per request, replace
-> `'nonce-$request_id'` with the precomputed `'sha256-...'` hashes.
+> **Nonce-based approach for Nginx:** `$request_id` is an nginx-internal hex identifier
+> that sets the CSP header, but the pre-built HTML `<script>` tags have no matching
+> `nonce="..."` attributes. To use nonces with Nginx you must also rewrite the HTML via
+> an `ngx_http_sub_module` `sub_filter` or an njs/Lua module that injects the nonce into
+> every `<script>` tag. For static turbo-themes builds, the hash-based approach above is
+> simpler and fully functional.
 
 ### Apache
 
@@ -251,7 +267,10 @@ server {
          style-src 'self' https://fonts.googleapis.com; \
          font-src 'self' https://fonts.gstatic.com; \
          script-src 'self' 'nonce-REPLACE_WITH_NONCE'; \
-         img-src 'self' data:;"
+         img-src 'self' data:; \
+         connect-src 'self'; \
+         base-uri 'self'; \
+         object-src 'none';"
 </IfModule>
 ```
 
@@ -268,7 +287,7 @@ For static sites served by Apache, replace `'nonce-REPLACE_WITH_NONCE'` with the
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:;"
+          "value": "default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none';"
         }
       ]
     }
@@ -293,14 +312,14 @@ In your `netlify.toml` or a `_headers` file placed in the site's publish directo
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:;"
+    Content-Security-Policy = "default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none';"
 ```
 
 **`_headers` file:**
 
 ```
 /*
-  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:;
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none';
 ```
 
 ### GitHub Pages
@@ -317,6 +336,9 @@ The only CSP option on Pages is the `<meta>` tag approach:
     font-src 'self' https://fonts.gstatic.com;
     script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH';
     img-src 'self' data:;
+    connect-src 'self';
+    base-uri 'self';
+    object-src 'none';
   "
 />
 ```

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -99,7 +99,18 @@ ones, because the nonce travels in the HTTP header and in the `nonce` attribute 
 
 **Steps for an Astro SSR deployment:**
 
-1. Generate a cryptographically-random nonce in server middleware:
+1. Declare the `cspNonce` type so TypeScript knows about `Astro.locals.cspNonce`:
+
+   ```typescript
+   // src/env.d.ts  (or any file included in tsconfig)
+   declare namespace App {
+     interface Locals {
+       cspNonce: string;
+     }
+   }
+   ```
+
+2. Generate a cryptographically-random nonce in server middleware:
 
    ```typescript
    // src/middleware.ts
@@ -129,9 +140,26 @@ ones, because the nonce travels in the HTTP header and in the `nonce` attribute 
    });
    ```
 
-2. Pass the nonce through the layout chain and add a `nonce` attribute to each
-   `<script is:inline>` block. Astro's `define:vars` scripts automatically carry the
-   `nonce` attribute when the parent layout propagates it.
+3. Add a `nonce` attribute to every `<script is:inline>` block in your layouts so
+   the browser can match the header value against the script tag:
+
+   ```astro
+   ---
+   // src/layouts/BaseLayout.astro
+   const nonce = Astro.locals.cspNonce;
+   ---
+   <!-- FOUC-prevention script — must run before first paint -->
+   <script is:inline nonce={nonce} define:vars={{ validThemeIds }}>
+     /* ... FOUC script body ... */
+   </script>
+   <!-- Theme dropdown script -->
+   <script is:inline nonce={nonce} define:vars={{ themeNames, themeIcons }}>
+     /* ... dropdown script body ... */
+   </script>
+   ```
+
+   Apply the same `nonce={Astro.locals.cspNonce}` pattern to every `<script is:inline>`
+   in `DocsLayout.astro` and any other layout that emits inline scripts.
 
 **For static site generation (SSG):** Nonces require a server to generate a new random
 value per request; they cannot be embedded in pre-built HTML files. Use hash-based CSP
@@ -154,32 +182,55 @@ well for scripts whose rendered content does not change between page loads.
 
 **Computing hashes from a built site:**
 
-After running `bun run build`, extract the inline script body from the built HTML and
-hash it:
+After running `bun run build`, extract each inline script body and hash it.
+All three scripts must be listed in `script-src` — missing any one will block that
+feature:
 
 ```bash
-# 1. Pull out the raw script text (adjust the page path as needed):
+# Extract and hash the FOUC-prevention script (BaseLayout.astro, define:vars)
 node -e "
 const fs = require('fs');
 const html = fs.readFileSync('apps/site/dist/index.html', 'utf8');
-// Match the first <script> block that contains the FOUC keyword
-const m = html.match(/<script[^>]*>(([\s\S]*?FOUC[\s\S]*?))<\/script>/);
+const m = html.match(/<script[^>]*>(([\s\S]*?validThemeIds[\s\S]*?))<\/script>/);
 if (m) process.stdout.write(m[1]);
 " > fouc-script.txt
+FOUC_HASH=$(openssl dgst -sha256 -binary fouc-script.txt | openssl base64 -A)
 
-# 2. Compute the SHA-256 and base64-encode it:
-openssl dgst -sha256 -binary fouc-script.txt | openssl base64 -A
+# Extract and hash the theme-dropdown script (BaseLayout.astro, define:vars)
+node -e "
+const fs = require('fs');
+const html = fs.readFileSync('apps/site/dist/index.html', 'utf8');
+const m = html.match(/<script[^>]*>(([\s\S]*?themeNames[\s\S]*?))<\/script>/);
+if (m) process.stdout.write(m[1]);
+" > dropdown-script.txt
+DROPDOWN_HASH=$(openssl dgst -sha256 -binary dropdown-script.txt | openssl base64 -A)
+
+# Extract and hash the sidebar-toggle script (DocsLayout.astro, static)
+# Use a docs page that renders DocsLayout, e.g. the first docs page:
+node -e "
+const fs = require('fs'), path = require('path'), glob = require('glob');
+const pages = glob.sync('apps/site/dist/docs/**/*.html');
+if (!pages.length) { process.stderr.write('No docs pages found\n'); process.exit(1); }
+const html = fs.readFileSync(pages[0], 'utf8');
+const m = html.match(/<script[^>]*>(([\s\S]*?sidebar[\s\S]*?))<\/script>/i);
+if (m) process.stdout.write(m[1]);
+" > sidebar-script.txt
+SIDEBAR_HASH=$(openssl dgst -sha256 -binary sidebar-script.txt | openssl base64 -A)
+
+echo "FOUC_HASH:     $FOUC_HASH"
+echo "DROPDOWN_HASH: $DROPDOWN_HASH"
+echo "SIDEBAR_HASH:  $SIDEBAR_HASH"
 ```
 
-Use the resulting string in your CSP:
+Use all three values in your CSP:
 
 ```
-script-src 'self' 'sha256-<output-from-above>';
+script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH';
 ```
 
-> **Important:** recompute and update the hash every time you run `bun run build` if
-> theme metadata has changed. A stale hash will silently block the FOUC script and cause
-> theme flashing.
+> **Important:** recompute and update all three hashes every time you run `bun run build`
+> if theme metadata has changed. A stale hash will silently block that script and cause
+> theme-flashing or broken navigation.
 
 ### unsafe-inline (last resort)
 

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -1,8 +1,8 @@
 # Content Security Policy (CSP) Guide
 
-This guide covers recommended Content Security Policy headers for deployments
-that serve turbo-themes — whether you are hosting the Astro demo/docs site or
-embedding turbo-themes stylesheets in your own application.
+This guide covers recommended Content Security Policy headers for deployments that serve
+turbo-themes — whether you are hosting the Astro demo/docs site or embedding
+turbo-themes stylesheets in your own application.
 
 ## Table of Contents
 
@@ -25,9 +25,8 @@ embedding turbo-themes stylesheets in your own application.
 
 ## Baseline CSP
 
-The following policy covers a turbo-themes deployment that loads Google Fonts,
-serves its own CSS, and runs the FOUC-prevention inline script with a
-per-request nonce:
+The following policy covers a turbo-themes deployment that loads Google Fonts, serves
+its own CSS, and runs the FOUC-prevention inline script with a per-request nonce:
 
 ```
 Content-Security-Policy:
@@ -39,8 +38,8 @@ Content-Security-Policy:
   connect-src 'self';
 ```
 
-Replace `{random}` with a cryptographically-random, base64-encoded value that
-is unique per HTTP response (see [Nonce-based CSP](#nonce-based-csp-recommended)).
+Replace `{random}` with a cryptographically-random, base64-encoded value that is unique
+per HTTP response (see [Nonce-based CSP](#nonce-based-csp-recommended)).
 
 If you self-host fonts (no Google Fonts), drop both `fonts.googleapis.com` and
 `fonts.gstatic.com` from the policy entirely.
@@ -49,24 +48,24 @@ If you self-host fonts (no Google Fonts), drop both `fonts.googleapis.com` and
 
 ## Google Fonts
 
-`apps/site/src/layouts/BaseLayout.astro` preconnects to and loads fonts from
-two Google Fonts domains:
+`apps/site/src/layouts/BaseLayout.astro` preconnects to and loads fonts from two Google
+Fonts domains:
 
 | Directive   | Domain                         | Purpose                          |
 | ----------- | ------------------------------ | -------------------------------- |
 | `style-src` | `https://fonts.googleapis.com` | Font CSS (Inter, JetBrains Mono) |
 | `font-src`  | `https://fonts.gstatic.com`    | Actual font binary files         |
 
-Both domains are required when using Google Fonts.  Omitting either will block
-font loading and cause a visible fallback.
+Both domains are required when using Google Fonts. Omitting either will block font
+loading and cause a visible fallback.
 
 Turbo-themes token files also expose a `webFonts` array pointing at
-`fonts.googleapis.com`, so downstream consumers who use those tokens in their
-own Astro/React/Vue apps also need these two entries.
+`fonts.googleapis.com`, so downstream consumers who use those tokens in their own
+Astro/React/Vue apps also need these two entries.
 
-**Self-hosted alternative:** Download the font files and serve them from your
-own origin.  With self-hosted fonts you can remove both external domains and
-add the font file path to `font-src 'self'`.
+**Self-hosted alternative:** Download the font files and serve them from your own
+origin. With self-hosted fonts you can remove both external domains and add the font
+file path to `font-src 'self'`.
 
 ---
 
@@ -80,22 +79,21 @@ add the font file path to `font-src 'self'`.
 | `apps/site/src/layouts/BaseLayout.astro:140` | `<script is:inline define:vars={{ themeNames, themeIcons }}>` | Yes            | Theme dropdown — wires click handlers, active state, and nav highlight       |
 | `apps/site/src/layouts/DocsLayout.astro:92`  | `<script is:inline>`                                          | No             | Sidebar toggle — opens/closes the mobile docs navigation                     |
 
-The two scripts that use Astro's `define:vars` are rendered with injected
-JavaScript variable declarations at the top of the script block (e.g.
-`const validThemeIds=[...];`).  These values come from the theme metadata at
-build time, which means the rendered script content changes whenever themes are
-added or renamed.  This matters for hash-based CSP.
+The two scripts that use Astro's `define:vars` are rendered with injected JavaScript
+variable declarations at the top of the script block (e.g.
+`const validThemeIds=[...];`). These values come from the theme metadata at build time,
+which means the rendered script content changes whenever themes are added or renamed.
+This matters for hash-based CSP.
 
-The FOUC-prevention script in particular **must run synchronously and before
-first paint** — it is intentionally a blocking `<script>` in `<head>`.  Any CSP
-that blocks it will cause a flash of unstyled/wrong-theme content.
+The FOUC-prevention script in particular **must run synchronously and before first
+paint** — it is intentionally a blocking `<script>` in `<head>`. Any CSP that blocks it
+will cause a flash of unstyled/wrong-theme content.
 
 ### Nonce-based CSP (recommended)
 
-A per-request nonce works with all three inline scripts, including the
-`define:vars` ones, because the nonce travels in the HTTP header and in the
-`nonce` attribute on each `<script>` element — the script content itself does
-not need to be known in advance.
+A per-request nonce works with all three inline scripts, including the `define:vars`
+ones, because the nonce travels in the HTTP header and in the `nonce` attribute on each
+`<script>` element — the script content itself does not need to be known in advance.
 
 **Steps for an Astro SSR deployment:**
 
@@ -119,7 +117,7 @@ not need to be known in advance.
            "font-src 'self' https://fonts.gstatic.com",
            `script-src 'self' 'nonce-${nonce}'`,
            "img-src 'self' data:",
-         ].join('; '),
+         ].join('; ')
        );
        return response;
      });
@@ -127,33 +125,32 @@ not need to be known in advance.
    ```
 
 2. Pass the nonce through the layout chain and add a `nonce` attribute to each
-   `<script is:inline>` block.  Astro's `define:vars` scripts automatically
-   carry the `nonce` attribute when the parent layout propagates it.
+   `<script is:inline>` block. Astro's `define:vars` scripts automatically carry the
+   `nonce` attribute when the parent layout propagates it.
 
-**For static site generation (SSG):** Nonces require a server to generate a
-new random value per request; they cannot be embedded in pre-built HTML files.
-Use hash-based CSP instead (see below), or set headers at the edge with a
-platform that supports dynamic header injection (Vercel/Netlify edge functions).
+**For static site generation (SSG):** Nonces require a server to generate a new random
+value per request; they cannot be embedded in pre-built HTML files. Use hash-based CSP
+instead (see below), or set headers at the edge with a platform that supports dynamic
+header injection (Vercel/Netlify edge functions).
 
 ### Hash-based CSP (static builds)
 
 Hash-based CSP (`'sha256-...'`) lets you allow a specific script without
-`'unsafe-inline'` by listing the exact SHA-256 of its content in the policy.
-This works well for scripts whose rendered content does not change between
-page loads.
+`'unsafe-inline'` by listing the exact SHA-256 of its content in the policy. This works
+well for scripts whose rendered content does not change between page loads.
 
 **Caveats for turbo-themes:**
 
-- The two `define:vars` scripts (`validThemeIds`, `themeNames`, `themeIcons`)
-  produce different rendered content each time themes are added or renamed.
-  Their hash must be recomputed after every build that changes theme metadata.
-- The DocsLayout sidebar toggle (`<script is:inline>` without `define:vars`)
-  has static content and is stable between builds.
+- The two `define:vars` scripts (`validThemeIds`, `themeNames`, `themeIcons`) produce
+  different rendered content each time themes are added or renamed. Their hash must be
+  recomputed after every build that changes theme metadata.
+- The DocsLayout sidebar toggle (`<script is:inline>` without `define:vars`) has static
+  content and is stable between builds.
 
 **Computing hashes from a built site:**
 
-After running `bun run build`, extract the inline script body from the built
-HTML and hash it:
+After running `bun run build`, extract the inline script body from the built HTML and
+hash it:
 
 ```bash
 # 1. Pull out the raw script text (adjust the page path as needed):
@@ -175,9 +172,9 @@ Use the resulting string in your CSP:
 script-src 'self' 'sha256-<output-from-above>';
 ```
 
-> **Important:** recompute and update the hash every time you run `bun run
-> build` if theme metadata has changed.  A stale hash will silently block the
-> FOUC script and cause theme flashing.
+> **Important:** recompute and update the hash every time you run `bun run build` if
+> theme metadata has changed. A stale hash will silently block the FOUC script and cause
+> theme flashing.
 
 ### unsafe-inline (last resort)
 
@@ -185,21 +182,21 @@ script-src 'self' 'sha256-<output-from-above>';
 script-src 'self' 'unsafe-inline';
 ```
 
-`'unsafe-inline'` defeats much of the XSS protection that CSP provides and is
-not recommended for production.  Use it only during local development or when
-neither nonces nor hashes are feasible.
+`'unsafe-inline'` defeats much of the XSS protection that CSP provides and is not
+recommended for production. Use it only during local development or when neither nonces
+nor hashes are feasible.
 
-> **Note:** when a `nonce-*` or `sha256-*` source is present in `script-src`,
-> browsers that support CSP Level 2 will ignore `'unsafe-inline'` entirely,
-> making it safe to include for backward-compatibility with very old browsers
-> that only understand CSP Level 1 — but this is rarely necessary in practice.
+> **Note:** when a `nonce-*` or `sha256-*` source is present in `script-src`, browsers
+> that support CSP Level 2 will ignore `'unsafe-inline'` entirely, making it safe to
+> include for backward-compatibility with very old browsers that only understand CSP
+> Level 1 — but this is rarely necessary in practice.
 
 ---
 
 ## CDN Usage
 
-If your users install turbo-themes from a CDN rather than bundling it, they
-need the CDN origin in `style-src`:
+If your users install turbo-themes from a CDN rather than bundling it, they need the CDN
+origin in `style-src`:
 
 | CDN      | Addition to `style-src`    |
 | -------- | -------------------------- |
@@ -217,8 +214,8 @@ Content-Security-Policy:
   img-src 'self' data:;
 ```
 
-CDN origins are broad by design — if you want a tighter policy, self-host the
-CSS file and remove the CDN entry.
+CDN origins are broad by design — if you want a tighter policy, self-host the CSS file
+and remove the CDN entry.
 
 ---
 
@@ -258,8 +255,8 @@ server {
 </IfModule>
 ```
 
-For static sites served by Apache, replace `'nonce-REPLACE_WITH_NONCE'` with
-the `'sha256-...'` values computed at build time.
+For static sites served by Apache, replace `'nonce-REPLACE_WITH_NONCE'` with the
+`'sha256-...'` values computed at build time.
 
 ### Vercel
 
@@ -279,17 +276,16 @@ the `'sha256-...'` values computed at build time.
 }
 ```
 
-Replace each `*_HASH` placeholder with the SHA-256 computed from the built
-output (see [Hash-based CSP](#hash-based-csp-static-builds)).
+Replace each `*_HASH` placeholder with the SHA-256 computed from the built output (see
+[Hash-based CSP](#hash-based-csp-static-builds)).
 
-For server-side rendering on Vercel (Node.js or Edge runtime), use an Astro
-middleware to generate a per-request nonce and set the header dynamically
-instead of using static hashes in `vercel.json`.
+For server-side rendering on Vercel (Node.js or Edge runtime), use an Astro middleware
+to generate a per-request nonce and set the header dynamically instead of using static
+hashes in `vercel.json`.
 
 ### Netlify
 
-In your `netlify.toml` or a `_headers` file placed in the site's publish
-directory:
+In your `netlify.toml` or a `_headers` file placed in the site's publish directory:
 
 **`netlify.toml`:**
 
@@ -309,8 +305,8 @@ directory:
 
 ### GitHub Pages
 
-GitHub Pages serves static files and does **not** support custom HTTP response
-headers.  The only CSP option on Pages is the `<meta>` tag approach:
+GitHub Pages serves static files and does **not** support custom HTTP response headers.
+The only CSP option on Pages is the `<meta>` tag approach:
 
 ```html
 <meta
@@ -329,16 +325,15 @@ Add this tag inside `<head>` in your base layout.
 
 **Limitations of `<meta>` CSP:**
 
-- The `<meta>` tag is processed by the HTML parser, not the network layer, so
-  it does not restrict `frame-ancestors`, `sandbox`, or `report-uri`/`report-to`
-  directives.  Those only work in HTTP headers.
-- The FOUC-prevention script appears _after_ the `<meta>` tag in the same
-  `<head>` block, so the browser will have already parsed the policy before
-  encountering the script.
+- The `<meta>` tag is processed by the HTML parser, not the network layer, so it does
+  not restrict `frame-ancestors`, `sandbox`, or `report-uri`/`report-to` directives.
+  Those only work in HTTP headers.
+- The FOUC-prevention script appears _after_ the `<meta>` tag in the same `<head>`
+  block, so the browser will have already parsed the policy before encountering the
+  script.
 
-For strongest protection, deploy on a platform that supports HTTP response
-headers (Vercel, Netlify, Nginx, Apache, Cloudflare Pages) and set the policy
-there.
+For strongest protection, deploy on a platform that supports HTTP response headers
+(Vercel, Netlify, Nginx, Apache, Cloudflare Pages) and set the policy there.
 
 ---
 
@@ -346,5 +341,5 @@ there.
 
 - [SECURITY.md](../SECURITY.md) — vulnerability reporting policy
 - [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-- [CSP Evaluator](https://csp-evaluator.withgoogle.com/) — Google tool for
-  auditing your policy
+- [CSP Evaluator](https://csp-evaluator.withgoogle.com/) — Google tool for auditing your
+  policy

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -207,10 +207,17 @@ DROPDOWN_HASH=$(openssl dgst -sha256 -binary dropdown-script.txt | openssl base6
 # Extract and hash the sidebar-toggle script (DocsLayout.astro, static)
 # Use a docs page that renders DocsLayout, e.g. the first docs page:
 node -e "
-const fs = require('fs'), path = require('path'), glob = require('glob');
-const pages = glob.sync('apps/site/dist/docs/**/*.html');
-if (!pages.length) { process.stderr.write('No docs pages found\n'); process.exit(1); }
-const html = fs.readFileSync(pages[0], 'utf8');
+const fs = require('fs'), path = require('path');
+function findHtml(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) { const r = findHtml(full); if (r) return r; }
+    else if (e.name.endsWith('.html')) return full;
+  }
+}
+const page = findHtml('apps/site/dist/docs');
+if (!page) { process.stderr.write('No docs pages found\n'); process.exit(1); }
+const html = fs.readFileSync(page, 'utf8');
 const m = html.match(/<script[^>]*>(([\s\S]*?sidebar[\s\S]*?))<\/script>/i);
 if (m) process.stdout.write(m[1]);
 " > sidebar-script.txt

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -1,0 +1,350 @@
+# Content Security Policy (CSP) Guide
+
+This guide covers recommended Content Security Policy headers for deployments
+that serve turbo-themes — whether you are hosting the Astro demo/docs site or
+embedding turbo-themes stylesheets in your own application.
+
+## Table of Contents
+
+- [Baseline CSP](#baseline-csp)
+- [Google Fonts](#google-fonts)
+- [Inline Script Handling](#inline-script-handling)
+  - [What inline scripts turbo-themes uses](#what-inline-scripts-turbo-themes-uses)
+  - [Nonce-based CSP (recommended)](#nonce-based-csp-recommended)
+  - [Hash-based CSP (static builds)](#hash-based-csp-static-builds)
+  - [unsafe-inline (last resort)](#unsafe-inline-last-resort)
+- [CDN Usage](#cdn-usage)
+- [Platform-specific Examples](#platform-specific-examples)
+  - [Nginx](#nginx)
+  - [Apache](#apache)
+  - [Vercel](#vercel)
+  - [Netlify](#netlify)
+  - [GitHub Pages](#github-pages)
+
+---
+
+## Baseline CSP
+
+The following policy covers a turbo-themes deployment that loads Google Fonts,
+serves its own CSS, and runs the FOUC-prevention inline script with a
+per-request nonce:
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  style-src 'self' https://fonts.googleapis.com;
+  font-src 'self' https://fonts.gstatic.com;
+  script-src 'self' 'nonce-{random}';
+  img-src 'self' data:;
+  connect-src 'self';
+```
+
+Replace `{random}` with a cryptographically-random, base64-encoded value that
+is unique per HTTP response (see [Nonce-based CSP](#nonce-based-csp-recommended)).
+
+If you self-host fonts (no Google Fonts), drop both `fonts.googleapis.com` and
+`fonts.gstatic.com` from the policy entirely.
+
+---
+
+## Google Fonts
+
+`apps/site/src/layouts/BaseLayout.astro` preconnects to and loads fonts from
+two Google Fonts domains:
+
+| Directive   | Domain                         | Purpose                          |
+| ----------- | ------------------------------ | -------------------------------- |
+| `style-src` | `https://fonts.googleapis.com` | Font CSS (Inter, JetBrains Mono) |
+| `font-src`  | `https://fonts.gstatic.com`    | Actual font binary files         |
+
+Both domains are required when using Google Fonts.  Omitting either will block
+font loading and cause a visible fallback.
+
+Turbo-themes token files also expose a `webFonts` array pointing at
+`fonts.googleapis.com`, so downstream consumers who use those tokens in their
+own Astro/React/Vue apps also need these two entries.
+
+**Self-hosted alternative:** Download the font files and serve them from your
+own origin.  With self-hosted fonts you can remove both external domains and
+add the font file path to `font-src 'self'`.
+
+---
+
+## Inline Script Handling
+
+### What inline scripts turbo-themes uses
+
+| File                                         | Tag                                                           | `define:vars`? | Purpose                                                                      |
+| -------------------------------------------- | ------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------- |
+| `apps/site/src/layouts/BaseLayout.astro:85`  | `<script is:inline define:vars={{ validThemeIds }}>`          | Yes            | FOUC prevention — reads localStorage, applies saved theme before first paint |
+| `apps/site/src/layouts/BaseLayout.astro:140` | `<script is:inline define:vars={{ themeNames, themeIcons }}>` | Yes            | Theme dropdown — wires click handlers, active state, and nav highlight       |
+| `apps/site/src/layouts/DocsLayout.astro:92`  | `<script is:inline>`                                          | No             | Sidebar toggle — opens/closes the mobile docs navigation                     |
+
+The two scripts that use Astro's `define:vars` are rendered with injected
+JavaScript variable declarations at the top of the script block (e.g.
+`const validThemeIds=[...];`).  These values come from the theme metadata at
+build time, which means the rendered script content changes whenever themes are
+added or renamed.  This matters for hash-based CSP.
+
+The FOUC-prevention script in particular **must run synchronously and before
+first paint** — it is intentionally a blocking `<script>` in `<head>`.  Any CSP
+that blocks it will cause a flash of unstyled/wrong-theme content.
+
+### Nonce-based CSP (recommended)
+
+A per-request nonce works with all three inline scripts, including the
+`define:vars` ones, because the nonce travels in the HTTP header and in the
+`nonce` attribute on each `<script>` element — the script content itself does
+not need to be known in advance.
+
+**Steps for an Astro SSR deployment:**
+
+1. Generate a cryptographically-random nonce in server middleware:
+
+   ```typescript
+   // src/middleware.ts
+   import { defineMiddleware } from 'astro:middleware';
+   import crypto from 'node:crypto';
+
+   export const onRequest = defineMiddleware((context, next) => {
+     const nonce = crypto.randomBytes(16).toString('base64');
+     context.locals.cspNonce = nonce;
+
+     return next().then((response) => {
+       response.headers.set(
+         'Content-Security-Policy',
+         [
+           "default-src 'self'",
+           "style-src 'self' https://fonts.googleapis.com",
+           "font-src 'self' https://fonts.gstatic.com",
+           `script-src 'self' 'nonce-${nonce}'`,
+           "img-src 'self' data:",
+         ].join('; '),
+       );
+       return response;
+     });
+   });
+   ```
+
+2. Pass the nonce through the layout chain and add a `nonce` attribute to each
+   `<script is:inline>` block.  Astro's `define:vars` scripts automatically
+   carry the `nonce` attribute when the parent layout propagates it.
+
+**For static site generation (SSG):** Nonces require a server to generate a
+new random value per request; they cannot be embedded in pre-built HTML files.
+Use hash-based CSP instead (see below), or set headers at the edge with a
+platform that supports dynamic header injection (Vercel/Netlify edge functions).
+
+### Hash-based CSP (static builds)
+
+Hash-based CSP (`'sha256-...'`) lets you allow a specific script without
+`'unsafe-inline'` by listing the exact SHA-256 of its content in the policy.
+This works well for scripts whose rendered content does not change between
+page loads.
+
+**Caveats for turbo-themes:**
+
+- The two `define:vars` scripts (`validThemeIds`, `themeNames`, `themeIcons`)
+  produce different rendered content each time themes are added or renamed.
+  Their hash must be recomputed after every build that changes theme metadata.
+- The DocsLayout sidebar toggle (`<script is:inline>` without `define:vars`)
+  has static content and is stable between builds.
+
+**Computing hashes from a built site:**
+
+After running `bun run build`, extract the inline script body from the built
+HTML and hash it:
+
+```bash
+# 1. Pull out the raw script text (adjust the page path as needed):
+node -e "
+const fs = require('fs');
+const html = fs.readFileSync('apps/site/dist/index.html', 'utf8');
+// Match the first <script> block that contains the FOUC keyword
+const m = html.match(/<script[^>]*>(([\s\S]*?FOUC[\s\S]*?))<\/script>/);
+if (m) process.stdout.write(m[1]);
+" > fouc-script.txt
+
+# 2. Compute the SHA-256 and base64-encode it:
+openssl dgst -sha256 -binary fouc-script.txt | openssl base64 -A
+```
+
+Use the resulting string in your CSP:
+
+```
+script-src 'self' 'sha256-<output-from-above>';
+```
+
+> **Important:** recompute and update the hash every time you run `bun run
+> build` if theme metadata has changed.  A stale hash will silently block the
+> FOUC script and cause theme flashing.
+
+### unsafe-inline (last resort)
+
+```
+script-src 'self' 'unsafe-inline';
+```
+
+`'unsafe-inline'` defeats much of the XSS protection that CSP provides and is
+not recommended for production.  Use it only during local development or when
+neither nonces nor hashes are feasible.
+
+> **Note:** when a `nonce-*` or `sha256-*` source is present in `script-src`,
+> browsers that support CSP Level 2 will ignore `'unsafe-inline'` entirely,
+> making it safe to include for backward-compatibility with very old browsers
+> that only understand CSP Level 1 — but this is rarely necessary in practice.
+
+---
+
+## CDN Usage
+
+If your users install turbo-themes from a CDN rather than bundling it, they
+need the CDN origin in `style-src`:
+
+| CDN      | Addition to `style-src`    |
+| -------- | -------------------------- |
+| unpkg    | `https://unpkg.com`        |
+| jsDelivr | `https://cdn.jsdelivr.net` |
+
+Example (unpkg):
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  style-src 'self' https://fonts.googleapis.com https://unpkg.com;
+  font-src 'self' https://fonts.gstatic.com;
+  script-src 'self' 'nonce-{random}';
+  img-src 'self' data:;
+```
+
+CDN origins are broad by design — if you want a tighter policy, self-host the
+CSS file and remove the CDN entry.
+
+---
+
+## Platform-specific Examples
+
+### Nginx
+
+```nginx
+server {
+    # ... other config ...
+
+    # Generate a per-request nonce with a Lua or njs module, or use a static
+    # hash for pre-built sites:
+    add_header Content-Security-Policy
+        "default-src 'self'; \
+         style-src 'self' https://fonts.googleapis.com; \
+         font-src 'self' https://fonts.gstatic.com; \
+         script-src 'self' 'nonce-$request_id'; \
+         img-src 'self' data:;"
+        always;
+}
+```
+
+> For static deployments where you cannot inject a nonce per request, replace
+> `'nonce-$request_id'` with the precomputed `'sha256-...'` hashes.
+
+### Apache
+
+```apache
+<IfModule mod_headers.c>
+    Header set Content-Security-Policy \
+        "default-src 'self'; \
+         style-src 'self' https://fonts.googleapis.com; \
+         font-src 'self' https://fonts.gstatic.com; \
+         script-src 'self' 'nonce-REPLACE_WITH_NONCE'; \
+         img-src 'self' data:;"
+</IfModule>
+```
+
+For static sites served by Apache, replace `'nonce-REPLACE_WITH_NONCE'` with
+the `'sha256-...'` values computed at build time.
+
+### Vercel
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:;"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Replace each `*_HASH` placeholder with the SHA-256 computed from the built
+output (see [Hash-based CSP](#hash-based-csp-static-builds)).
+
+For server-side rendering on Vercel (Node.js or Edge runtime), use an Astro
+middleware to generate a per-request nonce and set the header dynamically
+instead of using static hashes in `vercel.json`.
+
+### Netlify
+
+In your `netlify.toml` or a `_headers` file placed in the site's publish
+directory:
+
+**`netlify.toml`:**
+
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:;"
+```
+
+**`_headers` file:**
+
+```
+/*
+  Content-Security-Policy: default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH'; img-src 'self' data:;
+```
+
+### GitHub Pages
+
+GitHub Pages serves static files and does **not** support custom HTTP response
+headers.  The only CSP option on Pages is the `<meta>` tag approach:
+
+```html
+<meta
+  http-equiv="Content-Security-Policy"
+  content="
+    default-src 'self';
+    style-src 'self' https://fonts.googleapis.com;
+    font-src 'self' https://fonts.gstatic.com;
+    script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH';
+    img-src 'self' data:;
+  "
+/>
+```
+
+Add this tag inside `<head>` in your base layout.
+
+**Limitations of `<meta>` CSP:**
+
+- The `<meta>` tag is processed by the HTML parser, not the network layer, so
+  it does not restrict `frame-ancestors`, `sandbox`, or `report-uri`/`report-to`
+  directives.  Those only work in HTTP headers.
+- The FOUC-prevention script appears _after_ the `<meta>` tag in the same
+  `<head>` block, so the browser will have already parsed the policy before
+  encountering the script.
+
+For strongest protection, deploy on a platform that supports HTTP response
+headers (Vercel, Netlify, Nginx, Apache, Cloudflare Pages) and set the policy
+there.
+
+---
+
+## See Also
+
+- [SECURITY.md](../SECURITY.md) — vulnerability reporting policy
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [CSP Evaluator](https://csp-evaluator.withgoogle.com/) — Google tool for
+  auditing your policy

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -262,7 +262,7 @@ server {
 
 ```apache
 <IfModule mod_headers.c>
-    Header set Content-Security-Policy \
+    Header always set Content-Security-Policy \
         "default-src 'self'; \
          style-src 'self' https://fonts.googleapis.com; \
          font-src 'self' https://fonts.gstatic.com; \

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -114,7 +114,7 @@ ones, because the nonce travels in the HTTP header and in the `nonce` attribute 
        response.headers.set(
          'Content-Security-Policy',
          [
-         "default-src 'self'",
+           "default-src 'self'",
            "style-src 'self' https://fonts.googleapis.com",
            "font-src 'self' https://fonts.gstatic.com",
            `script-src 'self' 'nonce-${nonce}'`,
@@ -122,7 +122,7 @@ ones, because the nonce travels in the HTTP header and in the `nonce` attribute 
            "connect-src 'self'",
            "base-uri 'self'",
            "object-src 'none'",
-           ].join('; ')
+         ].join('; ')
        );
        return response;
      });

--- a/docs/SECURITY-CSP.md
+++ b/docs/SECURITY-CSP.md
@@ -140,8 +140,8 @@ ones, because the nonce travels in the HTTP header and in the `nonce` attribute 
    });
    ```
 
-3. Add a `nonce` attribute to every `<script is:inline>` block in your layouts so
-   the browser can match the header value against the script tag:
+3. Add a `nonce` attribute to every `<script is:inline>` block in your layouts so the
+   browser can match the header value against the script tag:
 
    ```astro
    ---
@@ -182,9 +182,8 @@ well for scripts whose rendered content does not change between page loads.
 
 **Computing hashes from a built site:**
 
-After running `bun run build`, extract each inline script body and hash it.
-All three scripts must be listed in `script-src` — missing any one will block that
-feature:
+After running `bun run build`, extract each inline script body and hash it. All three
+scripts must be listed in `script-src` — missing any one will block that feature:
 
 ```bash
 # Extract and hash the FOUC-prevention script (BaseLayout.astro, define:vars)
@@ -228,9 +227,9 @@ Use all three values in your CSP:
 script-src 'self' 'sha256-FOUC_HASH' 'sha256-DROPDOWN_HASH' 'sha256-SIDEBAR_HASH';
 ```
 
-> **Important:** recompute and update all three hashes every time you run `bun run build`
-> if theme metadata has changed. A stale hash will silently block that script and cause
-> theme-flashing or broken navigation.
+> **Important:** recompute and update all three hashes every time you run
+> `bun run build` if theme metadata has changed. A stale hash will silently block that
+> script and cause theme-flashing or broken navigation.
 
 ### unsafe-inline (last resort)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add CSP documentation for deploying turbo-themes / the docs site, covering Google Fonts, FOUC/inline script handling, CDN allowlists, and platform examples. Linked from `SECURITY.md`.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [x] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Added `docs/SECURITY-CSP.md` with baseline CSP, fonts, nonce guidance, CDN, and nginx/apache/vercel/netlify/pages examples
- Linked the guide from `SECURITY.md`

## Closes

- Closes #275

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Content Security Policy guidance for deployments.
  * Documented secure handling of fonts, scripts, images, connections, CDNs, and inline scripts.
  * Included configuration examples for Nginx, Apache, Vercel, Netlify, and GitHub Pages.
  * Added links to related security resources and CSP evaluation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `docs/SECURITY-CSP.md` guide covering Content Security Policy configuration for turbo-themes deployments, and links it from `SECURITY.md`. All issues raised in a prior review round (missing `base-uri`, inconsistent `connect-src`, Apache `Header always set`, nginx nonce caveat, and the `glob` dependency in hash extraction) have been fully addressed in this version.

- **Baseline & platform examples** are thorough and consistent: `base-uri 'self'`, `object-src 'none'`, and `connect-src 'self'` appear in every policy block across all five platform-specific snippets.
- **Inline script handling** is well-documented, with a working Node.js-only hash extraction script.
- **Two directives without a `default-src` fallback** — `form-action` and `frame-ancestors` — are absent from all policy examples.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime impact; safe to merge.

Every concrete issue from the prior review round was addressed. The two remaining observations are additive improvements to a guide that is already functional and accurate.

docs/SECURITY-CSP.md baseline policy block and sidebar hash-extraction snippet could benefit from small additions, but neither is a blocker.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SECURITY.md | Adds a 'Content Security Policy' section linking to the new CSP guide — minimal change, correct relative path, well-placed in the document. |
| docs/SECURITY-CSP.md | New CSP guide covering baseline policy, Google Fonts, nonce/hash/unsafe-inline approaches, CDN, and five platform examples. All previously flagged issues are addressed. Two directives without a default-src fallback — form-action and frame-ancestors — are absent from every policy block. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deploy turbo-themes] --> B{Hosting type?}
    B --> C[SSR / Node.js]
    B --> D[Static build]
    C --> E[Astro middleware generates nonce per request]
    E --> F[Set CSP header with nonce]
    F --> G[Add nonce attr to every script is:inline]
    G --> H[Nonce-based CSP]
    D --> I{Platform?}
    I --> J[Vercel / Netlify Edge Functions]
    I --> K[Nginx / Apache / Netlify / Vercel static]
    I --> L[GitHub Pages]
    J --> M[Inject nonce via edge middleware]
    M --> H
    K --> N[bun run build then extract script hashes]
    N --> O[sha256 FOUC + DROPDOWN + SIDEBAR hashes]
    O --> P[Set static CSP header with hash values]
    P --> Q[Hash-based CSP]
    L --> R[meta http-equiv CSP with sha256 hashes]
    R --> S[frame-ancestors and report-uri unavailable via meta tag]
    S --> T[Limited CSP via meta]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Deploy turbo-themes] --> B{Hosting type?}
    B --> C[SSR / Node.js]
    B --> D[Static build]
    C --> E[Astro middleware generates nonce per request]
    E --> F[Set CSP header with nonce]
    F --> G[Add nonce attr to every script is:inline]
    G --> H[Nonce-based CSP]
    D --> I{Platform?}
    I --> J[Vercel / Netlify Edge Functions]
    I --> K[Nginx / Apache / Netlify / Vercel static]
    I --> L[GitHub Pages]
    J --> M[Inject nonce via edge middleware]
    M --> H
    K --> N[bun run build then extract script hashes]
    N --> O[sha256 FOUC + DROPDOWN + SIDEBAR hashes]
    O --> P[Set static CSP header with hash values]
    P --> Q[Hash-based CSP]
    L --> R[meta http-equiv CSP with sha256 hashes]
    R --> S[frame-ancestors and report-uri unavailable via meta tag]
    S --> T[Limited CSP via meta]
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(docs): replace require(&#39;glob&#39;) with ..."](https://github.com/lgtm-hq/turbo-themes/commit/ff13c4b05a008fc5fd70ff44a43c6441c9a043ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45107468)</sub>

<!-- /greptile_comment -->