### PR TITLE
docs(site): add Astro + GitHub Pages integration guide

### DIFF
--- a/apps/site/src/content/docs/installation/npm.md
+++ b/apps/site/src/content/docs/installation/npm.md
@@ -153,3 +153,4 @@ Turbo Themes CSS is standard CSS custom properties - no PostCSS processing requi
 - Learn about [CDN installation](/docs/installation/cdn/) for no-build-step usage
 - Explore [framework integrations](/docs/integrations/) for Tailwind, Bulma, and more
 - Check the [CSS Variables Reference](/docs/api-reference/css-variables/)
+- Building an Astro doc site? See the [Astro + GitHub Pages integration guide](/docs/integrations/astro-github-pages/) for CSS load order, Shiki binding, and CI setup.

--- a/apps/site/src/content/docs/installation/npm.md
+++ b/apps/site/src/content/docs/installation/npm.md
@@ -153,4 +153,6 @@ Turbo Themes CSS is standard CSS custom properties - no PostCSS processing requi
 - Learn about [CDN installation](/docs/installation/cdn/) for no-build-step usage
 - Explore [framework integrations](/docs/integrations/) for Tailwind, Bulma, and more
 - Check the [CSS Variables Reference](/docs/api-reference/css-variables/)
-- Building an Astro doc site? See the [Astro + GitHub Pages integration guide](/docs/integrations/astro-github-pages/) for CSS load order, Shiki binding, and CI setup.
+- Building an Astro doc site? See the
+  [Astro + GitHub Pages integration guide](/docs/integrations/astro-github-pages/) for
+  CSS load order, Shiki binding, and CI setup.

--- a/apps/site/src/content/docs/integrations/astro-github-pages.md
+++ b/apps/site/src/content/docs/integrations/astro-github-pages.md
@@ -1,6 +1,8 @@
 ---
 title: Astro + GitHub Pages
-description: Deploy a turbo-themes-powered Astro doc site to GitHub Pages with Shiki syntax highlighting, a theme switcher, and Pagefind search.
+description:
+  Deploy a turbo-themes-powered Astro doc site to GitHub Pages with Shiki syntax
+  highlighting, a theme switcher, and Pagefind search.
 category: integrations
 order: 7
 prev: integrations/swiftui
@@ -16,15 +18,15 @@ keywords:
 
 # Astro + GitHub Pages Integration
 
