### PR TITLE
feat(ci): run action-pinning validation on every PR and merge queue run

### DIFF
--- a/.github/workflows/TRIGGERS.md
+++ b/.github/workflows/TRIGGERS.md
@@ -63,7 +63,7 @@ turbo-themes, their triggers, and purposes.
 
 #### quality-validate-action-pinning.yml
 
-**Triggers:** Push to main, Pull requests  
+**Triggers:** Pull requests (all), Merge queue, Manual  
 **Purpose:** Ensures all GitHub Actions use SHA pinning
 
 ### Security

--- a/.github/workflows/quality-validate-action-pinning.yml
+++ b/.github/workflows/quality-validate-action-pinning.yml
@@ -3,9 +3,8 @@ name: Quality Check - Action Pinning Validation
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

Removes the `.github/**` path filter from `quality-validate-action-pinning.yml` and adds the `merge_group` trigger (same block as `quality-lintro.yml`), so the check reports on every PR and inside merge-queue runs.

## Problem

Path-filtered checks can't be made required — they'd hang PRs where they never trigger — so the pinning validation was advisory, and #545 merged through the queue while it was red. The scan is repo-wide and takes ~30s; there's no reason to skip it on non-workflow PRs.

## Solution

Trigger-only change; the reusable lgtm-ci job and its inputs are untouched. Also corrects the stale trigger description in TRIGGERS.md.

**Follow-up (admin step, after this merges):** add `validate / Validate Action Pinning` to the main ruleset's required status checks.

Fixes #559

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the `.github/**` path filter from the `quality-validate-action-pinning` workflow so it runs on every PR, and adds a `merge_group` trigger so it also runs inside merge-queue batches — making it eligible to be a required status check. The description text in `TRIGGERS.md` is updated to match, though the trigger matrix table is not fully corrected.

- **`quality-validate-action-pinning.yml`**: drops the `paths` filter from `pull_request` and adds `merge_group: types: [checks_requested]`; the reusable job, its inputs, and the concurrency group are unchanged.
- **`TRIGGERS.md`**: description text updated from \"Push to main, Pull requests\" to \"Pull requests (all), Merge queue, Manual\", but the trigger matrix table row still shows a stale ✅ under \"Push (main)\" and no ✅ under \"Manual\".
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a minimal trigger-only edit with no impact on job logic.

The workflow change itself is correct: dropping the path filter and adding merge_group with checks_requested is exactly what is needed for the check to become a required status check. The only gap is in TRIGGERS.md, where the trigger matrix table was not updated to match the corrected description text — it still advertises a Push (main) trigger that was never present and omits the Manual entry. The workflow file is clean.

