### PR TITLE
fix(ci): use GitHub App token for softprops/action-gh-release

### DIFF
--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -48,6 +48,14 @@ jobs:
             pkg-containers.githubusercontent.com:443
             uploads.github.com:443
 
+      - name: Create GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Download SBOM artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -57,6 +65,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
+          token: ${{ steps.app-token.outputs.token }}
           files: |
             sbom/sbom.cyclonedx.json
             sbom/sbom.cyclonedx.json.sig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`release-publish-pr.yml` created GitHub Releases with the default `GITHUB_TOKEN`, which can break or silently skip downstream workflows. Mint a GitHub App installation token (same pattern as other release workflows) and pass it to `softprops/action-gh-release`.

## Type

- [x] 🐛 Bug fix (`fix:`)
- [x] 🔧 CI/CD (`ci:`)

## Changes Made

- App token step using `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`
- Pass `token` into `softprops/action-gh-release`

## Closes

- Closes #364

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR mints a GitHub App installation token (using `RELEASE_APP_ID`/`RELEASE_APP_PRIVATE_KEY`) in the `github-release` job and passes it to `softprops/action-gh-release`, replacing the implicit `GITHUB_TOKEN`. This matches the pattern already used in `release-auto-tag.yml`, `release-version-pr.yml`, and `maintenance-renovate-theme-sync.yml`.

- Adds `actions/create-github-app-token@v2.2.2` step (pinned to commit SHA) consistent with other release workflows.
- Passes `token: ${{ steps.app-token.outputs.token }}` to `softprops/action-gh-release` so the release is authored by the App identity, enabling downstream workflow triggers.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is minimal, well-precedented across the repo, and correctly wires the App token to the release action.

The implementation is consistent with the established pattern in three other workflows. The only thing left on the table is that the job-level `contents: write` on `GITHUB_TOKEN` is now dead weight — release creation moved to the App token — but that is a hardening opportunity, not a defect.