-This guide documents the **recommended integration path** used by consumer doc sites such
-as [py-lintro](https://github.com/lgtm-hq/py-lintro) and
-[Rustume](https://github.com/lgtm-hq/Rustume).  It covers every piece of wiring that
-new sites need so you don't have to rediscover it: CSS load order, Shiki
-`css-variables` binding, a persistent theme switcher, GitHub Pages subpath handling,
-and optional Pagefind search.
+This guide documents the **recommended integration path** used by consumer doc sites
+such as [py-lintro](https://github.com/lgtm-hq/py-lintro) and
+[Rustume](https://github.com/lgtm-hq/Rustume). It covers every piece of wiring that new
+sites need so you don't have to rediscover it: CSS load order, Shiki `css-variables`
+binding, a persistent theme switcher, GitHub Pages subpath handling, and optional
+Pagefind search.
 
 > **Upcoming:** The Terminal flavor (#502) will ship a first-party Terminal theme and
-> replace the native-theme workaround described in §5 below.  Until it lands, use the
+> replace the native-theme workaround described in §5 below. Until it lands, use the
 > pattern shown here.
 
 ---
@@ -40,16 +42,14 @@ bun add @lgtm-hq/turbo-themes astro @astrojs/sitemap pagefind
 ### Copy CSS at build time
 
 Consumer sites copy CSS from the installed package into `public/` so Astro can serve
-them as static assets.  Create `scripts/copy-assets.mjs`:
+them as static assets. Create `scripts/copy-assets.mjs`:
 
 ```js
 // scripts/copy-assets.mjs
 import { cp } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-const src = resolve(
-  'node_modules/@lgtm-hq/turbo-themes/packages/css/dist',
-);
+const src = resolve('node_modules/@lgtm-hq/turbo-themes/packages/css/dist');
 const dest = resolve('public/assets/css');
 
 await cp(src, dest, { recursive: true });
@@ -86,8 +86,8 @@ public/assets/css/
 
 ## 2. BaseLayout CSS Load Order
 
-Load the CSS bundles in this exact order inside your `<head>`.  `{base}` is the
-GitHub Pages subpath (see §5):
+Load the CSS bundles in this exact order inside your `<head>`. `{base}` is the GitHub
+Pages subpath (see §5):
 
 ```html
 <!-- 1. Token definitions (required) -->
@@ -110,15 +110,15 @@ GitHub Pages subpath (see §5):
 />
 ```
 
-> The **order matters**: `turbo-syntax.css` must come after `turbo-core.css` because
-> it reads `--turbo-syntax-*` variables defined by the core file.
+> The **order matters**: `turbo-syntax.css` must come after `turbo-core.css` because it
+> reads `--turbo-syntax-*` variables defined by the core file.
 
 ---
 
 ## 3. Astro Markdown Config and Shiki Binding
 
 Set `shikiConfig.theme` to `"css-variables"` so Shiki emits `--astro-code-*` custom
-properties instead of hard-coded colors.  `turbo-syntax.css` already maps those
+properties instead of hard-coded colors. `turbo-syntax.css` already maps those
 properties onto `--turbo-syntax-*` tokens:
 
 ```
@@ -141,16 +141,16 @@ const base = process.env.ASTRO_BASE ?? '';
 
 export default defineConfig({
   site: 'https://<org>.github.io',
-  base,                          // e.g. '/my-repo' for GitHub Pages
+  base, // e.g. '/my-repo' for GitHub Pages
   integrations: [sitemap()],
   markdown: {
     shikiConfig: {
-      theme: 'css-variables',   // required for turbo-syntax binding
+      theme: 'css-variables', // required for turbo-syntax binding
       wrap: true,
     },
     rehypePlugins: [
       rehypeUnwrapHeadingLinks,
-      [rehypeDocLinks, { base }],  // rewrites internal links to include base
+      [rehypeDocLinks, { base }], // rewrites internal links to include base
     ],
   },
 });
@@ -187,7 +187,7 @@ Set `data-theme` and `data-appearance` on `<html>` before content renders to avo
 flash of unstyled content:
 
 ```html
-<html data-theme="catppuccin-mocha" data-appearance="dark">
+<html data-theme="catppuccin-mocha" data-appearance="dark"></html>
 ```
 
 ### Inline blocking script
@@ -198,16 +198,26 @@ Place this **before** any stylesheets to restore the last-used theme instantly:
 <script>
   (function () {
     var THEMES = [
-      'catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
-      'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
-      'bulma-dark', 'bulma-light',
+      'catppuccin-mocha',
+      'catppuccin-macchiato',
+      'catppuccin-frappe',
+      'catppuccin-latte',
+      'dracula',
+      'github-dark',
+      'github-light',
+      'bulma-dark',
+      'bulma-light',
     ];
     var DARK = new Set([
-      'catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
-      'dracula', 'github-dark', 'bulma-dark',
+      'catppuccin-mocha',
+      'catppuccin-macchiato',
+      'catppuccin-frappe',
+      'dracula',
+      'github-dark',
+      'bulma-dark',
     ]);
     var saved = localStorage.getItem('turbo-theme');
-    var theme = (saved && THEMES.includes(saved)) ? saved : 'catppuccin-mocha';
+    var theme = saved && THEMES.includes(saved) ? saved : 'catppuccin-mocha';
     var html = document.documentElement;
     html.setAttribute('data-theme', theme);
     html.setAttribute('data-appearance', DARK.has(theme) ? 'dark' : 'light');
@@ -219,8 +229,12 @@ Place this **before** any stylesheets to restore the last-used theme instantly:
 
 ```js
 const DARK_THEMES = new Set([
-  'catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
-  'dracula', 'github-dark', 'bulma-dark',
+  'catppuccin-mocha',
+  'catppuccin-macchiato',
+  'catppuccin-frappe',
+  'dracula',
+  'github-dark',
+  'bulma-dark',
 ]);
 
 /**
@@ -239,9 +253,7 @@ function setTheme(themeId, base = '') {
 
   localStorage.setItem('turbo-theme', themeId);
 
-  html.dispatchEvent(
-    new CustomEvent('turbo-theme-applied', { detail: { themeId } }),
-  );
+  html.dispatchEvent(new CustomEvent('turbo-theme-applied', { detail: { themeId } }));
 }
 ```
 
@@ -260,8 +272,8 @@ document.documentElement.addEventListener('turbo-theme-applied', (e) => {
 
 ## 5. GitHub Pages: `base` / `site` Config
 
-GitHub Pages serves repositories at `https://<org>.github.io/<repo>/`.  Set `base`
-in `astro.config.mjs` via an environment variable so local dev still works at `/`:
+GitHub Pages serves repositories at `https://<org>.github.io/<repo>/`. Set `base` in
+`astro.config.mjs` via an environment variable so local dev still works at `/`:
 
 ```bash
 # .env.production (or set in GitHub Actions)
@@ -284,9 +296,9 @@ call so hotlinked CSS paths are correct on the deployed subdomain.
 
 ### Image and link prefixing
 
-Astro handles `<Image />` and `<a href="…">` automatically when `base` is set.  For
-raw `<img src="…">` tags in Markdown, use the `{base}` variable injected by your
-layout component:
+Astro handles `<Image />` and `<a href="…">` automatically when `base` is set. For raw
+`<img src="…">` tags in Markdown, use the `{base}` variable injected by your layout
+component:
 
 ```astro
 ---
@@ -299,8 +311,8 @@ const { base } = Astro.props;
 
 ## 6. Pagefind Search
 
-[Pagefind](https://pagefind.app/) indexes your built site and provides a zero-JS
-runtime search UI.
+[Pagefind](https://pagefind.app/) indexes your built site and provides a zero-JS runtime
+search UI.
 
 ### Setup
 
@@ -420,10 +432,10 @@ jobs:
 
 These production sites use this stack and are kept up to date:
 
-| Site | Theme | Notes |
-| ---- | ----- | ----- |
+| Site                                                                               | Theme                     | Notes                    |
+| ---------------------------------------------------------------------------------- | ------------------------- | ------------------------ |
 | [py-lintro `apps/site/`](https://github.com/lgtm-hq/py-lintro/tree/main/apps/site) | Terminal (default flavor) | Resources footer pattern |
-| [Rustume `apps/site/`](https://github.com/lgtm-hq/Rustume/tree/main/apps/site) | Craft (native theme) | Minimal scaffold |
+| [Rustume `apps/site/`](https://github.com/lgtm-hq/Rustume/tree/main/apps/site)     | Craft (native theme)      | Minimal scaffold         |
 
 ---
 
@@ -432,4 +444,5 @@ These production sites use this stack and are kept up to date:
 - [CSS Variables Reference](/docs/api-reference/css-variables/) — full token listing
 - [Theme Switching Guide](/docs/guides/theme-switching/) — more switcher patterns
 - [npm/Bun Installation](/docs/installation/npm/) — installing turbo-themes packages
-- [CSS Package README](https://github.com/lgtm-hq/turbo-themes/blob/main/packages/css/README.md) — programmatic CSS generation
+- [CSS Package README](https://github.com/lgtm-hq/turbo-themes/blob/main/packages/css/README.md)
+  — programmatic CSS generation

--- a/apps/site/src/content/docs/integrations/astro-github-pages.md
+++ b/apps/site/src/content/docs/integrations/astro-github-pages.md
@@ -1,0 +1,435 @@
+---
+title: Astro + GitHub Pages
+description: Deploy a turbo-themes-powered Astro doc site to GitHub Pages with Shiki syntax highlighting, a theme switcher, and Pagefind search.
+category: integrations
+order: 7
+prev: integrations/swiftui
+next: api-reference/index
+keywords:
+  - astro
+  - github pages
+  - shiki
+  - syntax highlighting
+  - theme switching
+  - pagefind
+---
+
+# Astro + GitHub Pages Integration
+
+This guide documents the **recommended integration path** used by consumer doc sites such
+as [py-lintro](https://github.com/lgtm-hq/py-lintro) and
+[Rustume](https://github.com/lgtm-hq/Rustume).  It covers every piece of wiring that
+new sites need so you don't have to rediscover it: CSS load order, Shiki
+`css-variables` binding, a persistent theme switcher, GitHub Pages subpath handling,
+and optional Pagefind search.
+
+> **Upcoming:** The Terminal flavor (#502) will ship a first-party Terminal theme and
+> replace the native-theme workaround described in §5 below.  Until it lands, use the
+> pattern shown here.
+
+---
+
+## 1. Dependencies and Asset Copy
+
+### Install packages
+
+```bash
+bun add @lgtm-hq/turbo-themes astro @astrojs/sitemap pagefind
+```
+
+### Copy CSS at build time
+
+Consumer sites copy CSS from the installed package into `public/` so Astro can serve
+them as static assets.  Create `scripts/copy-assets.mjs`:
+
+```js
+// scripts/copy-assets.mjs
+import { cp } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const src = resolve(
+  'node_modules/@lgtm-hq/turbo-themes/packages/css/dist',
+);
+const dest = resolve('public/assets/css');
+
+await cp(src, dest, { recursive: true });
+console.log('turbo-themes CSS copied to public/assets/css/');
+```
+
+Wire it into your `package.json` build chain:
+
+```json
+{
+  "scripts": {
+    "prebuild": "node scripts/copy-assets.mjs",
+    "build": "astro build"
+  }
+}
+```
+
+After the copy you will have:
+
+```
+public/assets/css/
+├── turbo-core.css
+├── turbo-base.css
+├── turbo-syntax.css
+├── turbo-components.css
+└── themes/
+    ├── catppuccin-mocha.css
+    ├── catppuccin-latte.css
+    ├── dracula.css
+    └── …
+```
+
+---
+
+## 2. BaseLayout CSS Load Order
+
+Load the CSS bundles in this exact order inside your `<head>`.  `{base}` is the
+GitHub Pages subpath (see §5):
+
+```html
+<!-- 1. Token definitions (required) -->
+<link rel="stylesheet" href="{base}/assets/css/turbo-core.css" />
+
+<!-- 2. Base semantic styles (typography, forms, etc.) -->
+<link rel="stylesheet" href="{base}/assets/css/turbo-base.css" />
+
+<!-- 3. Shiki ↔ turbo-syntax bridge (required for code blocks) -->
+<link rel="stylesheet" href="{base}/assets/css/turbo-syntax.css" />
+
+<!-- 4. Optional component styles -->
+<link rel="stylesheet" href="{base}/assets/css/turbo-components.css" />
+
+<!-- 5. Active theme file (swapped on flavor change) -->
+<link
+  id="turbo-theme-css"
+  rel="stylesheet"
+  href="{base}/assets/css/themes/catppuccin-mocha.css"
+/>
+```
+
+> The **order matters**: `turbo-syntax.css` must come after `turbo-core.css` because
+> it reads `--turbo-syntax-*` variables defined by the core file.
+
+---
+
+## 3. Astro Markdown Config and Shiki Binding
+
+Set `shikiConfig.theme` to `"css-variables"` so Shiki emits `--astro-code-*` custom
+properties instead of hard-coded colors.  `turbo-syntax.css` already maps those
+properties onto `--turbo-syntax-*` tokens:
+
+```
+--astro-code-color-text        → --turbo-syntax-fg
+--astro-code-color-background  → --turbo-syntax-bg
+--astro-code-token-keyword     → --turbo-syntax-keyword
+--astro-code-token-string      → --turbo-syntax-string
+… (full mapping in packages/css/src/syntax.ts)
+```
+
+In `astro.config.mjs`:
+
+```js
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+import rehypeUnwrapHeadingLinks from './src/plugins/rehypeUnwrapHeadingLinks.mjs';
+import { rehypeDocLinks } from './src/plugins/rehypeDocLinks.mjs';
+
+const base = process.env.ASTRO_BASE ?? '';
+
+export default defineConfig({
+  site: 'https://<org>.github.io',
+  base,                          // e.g. '/my-repo' for GitHub Pages
+  integrations: [sitemap()],
+  markdown: {
+    shikiConfig: {
+      theme: 'css-variables',   // required for turbo-syntax binding
+      wrap: true,
+    },
+    rehypePlugins: [
+      rehypeUnwrapHeadingLinks,
+      [rehypeDocLinks, { base }],  // rewrites internal links to include base
+    ],
+  },
+});
+```
+
+### rehypeDocLinks helper
+
+A minimal plugin that prefixes internal hrefs with the deployment base path:
+
+```js
+// src/plugins/rehypeDocLinks.mjs
+import { visit } from 'unist-util-visit';
+
+export function rehypeDocLinks({ base = '' } = {}) {
+  return (tree) => {
+    visit(tree, 'element', (node) => {
+      if (node.tagName !== 'a') return;
+      const href = node.properties?.href ?? '';
+      if (href.startsWith('/') && !href.startsWith(base)) {
+        node.properties.href = base + href;
+      }
+    });
+  };
+}
+```
+
+---
+
+## 4. Theme Switcher Pattern
+
+### HTML attributes
+
+Set `data-theme` and `data-appearance` on `<html>` before content renders to avoid a
+flash of unstyled content:
+
+```html
+<html data-theme="catppuccin-mocha" data-appearance="dark">
+```
+
+### Inline blocking script
+
+Place this **before** any stylesheets to restore the last-used theme instantly:
+
+```html
+<script>
+  (function () {
+    var THEMES = [
+      'catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
+      'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+      'bulma-dark', 'bulma-light',
+    ];
+    var DARK = new Set([
+      'catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
+      'dracula', 'github-dark', 'bulma-dark',
+    ]);
+    var saved = localStorage.getItem('turbo-theme');
+    var theme = (saved && THEMES.includes(saved)) ? saved : 'catppuccin-mocha';
+    var html = document.documentElement;
+    html.setAttribute('data-theme', theme);
+    html.setAttribute('data-appearance', DARK.has(theme) ? 'dark' : 'light');
+  })();
+</script>
+```
+
+### Theme switcher function
+
+```js
+const DARK_THEMES = new Set([
+  'catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
+  'dracula', 'github-dark', 'bulma-dark',
+]);
+
+/**
+ * Apply a theme and persist the choice.
+ * Dispatches 'turbo-theme-applied' so other components can react.
+ */
+function setTheme(themeId, base = '') {
+  const link = document.getElementById('turbo-theme-css');
+  if (link) {
+    link.href = `${base}/assets/css/themes/${themeId}.css`;
+  }
+
+  const html = document.documentElement;
+  html.setAttribute('data-theme', themeId);
+  html.setAttribute('data-appearance', DARK_THEMES.has(themeId) ? 'dark' : 'light');
+
+  localStorage.setItem('turbo-theme', themeId);
+
+  html.dispatchEvent(
+    new CustomEvent('turbo-theme-applied', { detail: { themeId } }),
+  );
+}
+```
+
+Consumers can listen for `turbo-theme-applied` to update UI state:
+
+```js
+document.documentElement.addEventListener('turbo-theme-applied', (e) => {
+  const { themeId } = e.detail;
+  document.querySelectorAll('[data-theme-option]').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.themeOption === themeId);
+  });
+});
+```
+
+---
+
+## 5. GitHub Pages: `base` / `site` Config
+
+GitHub Pages serves repositories at `https://<org>.github.io/<repo>/`.  Set `base`
+in `astro.config.mjs` via an environment variable so local dev still works at `/`:
+
+```bash
+# .env.production (or set in GitHub Actions)
+ASTRO_BASE=/my-repo
+```
+
+```js
+// astro.config.mjs
+const base = process.env.ASTRO_BASE ?? '';
+
+export default defineConfig({
+  site: 'https://lgtm-hq.github.io',
+  base,   // Astro prefixes all asset URLs and internal links automatically
+  …
+});
+```
+
+Pass `base` to the CSS `<link>` hrefs and to the theme switcher's `setTheme(id, base)`
+call so hotlinked CSS paths are correct on the deployed subdomain.
+
+### Image and link prefixing
+
+Astro handles `<Image />` and `<a href="…">` automatically when `base` is set.  For
+raw `<img src="…">` tags in Markdown, use the `{base}` variable injected by your
+layout component:
+
+```astro
+---
+const { base } = Astro.props;
+---
+<img src={`${base}/images/logo.svg`} alt="Logo" />
+```
+
+---
+
+## 6. Pagefind Search
+
+[Pagefind](https://pagefind.app/) indexes your built site and provides a zero-JS
+runtime search UI.
+
+### Setup
+
+Add to your build script:
+
+```json
+{
+  "scripts": {
+    "build": "astro build && pagefind --site dist"
+  }
+}
+```
+
+### Exclude chrome from search index
+
+Add `data-pagefind-ignore` to navigation, sidebars, and footers so the search index
+contains only content:
+
+```html
+<nav data-pagefind-ignore>…</nav>
+<aside data-pagefind-ignore>…</aside>
+<footer data-pagefind-ignore>…</footer>
+```
+
+### Pagefind UI component
+
+```astro
+---
+// src/components/Search.astro
+---
+<div id="search"></div>
+
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
+<script src="/pagefind/pagefind-ui.js"></script>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    new PagefindUI({ element: '#search', showSubResults: true });
+  });
+</script>
+```
+
+---
+
+## 7. CI Workflows
+
+### Site quality check
+
+```yaml
+# .github/workflows/site-quality.yml
+name: site-quality
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run build
+        env:
+          ASTRO_BASE: /my-repo
+```
+
+### Deploy to GitHub Pages
+
+```yaml
+# .github/workflows/deploy-pages.yml
+name: deploy-pages
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run build
+        env:
+          ASTRO_BASE: /my-repo
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+---
+
+## 8. Pre-launch Checklist
+
+- [ ] `site` and `base` set in `astro.config.mjs` (use `ASTRO_BASE` env var)
+- [ ] CSS copied to `public/assets/css/` before `astro build`
+- [ ] CSS load order: core → base → syntax → components → theme file
+- [ ] `shikiConfig: { theme: "css-variables" }` in `markdown` config
+- [ ] Blocking theme-restore script before stylesheets
+- [ ] `#turbo-theme-css` link element targeted by the switcher
+- [ ] `turbo-theme-applied` event dispatched on theme change
+- [ ] `data-pagefind-ignore` on nav / sidebar / footer
+- [ ] `site-quality` CI passes on every PR
+- [ ] `deploy-pages` workflow enabled for the `main` branch
+
+---
+
+## Reference Implementations
+
+These production sites use this stack and are kept up to date:
+
+| Site | Theme | Notes |
+| ---- | ----- | ----- |
+| [py-lintro `apps/site/`](https://github.com/lgtm-hq/py-lintro/tree/main/apps/site) | Terminal (default flavor) | Resources footer pattern |
+| [Rustume `apps/site/`](https://github.com/lgtm-hq/Rustume/tree/main/apps/site) | Craft (native theme) | Minimal scaffold |
+
+---
+
+## Next Steps
+
+- [CSS Variables Reference](/docs/api-reference/css-variables/) — full token listing
+- [Theme Switching Guide](/docs/guides/theme-switching/) — more switcher patterns
+- [npm/Bun Installation](/docs/installation/npm/) — installing turbo-themes packages
+- [CSS Package README](https://github.com/lgtm-hq/turbo-themes/blob/main/packages/css/README.md) — programmatic CSS generation

--- a/apps/site/src/content/docs/integrations/index.md
+++ b/apps/site/src/content/docs/integrations/index.md
@@ -28,6 +28,12 @@ project.
 | [Python](/docs/integrations/python/)   | `turbo-themes` | `pip install turbo-themes` |
 | [SwiftUI](/docs/integrations/swiftui/) | `TurboThemes`  | Swift Package              |
 
+## Doc Site Stacks
+
+| Stack                                                          | Coverage                       | Complexity |
+| -------------------------------------------------------------- | ------------------------------ | ---------- |
+| [Astro + GitHub Pages](/docs/integrations/astro-github-pages/) | Shiki, CSS, theme switcher, CI | Moderate   |
+
 ## How Integrations Work
 
 ### Pure CSS (No Framework)
@@ -106,3 +112,4 @@ Choose your integration:
 - [Bootstrap Integration](/docs/integrations/bootstrap/)
 - [Python Library](/docs/integrations/python/)
 - [SwiftUI Package](/docs/integrations/swiftui/)
+- [Astro + GitHub Pages](/docs/integrations/astro-github-pages/)

--- a/apps/site/src/content/docs/integrations/swiftui.md
+++ b/apps/site/src/content/docs/integrations/swiftui.md
@@ -4,7 +4,7 @@ description: Use Turbo Themes in iOS and macOS applications with the Swift packa
 category: integrations
 order: 6
 prev: integrations/python
-next: api-reference/index
+next: integrations/astro-github-pages
 ---
 
 # SwiftUI Integration

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -268,6 +268,12 @@ const css = generateThemeCss(theme);
 console.log(css);
 ```
 
+## Using with Astro and GitHub Pages
+
+For a complete guide covering CSS load order, Shiki `css-variables` binding, a
+persistent theme switcher, and GitHub Pages CI setup, see the
+[Astro + GitHub Pages integration guide](https://lgtm-hq.github.io/turbo-themes/docs/integrations/astro-github-pages/).
+
 ## License
 
 MIT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an Astro + GitHub Pages integration guide covering CSS load order, Shiki css-variables, theme switching, Pages base/site config, Pagefind, and CI, plus nav/cross-links.

## Type

- [x] 📚 Documentation (`docs:`)

## Changes Made

- Added `apps/site/src/content/docs/integrations/astro-github-pages.md`
- Wired into integrations index / next links and CSS README

## Closes

- Closes #504

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] Markdown linting passes (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new Astro + GitHub Pages integration guide covering CSS load order, Shiki `css-variables` binding, a theme switcher, GitHub Pages `base`/`site` config, Pagefind search, and CI workflows, along with nav wiring across four other files.

- **New guide** (`astro-github-pages.md`): 448-line end-to-end walkthrough with code snippets for every integration layer; contains a logic bug in the `rehypeDocLinks` plugin and a documentation gap around FOUC prevention.
- **Nav/cross-link updates**: `swiftui.md`, `integrations/index.md`, `npm.md`, and `packages/css/README.md` all receive small additions to wire the new page into the site's navigation and cross-reference network.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the rehypeDocLinks path-boundary bug; the remaining findings are documentation quality issues.

The `rehypeDocLinks` helper shown in the guide uses `href.startsWith(base)` to skip already-prefixed links, but this check lacks a path-separator boundary. Any document path whose first segment begins with the same characters as the deployment base (e.g. base `/my-repo` vs. path `/my-report/…`) is silently left un-prefixed, producing a broken link on the deployed subpath site. All other changed files are straightforward nav/cross-link additions.

The `rehypeDocLinks` snippet in `astro-github-pages.md` (lines 163–177) needs the `startsWith` guard corrected before readers copy it into their own projects.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/content/docs/integrations/astro-github-pages.md | New 448-line integration guide — contains a real logic bug in the rehypeDocLinks helper (startsWith boundary issue) and a documentation inaccuracy around FOUC prevention; Pagefind path and real site URL issues already flagged in previous review rounds. |
| apps/site/src/content/docs/integrations/index.md | Adds 'Doc Site Stacks' table section and a bottom nav link for Astro + GitHub Pages; straightforward nav wiring, no issues. |
| apps/site/src/content/docs/integrations/swiftui.md | Updates `next` frontmatter to chain to the new Astro guide; single-line change, correct. |
| packages/css/README.md | Adds a cross-link section pointing consumers to the Astro + GitHub Pages guide; no issues. |
| apps/site/src/content/docs/installation/npm.md | Appends a three-line cross-link to the new integration guide; no issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant B as Browser
    participant L as BaseLayout (head)
    participant LS as localStorage
    participant CSS as turbo-theme-css link

    B->>L: page request
    L->>B: blocking inline script (before stylesheets)
    B->>LS: getItem('turbo-theme')
    LS-->>B: saved theme (or default)
    B->>B: setAttribute data-theme / data-appearance
    L->>B: CSS links (turbo-core, base, syntax, components)
    L->>CSS: "href = catppuccin-mocha.css (hard-coded)"
    B->>B: DOMContentLoaded
    B->>B: setTheme(saved, base)
    B->>CSS: update href to saved-theme.css
    Note over B,CSS: Flash window between CSS link load and setTheme call
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant B as Browser
    participant L as BaseLayout (head)
    participant LS as localStorage
    participant CSS as turbo-theme-css link

    B->>L: page request
    L->>B: blocking inline script (before stylesheets)
    B->>LS: getItem('turbo-theme')
    LS-->>B: saved theme (or default)
    B->>B: setAttribute data-theme / data-appearance
    L->>B: CSS links (turbo-core, base, syntax, components)
    L->>CSS: "href = catppuccin-mocha.css (hard-coded)"
    B->>B: DOMContentLoaded
    B->>B: setTheme(saved, base)
    B->>CSS: update href to saved-theme.css
    Note over B,CSS: Flash window between CSS link load and setTheme call
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["style: fix prettier formatting in docs"](https://github.com/lgtm-hq/turbo-themes/commit/ff11fd77aaa69728fbcfcabfa9ca08076a46c364) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45128484)</sub>

<!-- /greptile_comment -->