TRIGGERS.md — the trigger matrix table row for quality-validate-action-pinning needs the stale Push (main) checkmark removed and a Manual checkmark added.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/quality-validate-action-pinning.yml | Removes .github/** path filter from pull_request trigger and adds merge_group trigger; reusable job and its inputs are untouched. |
| .github/workflows/TRIGGERS.md | Updates the quality-validate-action-pinning description text correctly, but the trigger matrix table on line 19 still shows a stale checkmark under Push (main) and no checkmark under Manual, leaving the table inconsistent with the actual workflow. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Pull Request opened/synced] -->|all paths, no filter| B[quality-validate-action-pinning]
    C[Merge Queue checks_requested] --> B
    D[workflow_dispatch] --> B
    B --> E[reusable-validate-action-pinning via lgtm-ci]
    E --> F{All actions SHA-pinned?}
    F -->|Yes| G[Check passes]
    F -->|No| H[Check fails]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Pull Request opened/synced] -->|all paths, no filter| B[quality-validate-action-pinning]
    C[Merge Queue checks_requested] --> B
    D[workflow_dispatch] --> B
    B --> E[reusable-validate-action-pinning via lgtm-ci]
    E --> F{All actions SHA-pinned?}
    F -->|Yes| G[Check passes]
    F -->|No| H[Check fails]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/TRIGGERS.md`, line 19 ([link](https://github.com/lgtm-hq/turbo-themes/blob/178ef1d54214559308c010e8418a422895ca7ab0/.github/workflows/TRIGGERS.md#L19)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The trigger matrix table row for `quality-validate-action-pinning` was not updated alongside the description text. It still shows ✅ under "Push (main)" — a trigger that has never existed in this workflow — and leaves "Manual" blank even though `workflow_dispatch` has always been present. The table also has no column for Merge Queue. As-is, the table contradicts the corrected description text just a few lines below.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2FTRIGGERS.md%0ALine%3A%2019%0A%0AComment%3A%0AThe%20trigger%20matrix%20table%20row%20for%20%60quality-validate-action-pinning%60%20was%20not%20updated%20alongside%20the%20description%20text.%20It%20still%20shows%20%E2%9C%85%20under%20%22Push%20%28main%29%22%20%E2%80%94%20a%20trigger%20that%20has%20never%20existed%20in%20this%20workflow%20%E2%80%94%20and%20leaves%20%22Manual%22%20blank%20even%20though%20%60workflow_dispatch%60%20has%20always%20been%20present.%20The%20table%20also%20has%20no%20column%20for%20Merge%20Queue.%20As-is%2C%20the%20table%20contradicts%20the%20corrected%20description%20text%20just%20a%20few%20lines%20below.%0A%0A%60%60%60suggestion%0A%7C%20quality-validate-action-pinning%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2FTRIGGERS.md%0ALine%3A%2019%0A%0AComment%3A%0AThe%20trigger%20matrix%20table%20row%20for%20%60quality-validate-action-pinning%60%20was%20not%20updated%20alongside%20the%20description%20text.%20It%20still%20shows%20%E2%9C%85%20under%20%22Push%20%28main%29%22%20%E2%80%94%20a%20trigger%20that%20has%20never%20existed%20in%20this%20workflow%20%E2%80%94%20and%20leaves%20%22Manual%22%20blank%20even%20though%20%60workflow_dispatch%60%20has%20always%20been%20present.%20The%20table%20also%20has%20no%20column%20for%20Merge%20Queue.%20As-is%2C%20the%20table%20contradicts%20the%20corrected%20description%20text%20just%20a%20few%20lines%20below.%0A%0A%60%60%60suggestion%0A%7C%20quality-validate-action-pinning%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22feat%2Frequire-action-pinning-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frequire-action-pinning-check%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2FTRIGGERS.md%0ALine%3A%2019%0A%0AComment%3A%0AThe%20trigger%20matrix%20table%20row%20for%20%60quality-validate-action-pinning%60%20was%20not%20updated%20alongside%20the%20description%20text.%20It%20still%20shows%20%E2%9C%85%20under%20%22Push%20%28main%29%22%20%E2%80%94%20a%20trigger%20that%20has%20never%20existed%20in%20this%20workflow%20%E2%80%94%20and%20leaves%20%22Manual%22%20blank%20even%20though%20%60workflow_dispatch%60%20has%20always%20been%20present.%20The%20table%20also%20has%20no%20column%20for%20Merge%20Queue.%20As-is%2C%20the%20table%20contradicts%20the%20corrected%20description%20text%20just%20a%20few%20lines%20below.%0A%0A%60%60%60suggestion%0A%7C%20quality-validate-action-pinning%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FTRIGGERS.md%3A19%0AThe%20trigger%20matrix%20table%20row%20for%20%60quality-validate-action-pinning%60%20was%20not%20updated%20alongside%20the%20description%20text.%20It%20still%20shows%20%E2%9C%85%20under%20%22Push%20%28main%29%22%20%E2%80%94%20a%20trigger%20that%20has%20never%20existed%20in%20this%20workflow%20%E2%80%94%20and%20leaves%20%22Manual%22%20blank%20even%20though%20%60workflow_dispatch%60%20has%20always%20been%20present.%20The%20table%20also%20has%20no%20column%20for%20Merge%20Queue.%20As-is%2C%20the%20table%20contradicts%20the%20corrected%20description%20text%20just%20a%20few%20lines%20below.%0A%0A%60%60%60suggestion%0A%7C%20quality-validate-action-pinning%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%60%60%60%0A%0A&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FTRIGGERS.md%3A19%0AThe%20trigger%20matrix%20table%20row%20for%20%60quality-validate-action-pinning%60%20was%20not%20updated%20alongside%20the%20description%20text.%20It%20still%20shows%20%E2%9C%85%20under%20%22Push%20%28main%29%22%20%E2%80%94%20a%20trigger%20that%20has%20never%20existed%20in%20this%20workflow%20%E2%80%94%20and%20leaves%20%22Manual%22%20blank%20even%20though%20%60workflow_dispatch%60%20has%20always%20been%20present.%20The%20table%20also%20has%20no%20column%20for%20Merge%20Queue.%20As-is%2C%20the%20table%20contradicts%20the%20corrected%20description%20text%20just%20a%20few%20lines%20below.%0A%0A%60%60%60suggestion%0A%7C%20quality-validate-action-pinning%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22feat%2Frequire-action-pinning-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frequire-action-pinning-check%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FTRIGGERS.md%3A19%0AThe%20trigger%20matrix%20table%20row%20for%20%60quality-validate-action-pinning%60%20was%20not%20updated%20alongside%20the%20description%20text.%20It%20still%20shows%20%E2%9C%85%20under%20%22Push%20%28main%29%22%20%E2%80%94%20a%20trigger%20that%20has%20never%20existed%20in%20this%20workflow%20%E2%80%94%20and%20leaves%20%22Manual%22%20blank%20even%20though%20%60workflow_dispatch%60%20has%20always%20been%20present.%20The%20table%20also%20has%20no%20column%20for%20Merge%20Queue.%20As-is%2C%20the%20table%20contradicts%20the%20corrected%20description%20text%20just%20a%20few%20lines%20below.%0A%0A%60%60%60suggestion%0A%7C%20quality-validate-action-pinning%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%20%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%7C%20%E2%9C%85%20%20%20%20%20%7C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): run action-pinning validation ..."](https://github.com/lgtm-hq/turbo-themes/commit/178ef1d54214559308c010e8418a422895ca7ab0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45101757)</sub>

<!-- /greptile_comment -->