.github/workflows/release-publish-pr.yml — the `contents: write` job permission is worth a second look now that the App token handles release creation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-pr.yml | Adds a GitHub App token creation step before `softprops/action-gh-release` and passes the token to it; job-level `contents: write` on the GITHUB_TOKEN is now unused. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/release-publish-pr.yml`, line 38-40 ([link](https://github.com/lgtm-hq/turbo-themes/blob/35c5eac543245146ed711a38df43b899350135fa/.github/workflows/release-publish-pr.yml#L38-L40)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Now that `softprops/action-gh-release` uses the App token to create the release, the `GITHUB_TOKEN` no longer needs `contents: write`. The only remaining steps that use `GITHUB_TOKEN` implicitly (`harden-runner`, `download-artifact`) work fine with `contents: read`. Downgrading keeps the job at least-privilege.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Frelease-publish-pr.yml%0ALine%3A%2038-40%0A%0AComment%3A%0ANow%20that%20%60softprops%2Faction-gh-release%60%20uses%20the%20App%20token%20to%20create%20the%20release%2C%20the%20%60GITHUB_TOKEN%60%20no%20longer%20needs%20%60contents%3A%20write%60.%20The%20only%20remaining%20steps%20that%20use%20%60GITHUB_TOKEN%60%20implicitly%20%28%60harden-runner%60%2C%20%60download-artifact%60%29%20work%20fine%20with%20%60contents%3A%20read%60.%20Downgrading%20keeps%20the%20job%20at%20least-privilege.%0A%0A%60%60%60suggestion%0A%20%20%20%20permissions%3A%0A%20%20%20%20%20%20contents%3A%20read%0A%20%20%20%20steps%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Frelease-publish-pr.yml%0ALine%3A%2038-40%0A%0AComment%3A%0ANow%20that%20%60softprops%2Faction-gh-release%60%20uses%20the%20App%20token%20to%20create%20the%20release%2C%20the%20%60GITHUB_TOKEN%60%20no%20longer%20needs%20%60contents%3A%20write%60.%20The%20only%20remaining%20steps%20that%20use%20%60GITHUB_TOKEN%60%20implicitly%20%28%60harden-runner%60%2C%20%60download-artifact%60%29%20work%20fine%20with%20%60contents%3A%20read%60.%20Downgrading%20keeps%20the%20job%20at%20least-privilege.%0A%0A%60%60%60suggestion%0A%20%20%20%20permissions%3A%0A%20%20%20%20%20%20contents%3A%20read%0A%20%20%20%20steps%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F364-release-token-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F364-release-token-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Frelease-publish-pr.yml%0ALine%3A%2038-40%0A%0AComment%3A%0ANow%20that%20%60softprops%2Faction-gh-release%60%20uses%20the%20App%20token%20to%20create%20the%20release%2C%20the%20%60GITHUB_TOKEN%60%20no%20longer%20needs%20%60contents%3A%20write%60.%20The%20only%20remaining%20steps%20that%20use%20%60GITHUB_TOKEN%60%20implicitly%20%28%60harden-runner%60%2C%20%60download-artifact%60%29%20work%20fine%20with%20%60contents%3A%20read%60.%20Downgrading%20keeps%20the%20job%20at%20least-privilege.%0A%0A%60%60%60suggestion%0A%20%20%20%20permissions%3A%0A%20%20%20%20%20%20contents%3A%20read%0A%20%20%20%20steps%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-publish-pr.yml%3A38-40%0ANow%20that%20%60softprops%2Faction-gh-release%60%20uses%20the%20App%20token%20to%20create%20the%20release%2C%20the%20%60GITHUB_TOKEN%60%20no%20longer%20needs%20%60contents%3A%20write%60.%20The%20only%20remaining%20steps%20that%20use%20%60GITHUB_TOKEN%60%20implicitly%20%28%60harden-runner%60%2C%20%60download-artifact%60%29%20work%20fine%20with%20%60contents%3A%20read%60.%20Downgrading%20keeps%20the%20job%20at%20least-privilege.%0A%0A%60%60%60suggestion%0A%20%20%20%20permissions%3A%0A%20%20%20%20%20%20contents%3A%20read%0A%20%20%20%20steps%3A%0A%60%60%60%0A%0A&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-publish-pr.yml%3A38-40%0ANow%20that%20%60softprops%2Faction-gh-release%60%20uses%20the%20App%20token%20to%20create%20the%20release%2C%20the%20%60GITHUB_TOKEN%60%20no%20longer%20needs%20%60contents%3A%20write%60.%20The%20only%20remaining%20steps%20that%20use%20%60GITHUB_TOKEN%60%20implicitly%20%28%60harden-runner%60%2C%20%60download-artifact%60%29%20work%20fine%20with%20%60contents%3A%20read%60.%20Downgrading%20keeps%20the%20job%20at%20least-privilege.%0A%0A%60%60%60suggestion%0A%20%20%20%20permissions%3A%0A%20%20%20%20%20%20contents%3A%20read%0A%20%20%20%20steps%3A%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F364-release-token-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F364-release-token-6221%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-publish-pr.yml%3A38-40%0ANow%20that%20%60softprops%2Faction-gh-release%60%20uses%20the%20App%20token%20to%20create%20the%20release%2C%20the%20%60GITHUB_TOKEN%60%20no%20longer%20needs%20%60contents%3A%20write%60.%20The%20only%20remaining%20steps%20that%20use%20%60GITHUB_TOKEN%60%20implicitly%20%28%60harden-runner%60%2C%20%60download-artifact%60%29%20work%20fine%20with%20%60contents%3A%20read%60.%20Downgrading%20keeps%20the%20job%20at%20least-privilege.%0A%0A%60%60%60suggestion%0A%20%20%20%20permissions%3A%0A%20%20%20%20%20%20contents%3A%20read%0A%20%20%20%20steps%3A%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use GitHub App token for softpr..."](https://github.com/lgtm-hq/turbo-themes/commit/35c5eac543245146ed711a38df43b899350135fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45128479)</sub>

<!-- /greptile_comment -->