### PR TITLE
docs(examples): document consumer theme curation patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,25 +134,25 @@ let mocha = ThemeRegistry.themes[.catppuccinMocha]
 
 ### Available Exports
 
-| Import Path                          | Use Case                      |
-| ------------------------------------ | ----------------------------- |
-| `@lgtm-hq/turbo-themes/tokens.json`  | Platform-agnostic JSON tokens |
-| `@lgtm-hq/turbo-themes/tokens`       | TypeScript tokens with types  |
-| `@lgtm-hq/turbo-themes/css/*`        | Pre-built CSS files           |
+| Import Path                         | Use Case                      |
+| ----------------------------------- | ----------------------------- |
+| `@lgtm-hq/turbo-themes/tokens.json` | Platform-agnostic JSON tokens |
+| `@lgtm-hq/turbo-themes/tokens`      | TypeScript tokens with types  |
+| `@lgtm-hq/turbo-themes/css/*`       | Pre-built CSS files           |
 
 ## Choosing Themes
 
-Turbo Themes ships with 24 curated themes. Use the existing API exports to
-build a catalog that stays in sync with the package automatically.
+Turbo Themes ships with 24 curated themes. Use the existing API exports to build a
+catalog that stays in sync with the package automatically.
 
 ### Utility exports
 
 ```typescript
 import {
-  themeIds,             // readonly string[] — all 24 IDs
-  flavors,              // ThemeFlavor[] — full metadata
-  getThemesByVendor,    // filter by vendor string
-  getThemesByAppearance // filter by 'dark' | 'light'
+  themeIds, // readonly string[] — all 24 IDs
+  flavors, // ThemeFlavor[] — full metadata
+  getThemesByVendor, // filter by vendor string
+  getThemesByAppearance, // filter by 'dark' | 'light'
 } from '@lgtm-hq/turbo-themes';
 ```
 
@@ -164,27 +164,30 @@ const CATALOG = themeIds;
 
 // b) Hardcoded minimal set (copy-paste friendly, no build required)
 const CATALOG = [
-  'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+  'catppuccin-mocha',
+  'catppuccin-latte',
+  'dracula',
+  'github-dark',
+  'github-light',
 ];
 
 // c) Vendor opt-in — stays in sync automatically
 const CATALOG = getThemesByVendor('catppuccin').map((f) => f.id);
 
 // d) Appearance filter
-const darkCatalog  = getThemesByAppearance('dark').map((f) => f.id);  // 15
+const darkCatalog = getThemesByAppearance('dark').map((f) => f.id); // 15
 const lightCatalog = getThemesByAppearance('light').map((f) => f.id); //  9
 ```
 
-> **Planned in [#495](https://github.com/lgtm-hq/turbo-themes/issues/495):**
-> A `themeSets` object (named pre-defined subsets) and a `createThemeCatalog()`
-> factory (filter vendor + appearance in one call) will make these patterns
-> even more concise.
+> **Planned in [#495](https://github.com/lgtm-hq/turbo-themes/issues/495):** A
+> `themeSets` object (named pre-defined subsets) and a `createThemeCatalog()` factory
+> (filter vendor + appearance in one call) will make these patterns even more concise.
 
 ### FOUC prevention with `generateBlockingScript()`
 
-The `@lgtm-hq/turbo-theme-selector` package exports `generateBlockingScript()`,
-which generates a self-contained inline script from your catalog. Inject it
-into `<head>` at build time to apply the user's saved theme before first paint:
+The `@lgtm-hq/turbo-theme-selector` package exports `generateBlockingScript()`, which
+generates a self-contained inline script from your catalog. Inject it into `<head>` at
+build time to apply the user's saved theme before first paint:
 
 ```typescript
 import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';

--- a/README.md
+++ b/README.md
@@ -134,11 +134,69 @@ let mocha = ThemeRegistry.themes[.catppuccinMocha]
 
 ### Available Exports
 
-| Import Path                         | Use Case                      |
-| ----------------------------------- | ----------------------------- |
-| `@lgtm-hq/turbo-themes/tokens.json` | Platform-agnostic JSON tokens |
-| `@lgtm-hq/turbo-themes/tokens`      | TypeScript tokens with types  |
-| `@lgtm-hq/turbo-themes/css/*`       | Pre-built CSS files           |
+| Import Path                          | Use Case                      |
+| ------------------------------------ | ----------------------------- |
+| `@lgtm-hq/turbo-themes/tokens.json`  | Platform-agnostic JSON tokens |
+| `@lgtm-hq/turbo-themes/tokens`       | TypeScript tokens with types  |
+| `@lgtm-hq/turbo-themes/css/*`        | Pre-built CSS files           |
+
+## Choosing Themes
+
+Turbo Themes ships with 24 curated themes. Use the existing API exports to
+build a catalog that stays in sync with the package automatically.
+
+### Utility exports
+
+```typescript
+import {
+  themeIds,             // readonly string[] — all 24 IDs
+  flavors,              // ThemeFlavor[] — full metadata
+  getThemesByVendor,    // filter by vendor string
+  getThemesByAppearance // filter by 'dark' | 'light'
+} from '@lgtm-hq/turbo-themes';
+```
+
+### Consumer curation patterns
+
+```typescript
+// a) All themes
+const CATALOG = themeIds;
+
+// b) Hardcoded minimal set (copy-paste friendly, no build required)
+const CATALOG = [
+  'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+];
+
+// c) Vendor opt-in — stays in sync automatically
+const CATALOG = getThemesByVendor('catppuccin').map((f) => f.id);
+
+// d) Appearance filter
+const darkCatalog  = getThemesByAppearance('dark').map((f) => f.id);  // 15
+const lightCatalog = getThemesByAppearance('light').map((f) => f.id); //  9
+```
+
+> **Planned in [#495](https://github.com/lgtm-hq/turbo-themes/issues/495):**
+> A `themeSets` object (named pre-defined subsets) and a `createThemeCatalog()`
+> factory (filter vendor + appearance in one call) will make these patterns
+> even more concise.
+
+### FOUC prevention with `generateBlockingScript()`
+
+The `@lgtm-hq/turbo-theme-selector` package exports `generateBlockingScript()`,
+which generates a self-contained inline script from your catalog. Inject it
+into `<head>` at build time to apply the user's saved theme before first paint:
+
+```typescript
+import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
+
+const script = generateBlockingScript({
+  validThemes: ['catppuccin-mocha', 'catppuccin-latte', 'dracula'],
+});
+// Inline the returned string in a <script> tag in <head>
+```
+
+See the [theme switching guide](apps/site/src/content/docs/guides/theme-switching.md)
+for a complete walkthrough.
 
 ## Examples
 

--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -14,107 +14,246 @@ Reference for the Turbo Themes JavaScript and TypeScript exports.
 ## Installation
 
 ```bash
-npm install turbo-themes
+npm install @lgtm-hq/turbo-themes
 ```
 
-## Exports
+## Core exports (`@lgtm-hq/turbo-themes`)
 
-### Theme IDs
+### `themeIds`
+
+A readonly array of all 24 theme IDs sorted by vendor then variant. Use this
+as the single source of truth so your catalog stays in sync when the package
+is upgraded.
 
 ```typescript
-import { themeIds } from 'turbo-themes';
+import { themeIds } from '@lgtm-hq/turbo-themes';
 
-console.log(themeIds);
-// [
-//   'catppuccin-mocha',
-//   'catppuccin-macchiato',
-//   'catppuccin-frappe',
-//   'catppuccin-latte',
-//   'dracula',
-//   'github-dark',
-//   'github-light',
-//   'bulma-dark',
-//   'bulma-light'
-// ]
+console.log(themeIds.length); // 24
+console.log(themeIds[0]);     // 'bulma-dark'
 ```
 
-### ThemeId Type
+### `flavors`
+
+A readonly array of `ThemeFlavor` objects with full metadata for every theme.
 
 ```typescript
-import type { ThemeId } from 'turbo-themes';
+import { flavors } from '@lgtm-hq/turbo-themes';
 
-// Type is a union of all valid theme IDs
-type ThemeId =
-  | 'catppuccin-mocha'
-  | 'catppuccin-macchiato'
-  | 'catppuccin-frappe'
-  | 'catppuccin-latte'
-  | 'dracula'
-  | 'github-dark'
-  | 'github-light'
-  | 'bulma-dark'
-  | 'bulma-light';
+const mocha = flavors.find((f) => f.id === 'catppuccin-mocha');
+// { id: 'catppuccin-mocha', label: 'Catppuccin Mocha', vendor: 'catppuccin',
+//   appearance: 'dark', … }
+```
 
-// Use for type-safe theme selection
-function setTheme(theme: ThemeId) {
-  // TypeScript will error if invalid theme passed
+### `getThemesByVendor(vendor)`
+
+Returns all `ThemeFlavor` entries for a given vendor.
+
+```typescript
+import { getThemesByVendor } from '@lgtm-hq/turbo-themes';
+
+const catppuccin = getThemesByVendor('catppuccin');
+// → 4 flavors: mocha, macchiato, frappe, latte
+
+const ids = catppuccin.map((f) => f.id);
+// → ['catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe', 'catppuccin-latte']
+```
+
+### `getThemesByAppearance(appearance)`
+
+Returns all `ThemeFlavor` entries matching `'dark'` or `'light'`.
+
+```typescript
+import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
+
+const dark  = getThemesByAppearance('dark');  // 15 themes
+const light = getThemesByAppearance('light'); //  9 themes
+```
+
+### `DEFAULT_THEME`
+
+The default theme ID (`'catppuccin-mocha'`).
+
+```typescript
+import { DEFAULT_THEME } from '@lgtm-hq/turbo-themes';
+```
+
+### `VENDOR_GROUPS`
+
+An ordered array of vendor groupings, each with an `id`, `label`, and
+`themes` array. Useful for building grouped `<select>` elements.
+
+```typescript
+import { VENDOR_GROUPS } from '@lgtm-hq/turbo-themes';
+
+for (const group of VENDOR_GROUPS) {
+  console.log(group.id, group.themes.map((t) => t.id));
 }
 ```
 
-### Token Data
+### Token data
 
 ```typescript
-import tokens from 'turbo-themes/tokens.json';
+import tokens from '@lgtm-hq/turbo-themes/tokens.json';
+// or the typed version:
+import { packages } from '@lgtm-hq/turbo-themes';
 
-// Access metadata
-tokens.meta.themeIds; // string[]
-tokens.meta.vendors; // string[]
-tokens.meta.totalThemes; // number
-tokens.meta.lightThemes; // number
-tokens.meta.darkThemes; // number
-
-// Access theme data
 const mocha = tokens.themes['catppuccin-mocha'];
-mocha.id; // 'catppuccin-mocha'
-mocha.label; // 'Catppuccin Mocha'
-mocha.vendor; // 'catppuccin'
 mocha.appearance; // 'dark'
-mocha.tokens; // Token values
+mocha.vendor;     // 'catppuccin'
+mocha.tokens;     // CSS custom-property values
 ```
 
-## Theme Switching Implementation
+## Curating a theme catalog
 
-### Basic Implementation
+A "catalog" is the subset of themes your app exposes to users. The right
+pattern depends on whether you have a build step.
+
+### Hardcoded list (no build step)
+
+The simplest approach. Keep a plain array and update it when you upgrade:
+
+```javascript
+const CATALOG = [
+  'catppuccin-mocha',
+  'catppuccin-latte',
+  'dracula',
+  'github-dark',
+  'github-light',
+];
+```
+
+### Vendor opt-in (TS/ESM build)
 
 ```typescript
-import { themeIds, type ThemeId } from 'turbo-themes';
+import { getThemesByVendor } from '@lgtm-hq/turbo-themes';
+
+const CATALOG = [
+  ...getThemesByVendor('catppuccin').map((f) => f.id),
+  ...getThemesByVendor('github').map((f) => f.id),
+];
+```
+
+### Appearance filter
+
+```typescript
+import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
+
+const DARK_CATALOG  = getThemesByAppearance('dark').map((f) => f.id);
+const LIGHT_CATALOG = getThemesByAppearance('light').map((f) => f.id);
+```
+
+### All themes
+
+```typescript
+import { themeIds } from '@lgtm-hq/turbo-themes';
+
+const CATALOG = themeIds; // all 24
+```
+
+> **Planned (#495):** `themeSets` (named pre-defined subsets like
+> `themeSets.minimal` and `themeSets.dark`) and `createThemeCatalog()`
+> (filter by vendor _and_ appearance in one call) will ship in `#495`.
+
+## FOUC prevention
+
+### `generateBlockingScript()` — `@lgtm-hq/turbo-theme-selector`
+
+The `@lgtm-hq/turbo-theme-selector` package exports a `generateBlockingScript()`
+helper that builds a self-contained IIFE from your catalog. Inline the result
+in `<head>` at build time so the saved theme is applied before first paint.
+
+```typescript
+import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
+
+// Pass your curated catalog via validThemes:
+const script = generateBlockingScript({
+  validThemes: ['catppuccin-mocha', 'catppuccin-latte', 'dracula',
+                'github-dark', 'github-light'],
+  defaultTheme: 'catppuccin-mocha',
+});
+// → embed the returned string inside a <script> tag in <head>
+```
+
+**Astro:**
+
+```astro
+---
+import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
+const blockingScript = generateBlockingScript();
+---
+<head>
+  <Fragment set:html={`<script>${blockingScript}</script>`} />
+</head>
+```
+
+### Inline FOUC script (plain HTML, no build step)
+
+For static pages, write the script directly. Keep `VALID_THEMES` in sync with
+your `<select>` options:
+
+```html
+<script>
+  (function () {
+    try {
+      var DEFAULT_THEME = 'catppuccin-mocha';
+      var VALID_THEMES = [
+        'bulma-dark',        'bulma-light',
+        'catppuccin-frappe', 'catppuccin-latte',
+        'catppuccin-macchiato', 'catppuccin-mocha',
+        'dracula',
+        'github-dark',       'github-light',
+        'gruvbox-dark-hard', 'gruvbox-dark-soft', 'gruvbox-dark',
+        'gruvbox-light-hard', 'gruvbox-light-soft', 'gruvbox-light',
+        'nord',
+        'rose-pine-dawn',    'rose-pine-moon',    'rose-pine',
+        'solarized-dark',    'solarized-light',
+        'tokyo-night-dark',  'tokyo-night-light', 'tokyo-night-storm',
+      ];
+
+      var saved = localStorage.getItem('turbo-theme');
+      var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
+
+      document.documentElement.setAttribute('data-theme', theme);
+      var link = document.getElementById('theme-css');
+      if (link) link.href = '/css/themes/turbo/' + theme + '.css';
+    } catch (e) {
+      console.warn('Unable to load saved theme:', e);
+    }
+  })();
+</script>
+```
+
+## Theme switching implementation
+
+### Vanilla JavaScript
+
+```typescript
+import {
+  themeIds,
+  DEFAULT_THEME,
+  getThemesByAppearance,
+} from '@lgtm-hq/turbo-themes';
 
 const STORAGE_KEY = 'turbo-theme';
-const DEFAULT_THEME: ThemeId = 'catppuccin-mocha';
 
-function getStoredTheme(): ThemeId {
+// Build your catalog — hardcode or filter:
+const CATALOG: readonly string[] = themeIds; // or a curated subset
+
+function getStoredTheme(): string {
   const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored && themeIds.includes(stored as ThemeId)) {
-    return stored as ThemeId;
-  }
-  return DEFAULT_THEME;
+  return stored && CATALOG.includes(stored) ? stored : DEFAULT_THEME;
 }
 
-function setTheme(themeId: ThemeId): void {
-  // Update CSS
-  const link = document.getElementById('theme-css') as HTMLLinkElement;
-  if (link) {
-    link.href = `/css/themes/turbo/${themeId}.css`;
-  }
+function setTheme(themeId: string): void {
+  if (!CATALOG.includes(themeId)) return;
 
-  // Update data attribute
+  const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+  if (link) link.href = `/css/themes/turbo/${themeId}.css`;
+
   document.documentElement.setAttribute('data-theme', themeId);
-
-  // Persist
   localStorage.setItem(STORAGE_KEY, themeId);
 }
 
-// Initialize on page load
 document.addEventListener('DOMContentLoaded', () => {
   setTheme(getStoredTheme());
 });
@@ -123,50 +262,39 @@ document.addEventListener('DOMContentLoaded', () => {
 ### With React
 
 ```tsx
-import { useState, useEffect, createContext, useContext } from 'react';
-import { themeIds, type ThemeId } from 'turbo-themes';
+import { useState, useEffect } from 'react';
+import { themeIds, flavors, DEFAULT_THEME } from '@lgtm-hq/turbo-themes';
 
-interface ThemeContextType {
-  theme: ThemeId;
-  setTheme: (theme: ThemeId) => void;
-  themes: readonly ThemeId[];
-}
-
-const ThemeContext = createContext<ThemeContextType | null>(null);
-
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<ThemeId>('catppuccin-mocha');
-
-  useEffect(() => {
-    const stored = localStorage.getItem('turbo-theme') as ThemeId;
-    if (stored && themeIds.includes(stored)) {
-      setThemeState(stored);
-    }
-  }, []);
-
-  const setTheme = (newTheme: ThemeId) => {
-    setThemeState(newTheme);
-    localStorage.setItem('turbo-theme', newTheme);
-
-    const link = document.getElementById('theme-css') as HTMLLinkElement;
-    if (link) {
-      link.href = `/css/themes/turbo/${newTheme}.css`;
-    }
-  };
-
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme, themes: themeIds }}>
-      {children}
-    </ThemeContext.Provider>
-  );
-}
+const CATALOG: readonly string[] = themeIds;
+const STORAGE_KEY = 'turbo-theme';
+const flavorMap = new Map(flavors.map((f) => [f.id, f]));
 
 export function useTheme() {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error('useTheme must be used within ThemeProvider');
-  }
-  return context;
+  const [theme, setThemeState] = useState<string>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored && CATALOG.includes(stored) ? stored : DEFAULT_THEME;
+  });
+
+  const setTheme = (newTheme: string) => {
+    if (!CATALOG.includes(newTheme)) return;
+    setThemeState(newTheme);
+    localStorage.setItem(STORAGE_KEY, newTheme);
+    const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+    if (link) link.href = `/css/themes/turbo/${newTheme}.css`;
+    document.documentElement.setAttribute('data-theme', newTheme);
+  };
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+    if (link) link.href = `/css/themes/turbo/${theme}.css`;
+  }, [theme]);
+
+  return {
+    theme,
+    setTheme,
+    themes: CATALOG.map((id) => ({ id, label: flavorMap.get(id)?.label ?? id })),
+  };
 }
 ```
 
@@ -174,144 +302,40 @@ export function useTheme() {
 
 ```vue
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { themeIds, type ThemeId } from 'turbo-themes';
+import { ref, onMounted, watch } from 'vue';
+import { themeIds, flavors, DEFAULT_THEME } from '@lgtm-hq/turbo-themes';
 
-const currentTheme = ref<ThemeId>('catppuccin-mocha');
+const CATALOG: readonly string[] = themeIds;
+const STORAGE_KEY = 'turbo-theme';
+const flavorMap = new Map(flavors.map((f) => [f.id, f]));
 
-function setTheme(theme: ThemeId) {
-  currentTheme.value = theme;
-  localStorage.setItem('turbo-theme', theme);
+const theme = ref<string>(DEFAULT_THEME);
 
-  const link = document.getElementById('theme-css') as HTMLLinkElement;
-  if (link) {
-    link.href = `/css/themes/turbo/${theme}.css`;
-  }
+function setTheme(newTheme: string) {
+  if (!CATALOG.includes(newTheme)) return;
+  theme.value = newTheme;
 }
 
+watch(theme, (id) => {
+  document.documentElement.setAttribute('data-theme', id);
+  const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+  if (link) link.href = `/css/themes/turbo/${id}.css`;
+  localStorage.setItem(STORAGE_KEY, id);
+});
+
 onMounted(() => {
-  const stored = localStorage.getItem('turbo-theme') as ThemeId;
-  if (stored && themeIds.includes(stored)) {
-    currentTheme.value = stored;
-  }
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && CATALOG.includes(stored)) theme.value = stored;
 });
 </script>
 
 <template>
-  <select :value="currentTheme" @change="setTheme($event.target.value)">
-    <option v-for="theme in themeIds" :key="theme" :value="theme">
-      {{ theme }}
+  <select :value="theme" @change="setTheme(($event.target as HTMLSelectElement).value)">
+    <option v-for="id in CATALOG" :key="id" :value="id">
+      {{ flavorMap.get(id)?.label ?? id }}
     </option>
   </select>
 </template>
-```
-
-### With Svelte
-
-```svelte
-<script lang="ts">
-  import { onMount } from 'svelte';
-  import { themeIds, type ThemeId } from 'turbo-themes';
-
-  let currentTheme: ThemeId = 'catppuccin-mocha';
-
-  function setTheme(theme: ThemeId) {
-    currentTheme = theme;
-    localStorage.setItem('turbo-theme', theme);
-
-    const link = document.getElementById('theme-css') as HTMLLinkElement;
-    if (link) {
-      link.href = `/css/themes/turbo/${theme}.css`;
-    }
-  }
-
-  onMount(() => {
-    const stored = localStorage.getItem('turbo-theme') as ThemeId;
-    if (stored && themeIds.includes(stored)) {
-      currentTheme = stored;
-    }
-  });
-</script>
-
-<select bind:value={currentTheme} on:change={() => setTheme(currentTheme)}>
-  {#each themeIds as theme}
-    <option value={theme}>{theme}</option>
-  {/each}
-</select>
-```
-
-## Preventing Flash of Unstyled Content (FOUC)
-
-Add this blocking script in your `<head>`:
-
-```html
-<script>
-  (function () {
-    const STORAGE_KEY = 'turbo-theme';
-    const DEFAULT = 'catppuccin-mocha';
-    const VALID = [
-      'catppuccin-mocha',
-      'catppuccin-macchiato',
-      'catppuccin-frappe',
-      'catppuccin-latte',
-      'dracula',
-      'github-dark',
-      'github-light',
-      'bulma-dark',
-      'bulma-light',
-    ];
-
-    let theme = localStorage.getItem(STORAGE_KEY) || DEFAULT;
-    if (!VALID.includes(theme)) theme = DEFAULT;
-
-    document.documentElement.setAttribute('data-theme', theme);
-
-    const link = document.getElementById('theme-css');
-    if (link && theme !== DEFAULT) {
-      link.href = '/css/themes/turbo/' + theme + '.css';
-    }
-  })();
-</script>
-```
-
-## Utility Functions
-
-### Check if Theme is Dark
-
-```typescript
-import tokens from 'turbo-themes/tokens.json';
-import type { ThemeId } from 'turbo-themes';
-
-function isDarkTheme(themeId: ThemeId): boolean {
-  return tokens.themes[themeId].appearance === 'dark';
-}
-```
-
-### Get Theme by Vendor
-
-```typescript
-import tokens from 'turbo-themes/tokens.json';
-
-function getThemesByVendor(vendor: string) {
-  return Object.values(tokens.themes).filter((theme) => theme.vendor === vendor);
-}
-
-// Get all Catppuccin themes
-const catppuccinThemes = getThemesByVendor('catppuccin');
-```
-
-### Get Light/Dark Themes
-
-```typescript
-import tokens from 'turbo-themes/tokens.json';
-
-const darkThemes = Object.values(tokens.themes)
-  .filter((t) => t.appearance === 'dark')
-  .map((t) => t.id);
-
-const lightThemes = Object.values(tokens.themes)
-  .filter((t) => t.appearance === 'light')
-  .map((t) => t.id);
 ```
 
 ## Next Steps

--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -21,15 +21,14 @@ npm install @lgtm-hq/turbo-themes
 
 ### `themeIds`
 
-A readonly array of all 24 theme IDs sorted by vendor then variant. Use this
-as the single source of truth so your catalog stays in sync when the package
-is upgraded.
+A readonly array of all 24 theme IDs sorted by vendor then variant. Use this as the
+single source of truth so your catalog stays in sync when the package is upgraded.
 
 ```typescript
 import { themeIds } from '@lgtm-hq/turbo-themes';
 
 console.log(themeIds.length); // 24
-console.log(themeIds[0]);     // 'bulma-dark'
+console.log(themeIds[0]); // 'bulma-dark'
 ```
 
 ### `flavors`
@@ -65,7 +64,7 @@ Returns all `ThemeFlavor` entries matching `'dark'` or `'light'`.
 ```typescript
 import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
-const dark  = getThemesByAppearance('dark');  // 15 themes
+const dark = getThemesByAppearance('dark'); // 15 themes
 const light = getThemesByAppearance('light'); //  9 themes
 ```
 
@@ -79,14 +78,17 @@ import { DEFAULT_THEME } from '@lgtm-hq/turbo-themes';
 
 ### `VENDOR_GROUPS`
 
-An ordered array of vendor groupings, each with an `id`, `label`, and
-`themes` array. Useful for building grouped `<select>` elements.
+An ordered array of vendor groupings, each with an `id`, `label`, and `themes` array.
+Useful for building grouped `<select>` elements.
 
 ```typescript
 import { VENDOR_GROUPS } from '@lgtm-hq/turbo-themes';
 
 for (const group of VENDOR_GROUPS) {
-  console.log(group.id, group.themes.map((t) => t.id));
+  console.log(
+    group.id,
+    group.themes.map((t) => t.id)
+  );
 }
 ```
 
@@ -99,14 +101,14 @@ import { packages } from '@lgtm-hq/turbo-themes';
 
 const mocha = tokens.themes['catppuccin-mocha'];
 mocha.appearance; // 'dark'
-mocha.vendor;     // 'catppuccin'
-mocha.tokens;     // CSS custom-property values
+mocha.vendor; // 'catppuccin'
+mocha.tokens; // CSS custom-property values
 ```
 
 ## Curating a theme catalog
 
-A "catalog" is the subset of themes your app exposes to users. The right
-pattern depends on whether you have a build step.
+A "catalog" is the subset of themes your app exposes to users. The right pattern depends
+on whether you have a build step.
 
 ### Hardcoded list (no build step)
 
@@ -138,7 +140,7 @@ const CATALOG = [
 ```typescript
 import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
-const DARK_CATALOG  = getThemesByAppearance('dark').map((f) => f.id);
+const DARK_CATALOG = getThemesByAppearance('dark').map((f) => f.id);
 const LIGHT_CATALOG = getThemesByAppearance('light').map((f) => f.id);
 ```
 
@@ -150,25 +152,30 @@ import { themeIds } from '@lgtm-hq/turbo-themes';
 const CATALOG = themeIds; // all 24
 ```
 
-> **Planned (#495):** `themeSets` (named pre-defined subsets like
-> `themeSets.minimal` and `themeSets.dark`) and `createThemeCatalog()`
-> (filter by vendor _and_ appearance in one call) will ship in `#495`.
+> **Planned (#495):** `themeSets` (named pre-defined subsets like `themeSets.minimal`
+> and `themeSets.dark`) and `createThemeCatalog()` (filter by vendor _and_ appearance in
+> one call) will ship in `#495`.
 
 ## FOUC prevention
 
 ### `generateBlockingScript()` — `@lgtm-hq/turbo-theme-selector`
 
-The `@lgtm-hq/turbo-theme-selector` package exports a `generateBlockingScript()`
-helper that builds a self-contained IIFE from your catalog. Inline the result
-in `<head>` at build time so the saved theme is applied before first paint.
+The `@lgtm-hq/turbo-theme-selector` package exports a `generateBlockingScript()` helper
+that builds a self-contained IIFE from your catalog. Inline the result in `<head>` at
+build time so the saved theme is applied before first paint.
 
 ```typescript
 import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
 
 // Pass your curated catalog via validThemes:
 const script = generateBlockingScript({
-  validThemes: ['catppuccin-mocha', 'catppuccin-latte', 'dracula',
-                'github-dark', 'github-light'],
+  validThemes: [
+    'catppuccin-mocha',
+    'catppuccin-latte',
+    'dracula',
+    'github-dark',
+    'github-light',
+  ],
   defaultTheme: 'catppuccin-mocha',
 });
 // → embed the returned string inside a <script> tag in <head>
@@ -188,8 +195,8 @@ const blockingScript = generateBlockingScript();
 
 ### Inline FOUC script (plain HTML, no build step)
 
-For static pages, write the script directly. Keep `VALID_THEMES` in sync with
-your `<select>` options:
+For static pages, write the script directly. Keep `VALID_THEMES` in sync with your
+`<select>` options:
 
 ```html
 <script>
@@ -197,17 +204,30 @@ your `<select>` options:
     try {
       var DEFAULT_THEME = 'catppuccin-mocha';
       var VALID_THEMES = [
-        'bulma-dark',        'bulma-light',
-        'catppuccin-frappe', 'catppuccin-latte',
-        'catppuccin-macchiato', 'catppuccin-mocha',
+        'bulma-dark',
+        'bulma-light',
+        'catppuccin-frappe',
+        'catppuccin-latte',
+        'catppuccin-macchiato',
+        'catppuccin-mocha',
         'dracula',
-        'github-dark',       'github-light',
-        'gruvbox-dark-hard', 'gruvbox-dark-soft', 'gruvbox-dark',
-        'gruvbox-light-hard', 'gruvbox-light-soft', 'gruvbox-light',
+        'github-dark',
+        'github-light',
+        'gruvbox-dark-hard',
+        'gruvbox-dark-soft',
+        'gruvbox-dark',
+        'gruvbox-light-hard',
+        'gruvbox-light-soft',
+        'gruvbox-light',
         'nord',
-        'rose-pine-dawn',    'rose-pine-moon',    'rose-pine',
-        'solarized-dark',    'solarized-light',
-        'tokyo-night-dark',  'tokyo-night-light', 'tokyo-night-storm',
+        'rose-pine-dawn',
+        'rose-pine-moon',
+        'rose-pine',
+        'solarized-dark',
+        'solarized-light',
+        'tokyo-night-dark',
+        'tokyo-night-light',
+        'tokyo-night-storm',
       ];
 
       var saved = localStorage.getItem('turbo-theme');
@@ -228,11 +248,7 @@ your `<select>` options:
 ### Vanilla JavaScript
 
 ```typescript
-import {
-  themeIds,
-  DEFAULT_THEME,
-  getThemesByAppearance,
-} from '@lgtm-hq/turbo-themes';
+import { themeIds, DEFAULT_THEME, getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
 const STORAGE_KEY = 'turbo-theme';
 

--- a/apps/site/src/content/docs/api-reference/themes.md
+++ b/apps/site/src/content/docs/api-reference/themes.md
@@ -9,8 +9,8 @@ next: api-reference/javascript-api
 
 # Theme Definitions
 
-Turbo Themes includes 24 color schemes across 9 vendor families. The canonical
-list is always available at runtime:
+Turbo Themes includes 24 color schemes across 9 vendor families. The canonical list is
+always available at runtime:
 
 ```typescript
 import { themeIds } from '@lgtm-hq/turbo-themes';
@@ -19,32 +19,32 @@ import { themeIds } from '@lgtm-hq/turbo-themes';
 
 ## Theme Overview
 
-| Theme                   | Vendor      | Appearance | ID                      |
-| ----------------------- | ----------- | ---------- | ----------------------- |
-| Catppuccin Mocha        | Catppuccin  | Dark       | `catppuccin-mocha`      |
-| Catppuccin Macchiato    | Catppuccin  | Dark       | `catppuccin-macchiato`  |
-| Catppuccin Frappé       | Catppuccin  | Dark       | `catppuccin-frappe`     |
-| Catppuccin Latte        | Catppuccin  | Light      | `catppuccin-latte`      |
-| Dracula                 | Dracula     | Dark       | `dracula`               |
-| Gruvbox Dark Hard       | Gruvbox     | Dark       | `gruvbox-dark-hard`     |
-| Gruvbox Dark            | Gruvbox     | Dark       | `gruvbox-dark`          |
-| Gruvbox Dark Soft       | Gruvbox     | Dark       | `gruvbox-dark-soft`     |
-| Gruvbox Light Hard      | Gruvbox     | Light      | `gruvbox-light-hard`    |
-| Gruvbox Light           | Gruvbox     | Light      | `gruvbox-light`         |
-| Gruvbox Light Soft      | Gruvbox     | Light      | `gruvbox-light-soft`    |
-| GitHub Dark             | GitHub      | Dark       | `github-dark`           |
-| GitHub Light            | GitHub      | Light      | `github-light`          |
-| Bulma Dark              | Bulma       | Dark       | `bulma-dark`            |
-| Bulma Light             | Bulma       | Light      | `bulma-light`           |
-| Nord                    | Nord        | Dark       | `nord`                  |
-| Rosé Pine               | Rosé Pine   | Dark       | `rose-pine`             |
-| Rosé Pine Moon          | Rosé Pine   | Dark       | `rose-pine-moon`        |
-| Rosé Pine Dawn          | Rosé Pine   | Light      | `rose-pine-dawn`        |
-| Solarized Dark          | Solarized   | Dark       | `solarized-dark`        |
-| Solarized Light         | Solarized   | Light      | `solarized-light`       |
-| Tokyo Night Dark        | Tokyo Night | Dark       | `tokyo-night-dark`      |
-| Tokyo Night Storm       | Tokyo Night | Dark       | `tokyo-night-storm`     |
-| Tokyo Night Light       | Tokyo Night | Light      | `tokyo-night-light`     |
+| Theme                | Vendor      | Appearance | ID                     |
+| -------------------- | ----------- | ---------- | ---------------------- |
+| Catppuccin Mocha     | Catppuccin  | Dark       | `catppuccin-mocha`     |
+| Catppuccin Macchiato | Catppuccin  | Dark       | `catppuccin-macchiato` |
+| Catppuccin Frappé    | Catppuccin  | Dark       | `catppuccin-frappe`    |
+| Catppuccin Latte     | Catppuccin  | Light      | `catppuccin-latte`     |
+| Dracula              | Dracula     | Dark       | `dracula`              |
+| Gruvbox Dark Hard    | Gruvbox     | Dark       | `gruvbox-dark-hard`    |
+| Gruvbox Dark         | Gruvbox     | Dark       | `gruvbox-dark`         |
+| Gruvbox Dark Soft    | Gruvbox     | Dark       | `gruvbox-dark-soft`    |
+| Gruvbox Light Hard   | Gruvbox     | Light      | `gruvbox-light-hard`   |
+| Gruvbox Light        | Gruvbox     | Light      | `gruvbox-light`        |
+| Gruvbox Light Soft   | Gruvbox     | Light      | `gruvbox-light-soft`   |
+| GitHub Dark          | GitHub      | Dark       | `github-dark`          |
+| GitHub Light         | GitHub      | Light      | `github-light`         |
+| Bulma Dark           | Bulma       | Dark       | `bulma-dark`           |
+| Bulma Light          | Bulma       | Light      | `bulma-light`          |
+| Nord                 | Nord        | Dark       | `nord`                 |
+| Rosé Pine            | Rosé Pine   | Dark       | `rose-pine`            |
+| Rosé Pine Moon       | Rosé Pine   | Dark       | `rose-pine-moon`       |
+| Rosé Pine Dawn       | Rosé Pine   | Light      | `rose-pine-dawn`       |
+| Solarized Dark       | Solarized   | Dark       | `solarized-dark`       |
+| Solarized Light      | Solarized   | Light      | `solarized-light`      |
+| Tokyo Night Dark     | Tokyo Night | Dark       | `tokyo-night-dark`     |
+| Tokyo Night Storm    | Tokyo Night | Dark       | `tokyo-night-storm`    |
+| Tokyo Night Light    | Tokyo Night | Light      | `tokyo-night-light`    |
 
 ## Curating a theme subset
 
@@ -63,10 +63,10 @@ const all = themeIds;
 
 // Vendor opt-in
 const catppuccin = getThemesByVendor('catppuccin').map((f) => f.id);
-const github     = getThemesByVendor('github').map((f) => f.id);
+const github = getThemesByVendor('github').map((f) => f.id);
 
 // Appearance filter
-const darkOnly  = getThemesByAppearance('dark').map((f) => f.id);
+const darkOnly = getThemesByAppearance('dark').map((f) => f.id);
 const lightOnly = getThemesByAppearance('light').map((f) => f.id);
 
 // Hardcoded minimal set (copy-paste friendly)
@@ -79,9 +79,8 @@ const minimal = [
 ];
 ```
 
-> **Planned (#495):** `themeSets` (pre-defined named subsets) and
-> `createThemeCatalog()` (vendor + appearance filter in one call) will
-> ship as part of issue #495.
+> **Planned (#495):** `themeSets` (pre-defined named subsets) and `createThemeCatalog()`
+> (vendor + appearance filter in one call) will ship as part of issue #495.
 
 ## Catppuccin Themes
 
@@ -272,8 +271,8 @@ Based on the [Bulma CSS framework](https://bulma.io/) default colors.
 
 ## Nord Theme
 
-[Nord](https://www.nordtheme.com/) is an arctic, north-bluish color palette with a
-clean aesthetic.
+[Nord](https://www.nordtheme.com/) is an arctic, north-bluish color palette with a clean
+aesthetic.
 
 ### Nord (Dark)
 
@@ -329,8 +328,8 @@ tones.
 
 ## Solarized Themes
 
-[Solarized](https://ethanschoonover.com/solarized/) is a precision color scheme with
-16 carefully chosen colors.
+[Solarized](https://ethanschoonover.com/solarized/) is a precision color scheme with 16
+carefully chosen colors.
 
 ### Solarized Dark
 
@@ -407,7 +406,7 @@ A slightly lighter dark variant.
 ```typescript
 import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
-const darkThemes  = getThemesByAppearance('dark').map((f) => f.id);  // 15 themes
+const darkThemes = getThemesByAppearance('dark').map((f) => f.id); // 15 themes
 const lightThemes = getThemesByAppearance('light').map((f) => f.id); // 9 themes
 ```
 

--- a/apps/site/src/content/docs/api-reference/themes.md
+++ b/apps/site/src/content/docs/api-reference/themes.md
@@ -1,6 +1,6 @@
 ---
 title: Theme Definitions
-description: Complete reference for all 9 Turbo Themes color schemes.
+description: Complete reference for all 24 Turbo Themes color schemes.
 category: api-reference
 order: 4
 prev: api-reference/tokens
@@ -9,21 +9,79 @@ next: api-reference/javascript-api
 
 # Theme Definitions
 
-Turbo Themes includes 9 beautiful color schemes across 4 theme families.
+Turbo Themes includes 24 color schemes across 9 vendor families. The canonical
+list is always available at runtime:
+
+```typescript
+import { themeIds } from '@lgtm-hq/turbo-themes';
+// → readonly string[] of all 24 theme IDs, sorted by vendor then variant
+```
 
 ## Theme Overview
 
-| Theme                | Family     | Appearance | File                       |
-| -------------------- | ---------- | ---------- | -------------------------- |
-| Catppuccin Mocha     | Catppuccin | Dark       | `catppuccin-mocha.css`     |
-| Catppuccin Macchiato | Catppuccin | Dark       | `catppuccin-macchiato.css` |
-| Catppuccin Frappé    | Catppuccin | Dark       | `catppuccin-frappe.css`    |
-| Catppuccin Latte     | Catppuccin | Light      | `catppuccin-latte.css`     |
-| Dracula              | Dracula    | Dark       | `dracula.css`              |
-| GitHub Dark          | GitHub     | Dark       | `github-dark.css`          |
-| GitHub Light         | GitHub     | Light      | `github-light.css`         |
-| Bulma Dark           | Bulma      | Dark       | `bulma-dark.css`           |
-| Bulma Light          | Bulma      | Light      | `bulma-light.css`          |
+| Theme                   | Vendor      | Appearance | ID                      |
+| ----------------------- | ----------- | ---------- | ----------------------- |
+| Catppuccin Mocha        | Catppuccin  | Dark       | `catppuccin-mocha`      |
+| Catppuccin Macchiato    | Catppuccin  | Dark       | `catppuccin-macchiato`  |
+| Catppuccin Frappé       | Catppuccin  | Dark       | `catppuccin-frappe`     |
+| Catppuccin Latte        | Catppuccin  | Light      | `catppuccin-latte`      |
+| Dracula                 | Dracula     | Dark       | `dracula`               |
+| Gruvbox Dark Hard       | Gruvbox     | Dark       | `gruvbox-dark-hard`     |
+| Gruvbox Dark            | Gruvbox     | Dark       | `gruvbox-dark`          |
+| Gruvbox Dark Soft       | Gruvbox     | Dark       | `gruvbox-dark-soft`     |
+| Gruvbox Light Hard      | Gruvbox     | Light      | `gruvbox-light-hard`    |
+| Gruvbox Light           | Gruvbox     | Light      | `gruvbox-light`         |
+| Gruvbox Light Soft      | Gruvbox     | Light      | `gruvbox-light-soft`    |
+| GitHub Dark             | GitHub      | Dark       | `github-dark`           |
+| GitHub Light            | GitHub      | Light      | `github-light`          |
+| Bulma Dark              | Bulma       | Dark       | `bulma-dark`            |
+| Bulma Light             | Bulma       | Light      | `bulma-light`           |
+| Nord                    | Nord        | Dark       | `nord`                  |
+| Rosé Pine               | Rosé Pine   | Dark       | `rose-pine`             |
+| Rosé Pine Moon          | Rosé Pine   | Dark       | `rose-pine-moon`        |
+| Rosé Pine Dawn          | Rosé Pine   | Light      | `rose-pine-dawn`        |
+| Solarized Dark          | Solarized   | Dark       | `solarized-dark`        |
+| Solarized Light         | Solarized   | Light      | `solarized-light`       |
+| Tokyo Night Dark        | Tokyo Night | Dark       | `tokyo-night-dark`      |
+| Tokyo Night Storm       | Tokyo Night | Dark       | `tokyo-night-storm`     |
+| Tokyo Night Light       | Tokyo Night | Light      | `tokyo-night-light`     |
+
+## Curating a theme subset
+
+Use existing utility exports to build your catalog programmatically:
+
+```typescript
+import {
+  themeIds,
+  flavors,
+  getThemesByVendor,
+  getThemesByAppearance,
+} from '@lgtm-hq/turbo-themes';
+
+// All 24 themes
+const all = themeIds;
+
+// Vendor opt-in
+const catppuccin = getThemesByVendor('catppuccin').map((f) => f.id);
+const github     = getThemesByVendor('github').map((f) => f.id);
+
+// Appearance filter
+const darkOnly  = getThemesByAppearance('dark').map((f) => f.id);
+const lightOnly = getThemesByAppearance('light').map((f) => f.id);
+
+// Hardcoded minimal set (copy-paste friendly)
+const minimal = [
+  'catppuccin-mocha',
+  'catppuccin-latte',
+  'dracula',
+  'github-dark',
+  'github-light',
+];
+```
+
+> **Planned (#495):** `themeSets` (pre-defined named subsets) and
+> `createThemeCatalog()` (vendor + appearance filter in one call) will
+> ship as part of issue #495.
 
 ## Catppuccin Themes
 
@@ -117,6 +175,33 @@ A warm, creamy light theme.
 | State Danger       | `#ff5555` |
 | State Info         | `#8be9fd` |
 
+## Gruvbox Themes
+
+[Gruvbox](https://github.com/morhetz/gruvbox) is a retro groove color scheme with warm
+earthy tones.
+
+### Gruvbox Dark Hard / Dark / Dark Soft
+
+Three contrast levels of the dark variant.
+
+| Token              | Hard      | Default   | Soft      |
+| ------------------ | --------- | --------- | --------- |
+| Background Base    | `#1d2021` | `#282828` | `#32302f` |
+| Background Surface | `#282828` | `#3c3836` | `#45403d` |
+| Text Primary       | `#ebdbb2` | `#ebdbb2` | `#ebdbb2` |
+| Brand Primary      | `#83a598` | `#83a598` | `#83a598` |
+
+### Gruvbox Light Hard / Light / Light Soft
+
+Three contrast levels of the light variant.
+
+| Token              | Hard      | Default   | Soft      |
+| ------------------ | --------- | --------- | --------- |
+| Background Base    | `#f9f5d7` | `#fbf1c7` | `#f2e5bc` |
+| Background Surface | `#ebdbb2` | `#ebdbb2` | `#ebdbb2` |
+| Text Primary       | `#3c3836` | `#3c3836` | `#3c3836` |
+| Brand Primary      | `#427b58` | `#427b58` | `#427b58` |
+
 ## GitHub Themes
 
 Inspired by GitHub's official color schemes.
@@ -185,19 +270,146 @@ Based on the [Bulma CSS framework](https://bulma.io/) default colors.
 | State Danger       | `#f14668` |
 | State Info         | `#3e8ed0` |
 
+## Nord Theme
+
+[Nord](https://www.nordtheme.com/) is an arctic, north-bluish color palette with a
+clean aesthetic.
+
+### Nord (Dark)
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#2e3440` |
+| Background Surface | `#3b4252` |
+| Background Overlay | `#434c5e` |
+| Text Primary       | `#eceff4` |
+| Text Secondary     | `#d8dee9` |
+| Brand Primary      | `#88c0d0` |
+| State Success      | `#a3be8c` |
+| State Warning      | `#ebcb8b` |
+| State Danger       | `#bf616a` |
+| State Info         | `#81a1c1` |
+
+## Rosé Pine Themes
+
+[Rosé Pine](https://rosepinetheme.com/) is a natural, minimal theme with warm, muted
+tones.
+
+### Rosé Pine (Dark)
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#191724` |
+| Background Surface | `#1f1d2e` |
+| Background Overlay | `#26233a` |
+| Text Primary       | `#e0def4` |
+| Brand Primary      | `#31748f` |
+| State Success      | `#9ccfd8` |
+| State Danger       | `#eb6f92` |
+
+### Rosé Pine Moon (Dark)
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#232136` |
+| Background Surface | `#2a273f` |
+| Background Overlay | `#393552` |
+| Text Primary       | `#e0def4` |
+| Brand Primary      | `#3e8fb0` |
+
+### Rosé Pine Dawn (Light)
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#faf4ed` |
+| Background Surface | `#fffaf3` |
+| Background Overlay | `#f2e9e1` |
+| Text Primary       | `#575279` |
+| Brand Primary      | `#286983` |
+
+## Solarized Themes
+
+[Solarized](https://ethanschoonover.com/solarized/) is a precision color scheme with
+16 carefully chosen colors.
+
+### Solarized Dark
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#002b36` |
+| Background Surface | `#073642` |
+| Background Overlay | `#586e75` |
+| Text Primary       | `#839496` |
+| Brand Primary      | `#268bd2` |
+| State Success      | `#859900` |
+| State Danger       | `#dc322f` |
+
+### Solarized Light
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#fdf6e3` |
+| Background Surface | `#eee8d5` |
+| Background Overlay | `#93a1a1` |
+| Text Primary       | `#657b83` |
+| Brand Primary      | `#268bd2` |
+
+## Tokyo Night Themes
+
+[Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) is a clean, dark theme
+celebrating the vibrant lights of downtown Tokyo at night.
+
+### Tokyo Night Dark
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#1a1b26` |
+| Background Surface | `#24283b` |
+| Background Overlay | `#292e42` |
+| Text Primary       | `#c0caf5` |
+| Brand Primary      | `#7aa2f7` |
+| State Success      | `#9ece6a` |
+| State Danger       | `#f7768e` |
+
+### Tokyo Night Storm
+
+A slightly lighter dark variant.
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#24283b` |
+| Background Surface | `#1f2335` |
+| Background Overlay | `#292e42` |
+| Text Primary       | `#c0caf5` |
+| Brand Primary      | `#7aa2f7` |
+
+### Tokyo Night Light
+
+| Token              | Value     |
+| ------------------ | --------- |
+| Background Base    | `#d5d6db` |
+| Background Surface | `#cbccd1` |
+| Background Overlay | `#b9bac2` |
+| Text Primary       | `#343b58` |
+| Brand Primary      | `#34548a` |
+
 ## Choosing a Theme
 
-### For Dark Mode Users
+### Starter recommendations
 
-- **Catppuccin Mocha** - Warm, cozy, easy on the eyes
-- **Dracula** - Vibrant accents, high contrast
-- **GitHub Dark** - Familiar if you use GitHub
+- **Dark, warm:** Catppuccin Mocha, Gruvbox Dark, Rosé Pine
+- **Dark, vibrant:** Dracula, Tokyo Night Dark
+- **Dark, minimal:** GitHub Dark, Nord
+- **Light:** Catppuccin Latte, GitHub Light, Rosé Pine Dawn, Solarized Light
 
-### For Light Mode Users
+### By appearance
 
-- **Catppuccin Latte** - Warm and creamy
-- **GitHub Light** - Clean and professional
-- **Bulma Light** - Modern and minimal
+```typescript
+import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
+
+const darkThemes  = getThemesByAppearance('dark').map((f) => f.id);  // 15 themes
+const lightThemes = getThemesByAppearance('light').map((f) => f.id); // 9 themes
+```
 
 ## Loading Themes
 
@@ -213,6 +425,8 @@ Based on the [Bulma CSS framework](https://bulma.io/) default colors.
 function setTheme(themeId) {
   const link = document.getElementById('theme-css');
   link.href = `/css/themes/turbo/${themeId}.css`;
+  document.documentElement.setAttribute('data-theme', themeId);
+  localStorage.setItem('turbo-theme', themeId);
 }
 ```
 

--- a/apps/site/src/content/docs/guides/theme-switching.md
+++ b/apps/site/src/content/docs/guides/theme-switching.md
@@ -11,11 +11,65 @@ next: guides/custom-themes
 
 Learn how to implement theme switching that persists across page loads.
 
+## Choosing your theme catalog
+
+Turbo Themes ships with 24 themes across 9 vendor families. A "catalog" is
+simply the subset of themes you expose to users in your app. The right approach
+depends on your build tooling.
+
+### Approach A — hardcoded list (no build step required)
+
+The simplest pattern. Maintain a plain array and update it when you upgrade
+the package:
+
+```javascript
+// Minimal set — copy-paste friendly
+const CATALOG = [
+  'catppuccin-mocha',
+  'catppuccin-latte',
+  'dracula',
+  'github-dark',
+  'github-light',
+];
+```
+
+### Approach B — filter by vendor or appearance (TS/ESM build)
+
+The `@lgtm-hq/turbo-themes` package exports `getThemesByVendor()` and
+`getThemesByAppearance()` so your catalog stays in sync with the package
+automatically:
+
+```typescript
+import {
+  themeIds,
+  getThemesByVendor,
+  getThemesByAppearance,
+} from '@lgtm-hq/turbo-themes';
+
+// Opt-in to specific vendors
+const catppuccin = getThemesByVendor('catppuccin').map((f) => f.id);
+// → ['catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe', 'catppuccin-latte']
+
+// Dark-only themes
+const darkOnly = getThemesByAppearance('dark').map((f) => f.id);
+
+// Light-only themes
+const lightOnly = getThemesByAppearance('light').map((f) => f.id);
+
+// All themes
+const allThemes = themeIds; // readonly string[], 24 entries
+```
+
+> **Planned (#495):** A `themeSets` object (pre-defined subsets like
+> `themeSets.minimal`, `themeSets.dark`) and a `createThemeCatalog()` factory
+> (filter by vendor _and_ appearance in one call) will ship in `#495` and
+> make these patterns even more concise.
+
 ## Basic Implementation
 
 ### 1. Set Up HTML
 
-Give your theme CSS link an ID:
+Give your theme CSS link an ID so JavaScript can swap it:
 
 ```html
 <head>
@@ -30,101 +84,122 @@ Give your theme CSS link an ID:
 
 ### 2. Create Theme Switcher
 
-Add a simple function to change themes:
-
 ```javascript
+const CATALOG = [
+  'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+];
+
 function setTheme(themeName) {
-  // Update CSS link
-  const themeLink = document.getElementById('theme-css');
-  themeLink.href = `/css/themes/turbo/${themeName}.css`;
+  if (!CATALOG.includes(themeName)) return;
 
-  // Save to localStorage
-  localStorage.setItem('turbo-theme', themeName);
-
-  // Update data attribute (useful for CSS selectors)
+  document.getElementById('theme-css').href = `/css/themes/turbo/${themeName}.css`;
   document.documentElement.setAttribute('data-theme', themeName);
+  localStorage.setItem('turbo-theme', themeName);
 }
 ```
 
 ### 3. Load Saved Theme
 
-Apply the saved theme on page load:
-
 ```javascript
 document.addEventListener('DOMContentLoaded', () => {
-  const savedTheme = localStorage.getItem('turbo-theme') || 'catppuccin-mocha';
-  setTheme(savedTheme);
+  const saved = localStorage.getItem('turbo-theme');
+  const initial = CATALOG.includes(saved) ? saved : 'catppuccin-mocha';
+  setTheme(initial);
 });
 ```
 
 ## Preventing FOUC
 
-Flash of Unstyled Content (FOUC) happens when the page renders with the wrong theme
-before JavaScript runs. Prevent it with a blocking script:
+Flash of Unstyled Content (FOUC) happens when the page renders with the wrong
+theme before JavaScript runs. A blocking script in `<head>` applies the saved
+theme synchronously before first paint.
 
-```html
+### Option 1 — Use `generateBlockingScript()`
+
+The `@lgtm-hq/turbo-theme-selector` package generates a self-contained IIFE
+from your catalog. Run it at build time and inline the result:
+
+```typescript
+import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
+import { themeIds } from '@lgtm-hq/turbo-themes';
+
+// Derive validThemes from your curated catalog (or pass themeIds for all):
+const validThemes = ['catppuccin-mocha', 'catppuccin-latte', 'dracula',
+                     'github-dark', 'github-light'];
+const blockingScript = generateBlockingScript({ validThemes });
+// → embed blockingScript in a <script> tag in <head>
+```
+
+**Astro example:**
+
+```astro
+---
+import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
+const blockingScript = generateBlockingScript();
+---
 <head>
-  <!-- Theme CSS -->
-  <link id="theme-css" rel="stylesheet" href="/css/themes/turbo/catppuccin-mocha.css" />
-
-  <!-- Blocking script (runs before page renders) -->
-  <script>
-    (function () {
-      var theme = localStorage.getItem('turbo-theme') || 'catppuccin-mocha';
-      var validThemes = [
-        'catppuccin-mocha',
-        'catppuccin-macchiato',
-        'catppuccin-frappe',
-        'catppuccin-latte',
-        'dracula',
-        'github-dark',
-        'github-light',
-        'bulma-dark',
-        'bulma-light',
-      ];
-
-      // Validate theme
-      if (validThemes.indexOf(theme) === -1) {
-        theme = 'catppuccin-mocha';
-      }
-
-      // Apply immediately
-      document.documentElement.setAttribute('data-theme', theme);
-      var link = document.getElementById('theme-css');
-      if (link) {
-        link.href = '/css/themes/turbo/' + theme + '.css';
-      }
-    })();
-  </script>
+  <Fragment set:html={`<script>${blockingScript}</script>`} />
 </head>
 ```
 
-## Theme Selector UI
+### Option 2 — Inline script (no build step)
 
-### Dropdown Selector
+For plain HTML files, write the script directly using your hardcoded catalog:
 
 ```html
-<div class="theme-selector">
-  <label for="theme-select">Theme:</label>
-  <select id="theme-select" onchange="setTheme(this.value)">
-    <optgroup label="Catppuccin">
-      <option value="catppuccin-mocha">Mocha</option>
-      <option value="catppuccin-macchiato">Macchiato</option>
-      <option value="catppuccin-frappe">Frappé</option>
-      <option value="catppuccin-latte">Latte</option>
-    </optgroup>
-    <optgroup label="Other">
-      <option value="dracula">Dracula</option>
-      <option value="github-dark">GitHub Dark</option>
-      <option value="github-light">GitHub Light</option>
-      <option value="bulma-dark">Bulma Dark</option>
-      <option value="bulma-light">Bulma Light</option>
-    </optgroup>
-  </select>
-</div>
+<script>
+  (function () {
+    try {
+      var DEFAULT_THEME = 'catppuccin-mocha';
+      var VALID_THEMES = [
+        'bulma-dark',        'bulma-light',
+        'catppuccin-frappe', 'catppuccin-latte', 'catppuccin-macchiato', 'catppuccin-mocha',
+        'dracula',
+        'github-dark',       'github-light',
+        'gruvbox-dark-hard', 'gruvbox-dark-soft', 'gruvbox-dark',
+        'gruvbox-light-hard', 'gruvbox-light-soft', 'gruvbox-light',
+        'nord',
+        'rose-pine-dawn',    'rose-pine-moon',    'rose-pine',
+        'solarized-dark',    'solarized-light',
+        'tokyo-night-dark',  'tokyo-night-light', 'tokyo-night-storm',
+      ];
+
+      var saved = localStorage.getItem('turbo-theme');
+      var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
+
+      document.documentElement.setAttribute('data-theme', theme);
+      var link = document.getElementById('theme-css');
+      if (link) link.href = '/css/themes/turbo/' + theme + '.css';
+    } catch (e) {
+      console.warn('Unable to load saved theme:', e);
+    }
+  })();
+</script>
+```
+
+Keep `VALID_THEMES` in sync with your `<select>` options. Trim the list to
+only the themes your app supports.
+
+## Theme Selector UI
+
+### Dropdown with vendor grouping
+
+```html
+<select id="theme-select" onchange="setTheme(this.value)">
+  <optgroup label="Catppuccin">
+    <option value="catppuccin-mocha">Catppuccin Mocha</option>
+    <option value="catppuccin-latte">Catppuccin Latte</option>
+  </optgroup>
+  <optgroup label="GitHub">
+    <option value="github-dark">GitHub Dark</option>
+    <option value="github-light">GitHub Light</option>
+  </optgroup>
+  <optgroup label="Dracula">
+    <option value="dracula">Dracula</option>
+  </optgroup>
+</select>
 
 <script>
-  // Set initial value
   document.addEventListener('DOMContentLoaded', function () {
     var saved = localStorage.getItem('turbo-theme') || 'catppuccin-mocha';
     document.getElementById('theme-select').value = saved;
@@ -132,180 +207,72 @@ before JavaScript runs. Prevent it with a blocking script:
 </script>
 ```
 
-### Button Grid
+When you have a build step, generate the `<option>` elements from your catalog:
 
-```html
-<div class="theme-buttons">
-  <button onclick="setTheme('catppuccin-mocha')" data-theme="catppuccin-mocha">
-    Mocha
-  </button>
-  <button onclick="setTheme('catppuccin-latte')" data-theme="catppuccin-latte">
-    Latte
-  </button>
-  <button onclick="setTheme('dracula')" data-theme="dracula">Dracula</button>
-  <!-- ... more buttons ... -->
-</div>
+```typescript
+import { themeIds, flavors, getThemesByVendor, VENDOR_GROUPS } from '@lgtm-hq/turbo-themes';
 
-<style>
-  .theme-buttons button {
-    padding: 0.5rem 1rem;
-    border: 2px solid transparent;
-    border-radius: 4px;
-    cursor: pointer;
-    background: var(--turbo-bg-surface);
-    color: var(--turbo-text-primary);
+const flavorMap = new Map(flavors.map((f) => [f.id, f]));
+
+function populateSelector(select: HTMLSelectElement, catalog: readonly string[]): void {
+  select.innerHTML = '';
+  const groups = new Map<string, HTMLOptGroupElement>();
+
+  for (const id of catalog) {
+    const flavor = flavorMap.get(id);
+    if (!flavor) continue;
+
+    let group = groups.get(flavor.vendor);
+    if (!group) {
+      group = document.createElement('optgroup');
+      group.label = flavor.vendor;
+      select.appendChild(group);
+      groups.set(flavor.vendor, group);
+    }
+
+    const opt = document.createElement('option');
+    opt.value = id;
+    opt.textContent = flavor.label;
+    group.appendChild(opt);
   }
-
-  .theme-buttons button[data-theme='catppuccin-mocha'] {
-    border-color: #89b4fa;
-  }
-
-  .theme-buttons button.active {
-    border-color: var(--turbo-brand-primary);
-  }
-</style>
+}
 ```
 
 ### Light/Dark Toggle
 
-For simple light/dark switching:
+```javascript
+const DARK_THEMES = ['catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
+                     'dracula', 'github-dark'];
+const LIGHT_THEMES = ['catppuccin-latte', 'github-light'];
 
-```html
-<button id="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-  <span class="icon-sun">☀️</span>
-  <span class="icon-moon">🌙</span>
-</button>
+// Or derive from getThemesByAppearance():
+// import { getThemesByAppearance } from '@lgtm-hq/turbo-themes';
+// const DARK_THEMES = getThemesByAppearance('dark').map(f => f.id);
 
-<script>
-  var darkTheme = 'catppuccin-mocha';
-  var lightTheme = 'catppuccin-latte';
-
-  function toggleTheme() {
-    var current = localStorage.getItem('turbo-theme') || darkTheme;
-    var newTheme = current === darkTheme ? lightTheme : darkTheme;
-    setTheme(newTheme);
-    updateToggleIcon(newTheme);
-  }
-
-  function updateToggleIcon(theme) {
-    var toggle = document.getElementById('theme-toggle');
-    var isDark = [
-      'catppuccin-mocha',
-      'catppuccin-macchiato',
-      'catppuccin-frappe',
-      'dracula',
-      'github-dark',
-      'bulma-dark',
-    ].includes(theme);
-    toggle.querySelector('.icon-sun').style.display = isDark ? 'none' : 'inline';
-    toggle.querySelector('.icon-moon').style.display = isDark ? 'inline' : 'none';
-  }
-</script>
+function toggleTheme() {
+  const current = localStorage.getItem('turbo-theme') || 'catppuccin-mocha';
+  const isDark = DARK_THEMES.includes(current);
+  setTheme(isDark ? 'catppuccin-latte' : 'catppuccin-mocha');
+}
 ```
 
 ## System Preference Detection
 
-Respect the user's system preference as a default:
-
 ```javascript
 function getDefaultTheme() {
-  // Check localStorage first
-  var saved = localStorage.getItem('turbo-theme');
-  if (saved) return saved;
+  const saved = localStorage.getItem('turbo-theme');
+  if (saved && CATALOG.includes(saved)) return saved;
 
-  // Fall back to system preference
-  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    return 'catppuccin-mocha';
-  }
-  return 'catppuccin-latte';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'catppuccin-mocha'
+    : 'catppuccin-latte';
 }
 
-// Listen for system preference changes
-window
-  .matchMedia('(prefers-color-scheme: dark)')
-  .addEventListener('change', function (e) {
-    // Only apply if user hasn't set a preference
-    if (!localStorage.getItem('turbo-theme')) {
-      setTheme(e.matches ? 'catppuccin-mocha' : 'catppuccin-latte');
-    }
-  });
-```
-
-## Complete Example
-
-```html
-<!DOCTYPE html>
-<html lang="en" data-theme="catppuccin-mocha">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Theme Switching Example</title>
-
-    <link rel="stylesheet" href="/css/turbo-core.css" />
-    <link rel="stylesheet" href="/css/turbo-base.css" />
-    <link
-      id="theme-css"
-      rel="stylesheet"
-      href="/css/themes/turbo/catppuccin-mocha.css"
-    />
-
-    <!-- Prevent FOUC -->
-    <script>
-      (function () {
-        var theme = localStorage.getItem('turbo-theme');
-        if (!theme && window.matchMedia('(prefers-color-scheme: light)').matches) {
-          theme = 'catppuccin-latte';
-        }
-        theme = theme || 'catppuccin-mocha';
-        document.documentElement.setAttribute('data-theme', theme);
-        document.getElementById('theme-css').href =
-          '/css/themes/turbo/' + theme + '.css';
-      })();
-    </script>
-
-    <style>
-      body {
-        background: var(--turbo-bg-base);
-        color: var(--turbo-text-primary);
-        font-family: system-ui, sans-serif;
-        padding: 2rem;
-      }
-
-      .theme-select {
-        padding: 0.5rem;
-        background: var(--turbo-bg-surface);
-        color: var(--turbo-text-primary);
-        border: 1px solid var(--turbo-border-default);
-        border-radius: 4px;
-      }
-    </style>
-  </head>
-  <body>
-    <h1>Theme Switching Demo</h1>
-
-    <label for="theme">Choose theme:</label>
-    <select id="theme" class="theme-select" onchange="setTheme(this.value)">
-      <option value="catppuccin-mocha">Catppuccin Mocha</option>
-      <option value="catppuccin-latte">Catppuccin Latte</option>
-      <option value="dracula">Dracula</option>
-      <option value="github-dark">GitHub Dark</option>
-      <option value="github-light">GitHub Light</option>
-    </select>
-
-    <script>
-      function setTheme(theme) {
-        document.getElementById('theme-css').href =
-          '/css/themes/turbo/' + theme + '.css';
-        document.documentElement.setAttribute('data-theme', theme);
-        localStorage.setItem('turbo-theme', theme);
-      }
-
-      // Set initial select value
-      var saved = localStorage.getItem('turbo-theme') || 'catppuccin-mocha';
-      document.getElementById('theme').value = saved;
-    </script>
-  </body>
-</html>
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+  if (!localStorage.getItem('turbo-theme')) {
+    setTheme(e.matches ? 'catppuccin-mocha' : 'catppuccin-latte');
+  }
+});
 ```
 
 ## Next Steps

--- a/apps/site/src/content/docs/guides/theme-switching.md
+++ b/apps/site/src/content/docs/guides/theme-switching.md
@@ -13,14 +13,13 @@ Learn how to implement theme switching that persists across page loads.
 
 ## Choosing your theme catalog
 
-Turbo Themes ships with 24 themes across 9 vendor families. A "catalog" is
-simply the subset of themes you expose to users in your app. The right approach
-depends on your build tooling.
+Turbo Themes ships with 24 themes across 9 vendor families. A "catalog" is simply the
+subset of themes you expose to users in your app. The right approach depends on your
+build tooling.
 
 ### Approach A — hardcoded list (no build step required)
 
-The simplest pattern. Maintain a plain array and update it when you upgrade
-the package:
+The simplest pattern. Maintain a plain array and update it when you upgrade the package:
 
 ```javascript
 // Minimal set — copy-paste friendly
@@ -36,8 +35,7 @@ const CATALOG = [
 ### Approach B — filter by vendor or appearance (TS/ESM build)
 
 The `@lgtm-hq/turbo-themes` package exports `getThemesByVendor()` and
-`getThemesByAppearance()` so your catalog stays in sync with the package
-automatically:
+`getThemesByAppearance()` so your catalog stays in sync with the package automatically:
 
 ```typescript
 import {
@@ -61,9 +59,9 @@ const allThemes = themeIds; // readonly string[], 24 entries
 ```
 
 > **Planned (#495):** A `themeSets` object (pre-defined subsets like
-> `themeSets.minimal`, `themeSets.dark`) and a `createThemeCatalog()` factory
-> (filter by vendor _and_ appearance in one call) will ship in `#495` and
-> make these patterns even more concise.
+> `themeSets.minimal`, `themeSets.dark`) and a `createThemeCatalog()` factory (filter by
+> vendor _and_ appearance in one call) will ship in `#495` and make these patterns even
+> more concise.
 
 ## Basic Implementation
 
@@ -86,7 +84,11 @@ Give your theme CSS link an ID so JavaScript can swap it:
 
 ```javascript
 const CATALOG = [
-  'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+  'catppuccin-mocha',
+  'catppuccin-latte',
+  'dracula',
+  'github-dark',
+  'github-light',
 ];
 
 function setTheme(themeName) {
@@ -110,22 +112,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ## Preventing FOUC
 
-Flash of Unstyled Content (FOUC) happens when the page renders with the wrong
-theme before JavaScript runs. A blocking script in `<head>` applies the saved
-theme synchronously before first paint.
+Flash of Unstyled Content (FOUC) happens when the page renders with the wrong theme
+before JavaScript runs. A blocking script in `<head>` applies the saved theme
+synchronously before first paint.
 
 ### Option 1 — Use `generateBlockingScript()`
 
-The `@lgtm-hq/turbo-theme-selector` package generates a self-contained IIFE
-from your catalog. Run it at build time and inline the result:
+The `@lgtm-hq/turbo-theme-selector` package generates a self-contained IIFE from your
+catalog. Run it at build time and inline the result:
 
 ```typescript
 import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
 import { themeIds } from '@lgtm-hq/turbo-themes';
 
 // Derive validThemes from your curated catalog (or pass themeIds for all):
-const validThemes = ['catppuccin-mocha', 'catppuccin-latte', 'dracula',
-                     'github-dark', 'github-light'];
+const validThemes = [
+  'catppuccin-mocha',
+  'catppuccin-latte',
+  'dracula',
+  'github-dark',
+  'github-light',
+];
 const blockingScript = generateBlockingScript({ validThemes });
 // → embed blockingScript in a <script> tag in <head>
 ```
@@ -152,16 +159,30 @@ For plain HTML files, write the script directly using your hardcoded catalog:
     try {
       var DEFAULT_THEME = 'catppuccin-mocha';
       var VALID_THEMES = [
-        'bulma-dark',        'bulma-light',
-        'catppuccin-frappe', 'catppuccin-latte', 'catppuccin-macchiato', 'catppuccin-mocha',
+        'bulma-dark',
+        'bulma-light',
+        'catppuccin-frappe',
+        'catppuccin-latte',
+        'catppuccin-macchiato',
+        'catppuccin-mocha',
         'dracula',
-        'github-dark',       'github-light',
-        'gruvbox-dark-hard', 'gruvbox-dark-soft', 'gruvbox-dark',
-        'gruvbox-light-hard', 'gruvbox-light-soft', 'gruvbox-light',
+        'github-dark',
+        'github-light',
+        'gruvbox-dark-hard',
+        'gruvbox-dark-soft',
+        'gruvbox-dark',
+        'gruvbox-light-hard',
+        'gruvbox-light-soft',
+        'gruvbox-light',
         'nord',
-        'rose-pine-dawn',    'rose-pine-moon',    'rose-pine',
-        'solarized-dark',    'solarized-light',
-        'tokyo-night-dark',  'tokyo-night-light', 'tokyo-night-storm',
+        'rose-pine-dawn',
+        'rose-pine-moon',
+        'rose-pine',
+        'solarized-dark',
+        'solarized-light',
+        'tokyo-night-dark',
+        'tokyo-night-light',
+        'tokyo-night-storm',
       ];
 
       var saved = localStorage.getItem('turbo-theme');
@@ -177,8 +198,8 @@ For plain HTML files, write the script directly using your hardcoded catalog:
 </script>
 ```
 
-Keep `VALID_THEMES` in sync with your `<select>` options. Trim the list to
-only the themes your app supports.
+Keep `VALID_THEMES` in sync with your `<select>` options. Trim the list to only the
+themes your app supports.
 
 ## Theme Selector UI
 
@@ -210,7 +231,12 @@ only the themes your app supports.
 When you have a build step, generate the `<option>` elements from your catalog:
 
 ```typescript
-import { themeIds, flavors, getThemesByVendor, VENDOR_GROUPS } from '@lgtm-hq/turbo-themes';
+import {
+  themeIds,
+  flavors,
+  getThemesByVendor,
+  VENDOR_GROUPS,
+} from '@lgtm-hq/turbo-themes';
 
 const flavorMap = new Map(flavors.map((f) => [f.id, f]));
 
@@ -241,8 +267,13 @@ function populateSelector(select: HTMLSelectElement, catalog: readonly string[])
 ### Light/Dark Toggle
 
 ```javascript
-const DARK_THEMES = ['catppuccin-mocha', 'catppuccin-macchiato', 'catppuccin-frappe',
-                     'dracula', 'github-dark'];
+const DARK_THEMES = [
+  'catppuccin-mocha',
+  'catppuccin-macchiato',
+  'catppuccin-frappe',
+  'dracula',
+  'github-dark',
+];
 const LIGHT_THEMES = ['catppuccin-latte', 'github-light'];
 
 // Or derive from getThemesByAppearance():

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ scheme.
 
 All examples include:
 
-- **Theme Switching** - A dropdown selector to switch between 9 built-in themes
+- **Theme Switching** - A dropdown selector to switch between available themes (see `themeIds` for the full list)
 - **localStorage Persistence** - Selected theme persists across page reloads
 - **FOUC Prevention** - Blocking script prevents flash of unstyled content
 - **CSS Custom Properties** - All styling uses `var(--turbo-*)` tokens
@@ -86,7 +86,7 @@ Want to add a new example? Here's how:
 2. Include:
    - A complete, working implementation
    - A `README.md` with setup instructions
-   - Theme switching with all 9 themes
+   - Theme switching with your curated theme list
    - localStorage persistence
    - FOUC prevention script
 3. Add tests in a `test/` subdirectory

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,8 @@ scheme.
 
 All examples include:
 
-- **Theme Switching** - A dropdown selector to switch between available themes (see `themeIds` for the full list)
+- **Theme Switching** - A dropdown selector to switch between available themes (see
+  `themeIds` for the full list)
 - **localStorage Persistence** - Selected theme persists across page reloads
 - **FOUC Prevention** - Blocking script prevents flash of unstyled content
 - **CSS Custom Properties** - All styling uses `var(--turbo-*)` tokens

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -74,7 +74,8 @@
           ];
 
           var saved = localStorage.getItem('turbo-theme');
-          var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
+          var theme =
+            saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
 
           document.documentElement.setAttribute('data-theme', theme);
           document.documentElement.setAttribute(

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -12,54 +12,80 @@
       rel="stylesheet"
       href="./turbo-themes/themes/catppuccin-mocha.css"
     />
-    <!-- FOUC Prevention -->
+    <!--
+      FOUC Prevention — keeps the saved theme applied before first paint.
+
+      In an SSR/build context, generate this script automatically using
+      generateBlockingScript() from @lgtm-hq/turbo-theme-selector so the
+      VALID_THEMES list always matches your curated catalog:
+
+        import { generateBlockingScript } from '@lgtm-hq/turbo-theme-selector';
+        import { themeIds } from '@lgtm-hq/turbo-themes';
+
+        // Curate inline — or build from getThemesByVendor() / getThemesByAppearance():
+        const validThemes = ['catppuccin-mocha', 'catppuccin-latte', 'dracula',
+                              'github-dark', 'github-light'];
+
+        const script = generateBlockingScript({ validThemes });
+        // → inject returned string into a <script> tag in <head>
+
+      Note: a themeSets / createThemeCatalog() shorthand is planned in #495.
+    -->
     <script>
       (function () {
-        var DEFAULT_THEME = 'catppuccin-mocha';
-        var VALID_THEMES = [
-          'catppuccin-mocha',
-          'catppuccin-macchiato',
-          'catppuccin-frappe',
-          'catppuccin-latte',
-          'dracula',
-          'gruvbox-dark-hard',
-          'gruvbox-dark',
-          'gruvbox-dark-soft',
-          'gruvbox-light-hard',
-          'gruvbox-light',
-          'gruvbox-light-soft',
-          'github-dark',
-          'github-light',
-          'bulma-dark',
-          'bulma-light',
-          'nord',
-          'solarized-dark',
-          'solarized-light',
-          'rose-pine',
-          'rose-pine-moon',
-          'rose-pine-dawn',
-        ];
-        var lightThemes = [
-          'catppuccin-latte',
-          'gruvbox-light-hard',
-          'gruvbox-light',
-          'gruvbox-light-soft',
-          'github-light',
-          'bulma-light',
-          'solarized-light',
-          'rose-pine-dawn',
-        ];
+        try {
+          var DEFAULT_THEME = 'catppuccin-mocha';
+          var VALID_THEMES = [
+            'bulma-dark',
+            'bulma-light',
+            'catppuccin-frappe',
+            'catppuccin-latte',
+            'catppuccin-macchiato',
+            'catppuccin-mocha',
+            'dracula',
+            'github-dark',
+            'github-light',
+            'gruvbox-dark-hard',
+            'gruvbox-dark-soft',
+            'gruvbox-dark',
+            'gruvbox-light-hard',
+            'gruvbox-light-soft',
+            'gruvbox-light',
+            'nord',
+            'rose-pine-dawn',
+            'rose-pine-moon',
+            'rose-pine',
+            'solarized-dark',
+            'solarized-light',
+            'tokyo-night-dark',
+            'tokyo-night-light',
+            'tokyo-night-storm',
+          ];
+          var lightThemes = [
+            'bulma-light',
+            'catppuccin-latte',
+            'github-light',
+            'gruvbox-light-hard',
+            'gruvbox-light-soft',
+            'gruvbox-light',
+            'rose-pine-dawn',
+            'solarized-light',
+            'tokyo-night-light',
+          ];
 
-        var saved = localStorage.getItem('turbo-theme');
-        var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
+          var saved = localStorage.getItem('turbo-theme');
+          var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
 
-        document.documentElement.setAttribute('data-theme', theme);
-        document.documentElement.setAttribute(
-          'data-bs-theme',
-          lightThemes.indexOf(theme) !== -1 ? 'light' : 'dark'
-        );
-        var link = document.getElementById('theme-css');
-        if (link) link.href = './turbo-themes/themes/' + theme + '.css';
+          document.documentElement.setAttribute('data-theme', theme);
+          document.documentElement.setAttribute(
+            'data-bs-theme',
+            lightThemes.indexOf(theme) !== -1 ? 'light' : 'dark'
+          );
+          var link = document.getElementById('theme-css');
+          if (link) link.href = './turbo-themes/themes/' + theme + '.css';
+        } catch (e) {
+          console.warn('Unable to load saved theme:', e);
+        }
       })();
     </script>
     <!-- Bootstrap + Custom Styles -->
@@ -72,34 +98,17 @@
         <div class="d-flex align-items-center gap-3">
           <label class="d-flex align-items-center gap-2">
             <span class="text-body-secondary small">Theme</span>
+            <!--
+              Options are populated dynamically from CATALOG in src/main.ts.
+              Curate CATALOG via a hardcoded array, getThemesByVendor(), or
+              getThemesByAppearance() — no hardcoded option list to maintain.
+            -->
             <select
               id="theme-selector"
               class="form-select form-select-sm"
               style="width: auto"
               aria-label="Select theme"
-            >
-              <option value="catppuccin-mocha">Catppuccin Mocha</option>
-              <option value="catppuccin-macchiato">Catppuccin Macchiato</option>
-              <option value="catppuccin-frappe">Catppuccin Frappe</option>
-              <option value="catppuccin-latte">Catppuccin Latte</option>
-              <option value="dracula">Dracula</option>
-              <option value="gruvbox-dark-hard">Gruvbox Dark Hard</option>
-              <option value="gruvbox-dark">Gruvbox Dark</option>
-              <option value="gruvbox-dark-soft">Gruvbox Dark Soft</option>
-              <option value="gruvbox-light-hard">Gruvbox Light Hard</option>
-              <option value="gruvbox-light">Gruvbox Light</option>
-              <option value="gruvbox-light-soft">Gruvbox Light Soft</option>
-              <option value="github-dark">GitHub Dark</option>
-              <option value="github-light">GitHub Light</option>
-              <option value="bulma-dark">Bulma Dark</option>
-              <option value="bulma-light">Bulma Light</option>
-              <option value="nord">Nord</option>
-              <option value="solarized-dark">Solarized Dark</option>
-              <option value="solarized-light">Solarized Light</option>
-              <option value="rose-pine">Rosé Pine</option>
-              <option value="rose-pine-moon">Rosé Pine Moon</option>
-              <option value="rose-pine-dawn">Rosé Pine Dawn</option>
-            </select>
+            ></select>
           </label>
         </div>
       </div>

--- a/examples/bootstrap/src/main.ts
+++ b/examples/bootstrap/src/main.ts
@@ -1,41 +1,61 @@
-import { themeIds, flavors } from '@lgtm-hq/turbo-themes-core/tokens';
+import { themeIds, flavors, getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
 const STORAGE_KEY = 'turbo-theme';
 const DEFAULT_THEME = 'catppuccin-mocha';
 
-// Import theme IDs from core package (single source of truth)
-const VALID_THEMES = themeIds;
+/**
+ * Curated theme catalog for this app.
+ *
+ * Consumer curation patterns (using existing APIs):
+ *
+ * a) Hardcoded minimal set (copy-paste friendly):
+ *      const CATALOG: readonly string[] = [
+ *        'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+ *      ];
+ *
+ * b) Filter by vendor using getThemesByVendor() (import it if needed):
+ *      import { getThemesByVendor } from '@lgtm-hq/turbo-themes';
+ *      const CATALOG = getThemesByVendor('catppuccin').map((f) => f.id);
+ *
+ * c) Filter by appearance:
+ *      const CATALOG = getThemesByAppearance('dark').map((f) => f.id);
+ *
+ * d) All themes (default):
+ *      const CATALOG: readonly string[] = themeIds;
+ *
+ * Note: a `themeSets` helper and `createThemeCatalog()` factory are planned
+ * in #495 and will make these patterns more ergonomic.
+ */
+const CATALOG: readonly string[] = themeIds;
 
-type ThemeId = (typeof themeIds)[number];
+type ThemeId = string;
 
-// Derive light themes from flavor appearance (single source of truth)
-const LIGHT_THEMES: string[] = flavors.filter((f) => f.appearance === 'light').map((f) => f.id);
+const flavorMap = new Map(flavors.map((f) => [f.id, f]));
+
+const LIGHT_THEMES: ReadonlySet<string> = new Set(
+  getThemesByAppearance('light').map((f) => f.id)
+);
 
 function isValidTheme(theme: string): theme is ThemeId {
-  return VALID_THEMES.includes(theme as ThemeId);
+  return (CATALOG as readonly string[]).includes(theme);
 }
 
 function applyTheme(themeId: ThemeId): void {
-  // Set data-theme attribute
   document.documentElement.setAttribute('data-theme', themeId);
 
-  // Set Bootstrap's data-bs-theme for light/dark mode
-  const bsTheme = LIGHT_THEMES.includes(themeId) ? 'light' : 'dark';
+  const bsTheme = LIGHT_THEMES.has(themeId) ? 'light' : 'dark';
   document.documentElement.setAttribute('data-bs-theme', bsTheme);
 
-  // Update CSS link
   const themeLink = document.getElementById('theme-css') as HTMLLinkElement | null;
   if (themeLink) {
     themeLink.href = `./turbo-themes/themes/${themeId}.css`;
   }
 
-  // Update footer display
   const currentThemeEl = document.getElementById('current-theme');
   if (currentThemeEl) {
-    currentThemeEl.textContent = themeId;
+    currentThemeEl.textContent = flavorMap.get(themeId)?.label ?? themeId;
   }
 
-  // Persist to localStorage
   try {
     localStorage.setItem(STORAGE_KEY, themeId);
   } catch {
@@ -55,6 +75,30 @@ function getInitialTheme(): ThemeId {
   return DEFAULT_THEME;
 }
 
+function populateSelector(selector: HTMLSelectElement): void {
+  selector.innerHTML = '';
+
+  const vendorGroups = new Map<string, HTMLOptGroupElement>();
+
+  for (const id of CATALOG) {
+    const flavor = flavorMap.get(id);
+    if (!flavor) continue;
+
+    let group = vendorGroups.get(flavor.vendor);
+    if (!group) {
+      group = document.createElement('optgroup');
+      group.label = flavor.vendor.charAt(0).toUpperCase() + flavor.vendor.slice(1);
+      selector.appendChild(group);
+      vendorGroups.set(flavor.vendor, group);
+    }
+
+    const option = document.createElement('option');
+    option.value = id;
+    option.textContent = flavor.label;
+    group.appendChild(option);
+  }
+}
+
 function init(): void {
   const selector = document.getElementById('theme-selector') as HTMLSelectElement | null;
 
@@ -63,12 +107,12 @@ function init(): void {
     return;
   }
 
-  // Set initial value
+  populateSelector(selector);
+
   const initialTheme = getInitialTheme();
   selector.value = initialTheme;
   applyTheme(initialTheme);
 
-  // Listen for changes
   selector.addEventListener('change', (e) => {
     const target = e.target as HTMLSelectElement;
     const newTheme = target.value;
@@ -81,7 +125,6 @@ function init(): void {
   });
 }
 
-// Initialize when DOM is ready
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
 } else {

--- a/examples/bootstrap/test/bootstrap-example.spec.ts
+++ b/examples/bootstrap/test/bootstrap-example.spec.ts
@@ -169,10 +169,10 @@ test.describe('Bootstrap Example', () => {
   test.describe('Footer', () => {
     test('should show current theme in footer', async () => {
       const footer = bootstrapPage.getFooter();
-      await expect(footer).toContainText('catppuccin-mocha');
+      await expect(footer).toContainText('Catppuccin Mocha');
 
       await bootstrapPage.selectTheme('dracula');
-      await expect(footer).toContainText('dracula');
+      await expect(footer).toContainText('Dracula');
     });
   });
 

--- a/examples/bootstrap/vite.config.ts
+++ b/examples/bootstrap/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   base: './',
   resolve: {
     alias: {
+      // Resolve published import path to local monorepo build during development.
+      // In a real consumer project, install @lgtm-hq/turbo-themes from npm.
+      '@lgtm-hq/turbo-themes': corePackagePath,
       '@lgtm-hq/turbo-themes-core': corePackagePath,
     },
   },

--- a/examples/html-vanilla/index.html
+++ b/examples/html-vanilla/index.html
@@ -102,28 +102,66 @@
       </div>
       <label>
         <span class="muted">Theme</span><br />
+        <!--
+          Vendor opt-in: list only the themes you want to expose.
+
+          In a build/SSR context you can generate this list dynamically:
+
+            import { themeIds, getThemesByVendor, getThemesByAppearance }
+              from '@lgtm-hq/turbo-themes';
+
+            // All 24 themes:  themeIds
+            // Vendor filter:  getThemesByVendor('catppuccin').map(f => f.id)
+            // Appearance:     getThemesByAppearance('dark').map(f => f.id)
+            // Hardcoded set:  ['catppuccin-mocha', 'catppuccin-latte', 'dracula', ...]
+
+          A themeSets / createThemeCatalog() helper is planned in #495.
+          For now the <option> list below is the canonical curated selection.
+          VALID_THEMES in the script below is derived from these <option>s.
+        -->
         <select id="theme-selector">
-          <option value="catppuccin-mocha">Catppuccin Mocha</option>
-          <option value="catppuccin-macchiato">Catppuccin Macchiato</option>
-          <option value="catppuccin-frappe">Catppuccin Frappe</option>
-          <option value="catppuccin-latte">Catppuccin Latte</option>
-          <option value="dracula">Dracula</option>
-          <option value="gruvbox-dark-hard">Gruvbox Dark Hard</option>
-          <option value="gruvbox-dark">Gruvbox Dark</option>
-          <option value="gruvbox-dark-soft">Gruvbox Dark Soft</option>
-          <option value="gruvbox-light-hard">Gruvbox Light Hard</option>
-          <option value="gruvbox-light">Gruvbox Light</option>
-          <option value="gruvbox-light-soft">Gruvbox Light Soft</option>
-          <option value="github-dark">GitHub Dark</option>
-          <option value="github-light">GitHub Light</option>
-          <option value="bulma-dark">Bulma Dark</option>
-          <option value="bulma-light">Bulma Light</option>
-          <option value="nord">Nord</option>
-          <option value="solarized-dark">Solarized Dark</option>
-          <option value="solarized-light">Solarized Light</option>
-          <option value="rose-pine">Rosé Pine</option>
-          <option value="rose-pine-moon">Rosé Pine Moon</option>
-          <option value="rose-pine-dawn">Rosé Pine Dawn</option>
+          <optgroup label="Catppuccin">
+            <option value="catppuccin-mocha">Catppuccin Mocha</option>
+            <option value="catppuccin-macchiato">Catppuccin Macchiato</option>
+            <option value="catppuccin-frappe">Catppuccin Frappe</option>
+            <option value="catppuccin-latte">Catppuccin Latte</option>
+          </optgroup>
+          <optgroup label="Dracula">
+            <option value="dracula">Dracula</option>
+          </optgroup>
+          <optgroup label="Gruvbox">
+            <option value="gruvbox-dark-hard">Gruvbox Dark Hard</option>
+            <option value="gruvbox-dark">Gruvbox Dark</option>
+            <option value="gruvbox-dark-soft">Gruvbox Dark Soft</option>
+            <option value="gruvbox-light-hard">Gruvbox Light Hard</option>
+            <option value="gruvbox-light">Gruvbox Light</option>
+            <option value="gruvbox-light-soft">Gruvbox Light Soft</option>
+          </optgroup>
+          <optgroup label="GitHub">
+            <option value="github-dark">GitHub Dark</option>
+            <option value="github-light">GitHub Light</option>
+          </optgroup>
+          <optgroup label="Bulma">
+            <option value="bulma-dark">Bulma Dark</option>
+            <option value="bulma-light">Bulma Light</option>
+          </optgroup>
+          <optgroup label="Nord">
+            <option value="nord">Nord</option>
+          </optgroup>
+          <optgroup label="Solarized">
+            <option value="solarized-dark">Solarized Dark</option>
+            <option value="solarized-light">Solarized Light</option>
+          </optgroup>
+          <optgroup label="Rosé Pine">
+            <option value="rose-pine">Rosé Pine</option>
+            <option value="rose-pine-moon">Rosé Pine Moon</option>
+            <option value="rose-pine-dawn">Rosé Pine Dawn</option>
+          </optgroup>
+          <optgroup label="Tokyo Night">
+            <option value="tokyo-night-dark">Tokyo Night Dark</option>
+            <option value="tokyo-night-storm">Tokyo Night Storm</option>
+            <option value="tokyo-night-light">Tokyo Night Light</option>
+          </optgroup>
         </select>
       </label>
     </header>

--- a/examples/react/src/hooks/useTheme.ts
+++ b/examples/react/src/hooks/useTheme.ts
@@ -1,11 +1,32 @@
 import { useState, useEffect, useCallback } from 'react';
-import { themeIds, flavors } from '@lgtm-hq/turbo-themes-core/tokens';
+import { themeIds, flavors, getThemesByVendor, getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
 const STORAGE_KEY = 'turbo-theme';
 const DEFAULT_THEME = 'catppuccin-mocha';
 
-// Import theme IDs from core package (single source of truth)
-export const VALID_THEMES = themeIds;
+/**
+ * Curated theme catalog for this app.
+ *
+ * Consumer curation patterns (using existing APIs):
+ *
+ * a) Hardcoded minimal set (copy-paste friendly):
+ *      const CATALOG: readonly string[] = [
+ *        'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+ *      ];
+ *
+ * b) Filter by vendor using getThemesByVendor():
+ *      const CATALOG = getThemesByVendor('catppuccin').map((f) => f.id);
+ *
+ * c) Filter by appearance using getThemesByAppearance():
+ *      const CATALOG = getThemesByAppearance('dark').map((f) => f.id);
+ *
+ * d) All themes (default):
+ *      const CATALOG: readonly string[] = themeIds;
+ *
+ * Note: a `themeSets` helper and `createThemeCatalog()` factory are planned
+ * in #495 and will make these patterns more ergonomic.
+ */
+const CATALOG: readonly string[] = themeIds;
 
 export type ThemeId = (typeof themeIds)[number];
 
@@ -14,16 +35,18 @@ export interface ThemeOption {
   label: string;
 }
 
-// Generate theme options from core flavors
-export const THEME_OPTIONS: ThemeOption[] = flavors.map((f) => ({
-  id: f.id as ThemeId,
-  label: f.label,
+const flavorMap = new Map(flavors.map((f) => [f.id, f]));
+
+/** Theme options derived from the curated catalog. */
+export const THEME_OPTIONS: ThemeOption[] = CATALOG.map((id) => ({
+  id: id as ThemeId,
+  label: flavorMap.get(id)?.label ?? id,
 }));
 
 function getInitialTheme(): ThemeId {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved && VALID_THEMES.includes(saved as ThemeId)) {
+    if (saved && (CATALOG as readonly string[]).includes(saved)) {
       return saved as ThemeId;
     }
   } catch {
@@ -36,7 +59,7 @@ export function useTheme() {
   const [theme, setThemeState] = useState<ThemeId>(getInitialTheme);
 
   const setTheme = useCallback((newTheme: ThemeId) => {
-    if (!VALID_THEMES.includes(newTheme)) {
+    if (!(CATALOG as readonly string[]).includes(newTheme)) {
       console.warn('Invalid theme ID:', newTheme);
       return;
     }
@@ -62,8 +85,7 @@ export function useTheme() {
 
   // Sync with DOM on mount
   useEffect(() => {
-    // Validate theme before using in URL to prevent XSS
-    if (!VALID_THEMES.includes(theme)) return;
+    if (!(CATALOG as readonly string[]).includes(theme)) return;
 
     document.documentElement.setAttribute('data-theme', theme);
     const themeLink = document.getElementById('theme-css') as HTMLLinkElement | null;
@@ -78,3 +100,6 @@ export function useTheme() {
     themes: THEME_OPTIONS,
   };
 }
+
+// Re-export helpers for consumers building their own catalog
+export { getThemesByVendor, getThemesByAppearance };

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -18,6 +18,7 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
+      "@lgtm-hq/turbo-themes": ["../../packages/core/dist"],
       "@lgtm-hq/turbo-themes-core/*": ["../../packages/core/dist/*"]
     }
   },

--- a/examples/react/vite.config.ts
+++ b/examples/react/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      // Resolve published import path to local monorepo build during development.
+      // In a real consumer project, install @lgtm-hq/turbo-themes from npm.
+      '@lgtm-hq/turbo-themes': corePackagePath,
       '@lgtm-hq/turbo-themes-core': corePackagePath,
     },
   },

--- a/examples/tailwind/tailwind.config.js
+++ b/examples/tailwind/tailwind.config.js
@@ -1,4 +1,34 @@
-/** @type {import('tailwindcss').Config} */
+/**
+ * Tailwind + Turbo Themes example.
+ *
+ * The preset below enables all themes. To expose only a curated subset, pass
+ * a `themes` array to the preset using the existing filtering helpers:
+ *
+ *   const { themeIds, getThemesByVendor, getThemesByAppearance } =
+ *     require('@lgtm-hq/turbo-themes');
+ *   const preset = require('@lgtm-hq/turbo-themes/adapters/tailwind/preset');
+ *
+ *   module.exports = {
+ *     presets: [
+ *       // Hardcoded minimal set:
+ *       preset({ themes: ['catppuccin-mocha', 'catppuccin-latte', 'dracula',
+ *                         'github-dark', 'github-light'] }),
+ *
+ *       // Vendor filter:
+ *       preset({ themes: getThemesByVendor('catppuccin').map(f => f.id) }),
+ *
+ *       // Dark-only themes:
+ *       preset({ themes: getThemesByAppearance('dark').map(f => f.id) }),
+ *
+ *       // All themes (default):
+ *       preset({ themes: themeIds }),
+ *     ],
+ *   };
+ *
+ * Note: a themeSets / createThemeCatalog() shorthand is planned in #495.
+ *
+ * @type {import('tailwindcss').Config}
+ */
 module.exports = {
   content: ['./index.html'],
   theme: {

--- a/examples/vue/src/composables/useTheme.ts
+++ b/examples/vue/src/composables/useTheme.ts
@@ -1,11 +1,32 @@
 import { ref, onMounted, watch } from 'vue';
-import { themeIds, flavors } from '@lgtm-hq/turbo-themes-core/tokens';
+import { themeIds, flavors, getThemesByVendor, getThemesByAppearance } from '@lgtm-hq/turbo-themes';
 
 const STORAGE_KEY = 'turbo-theme';
 const DEFAULT_THEME = 'catppuccin-mocha';
 
-// Import theme IDs from core package (single source of truth)
-export const VALID_THEMES = themeIds;
+/**
+ * Curated theme catalog for this app.
+ *
+ * Consumer curation patterns (using existing APIs):
+ *
+ * a) Hardcoded minimal set (copy-paste friendly):
+ *      const CATALOG: readonly string[] = [
+ *        'catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light',
+ *      ];
+ *
+ * b) Filter by vendor using getThemesByVendor():
+ *      const CATALOG = getThemesByVendor('catppuccin').map((f) => f.id);
+ *
+ * c) Filter by appearance using getThemesByAppearance():
+ *      const CATALOG = getThemesByAppearance('dark').map((f) => f.id);
+ *
+ * d) All themes (default):
+ *      const CATALOG: readonly string[] = themeIds;
+ *
+ * Note: a `themeSets` helper and `createThemeCatalog()` factory are planned
+ * in #495 and will make these patterns more ergonomic.
+ */
+const CATALOG: readonly string[] = themeIds;
 
 export type ThemeId = (typeof themeIds)[number];
 
@@ -14,16 +35,18 @@ export interface ThemeOption {
   label: string;
 }
 
-// Generate theme options from core flavors
-export const THEME_OPTIONS: ThemeOption[] = flavors.map((f) => ({
-  id: f.id as ThemeId,
-  label: f.label,
+const flavorMap = new Map(flavors.map((f) => [f.id, f]));
+
+/** Theme options derived from the curated catalog. */
+export const THEME_OPTIONS: ThemeOption[] = CATALOG.map((id) => ({
+  id: id as ThemeId,
+  label: flavorMap.get(id)?.label ?? id,
 }));
 
 function getInitialTheme(): ThemeId {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved && VALID_THEMES.includes(saved as ThemeId)) {
+    if (saved && (CATALOG as readonly string[]).includes(saved)) {
       return saved as ThemeId;
     }
   } catch {
@@ -51,7 +74,7 @@ export function useTheme() {
   const theme = ref<ThemeId>(getInitialTheme());
 
   function setTheme(newTheme: ThemeId) {
-    if (!VALID_THEMES.includes(newTheme)) {
+    if (!(CATALOG as readonly string[]).includes(newTheme)) {
       console.warn('Invalid theme ID:', newTheme);
       return;
     }
@@ -78,3 +101,6 @@ export function useTheme() {
     themes: THEME_OPTIONS,
   };
 }
+
+// Re-export helpers for consumers building their own catalog
+export { getThemesByVendor, getThemesByAppearance };

--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -18,6 +18,7 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
+      "@lgtm-hq/turbo-themes": ["../../packages/core/dist"],
       "@lgtm-hq/turbo-themes-core/*": ["../../packages/core/dist/*"]
     }
   },

--- a/examples/vue/vite.config.ts
+++ b/examples/vue/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      // Resolve published import path to local monorepo build during development.
+      // In a real consumer project, install @lgtm-hq/turbo-themes from npm.
+      '@lgtm-hq/turbo-themes': corePackagePath,
       '@lgtm-hq/turbo-themes-core': corePackagePath,
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Document how consumers curate theme subsets using APIs already on main (`themeIds`, `getThemesByVendor`, `getThemesByAppearance`, hardcoded catalogs, `generateBlockingScript`), and update examples/docs accordingly. Notes planned `themeSets` / `createThemeCatalog` as Relates to #495 without implementing them.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [x] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Expanded theme-switching / JS API / themes docs with curation patterns
- Updated examples (react/vue/bootstrap/html-vanilla/tailwind) to demonstrate curated catalogs via existing APIs
- README “Choosing Themes” section

## Closes

- Closes #500
- Relates to #495

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR documents consumer theme curation patterns using APIs already on `main` (`themeIds`, `getThemesByVendor`, `getThemesByAppearance`, hardcoded catalogs, `generateBlockingScript`) and expands the theme reference from 9 to 24 themes, without shipping any new runtime code.

- **Docs expanded**: `javascript-api.md`, `themes.md`, `theme-switching.md`, and `README.md` all updated with curation pattern examples (hardcoded list, vendor filter, appearance filter) and FOUC prevention guidance for both build-step and no-build-step scenarios.
- **Examples updated**: React, Vue, Bootstrap, and vanilla HTML examples refactored to use the `CATALOG` pattern with guarded `localStorage` reads and dynamic vendor-grouped selectors.
- **Planned APIs noted**: `themeSets` and `createThemeCatalog()` (tracked in #495) are referenced but not implemented.
</details>


<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no new runtime code; all example changes are additive improvements with correct localStorage guards and catalog validation.

Every changed file is either documentation markdown or example code that ships no new library logic. The example implementations correctly guard localStorage access with try/catch, validate theme IDs against CATALOG before applying, and use idiomatic React/Vue patterns. The one inline comment-worthy issue is a dead import in a doc code snippet — it does not affect any running code.

No files require special attention beyond the already-threaded issues in javascript-api.md.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds "Choosing Themes" section documenting curation patterns, FOUC prevention, and a link to the theme-switching guide (link targets a repo-relative path flagged in a previous review thread). |
| apps/site/src/content/docs/api-reference/javascript-api.md | Expanded API reference documenting themeIds, flavors, getThemesByVendor, getThemesByAppearance, DEFAULT_THEME, VENDOR_GROUPS, and FOUC prevention; the React useTheme doc example reads localStorage inside a useState initializer (SSR-unsafe regression flagged in a previous review thread). |
| apps/site/src/content/docs/api-reference/themes.md | Expanded from 9 to 24 themes with new vendor sections (Gruvbox, Nord, Rosé Pine, Solarized, Tokyo Night); Tokyo Night Storm surface/base ordering question noted in a previous review thread. |
| apps/site/src/content/docs/guides/theme-switching.md | Adds catalog curation section with hardcoded, vendor-filter, and appearance-filter approaches; populateSelector example imports VENDOR_GROUPS and getThemesByVendor but neither is used in the function body. |
| examples/react/src/hooks/useTheme.ts | Refactored to use CATALOG pattern with try/catch-guarded localStorage read in useState initializer; correctly wraps DOM operations in useCallback and useEffect. |
| examples/vue/src/composables/useTheme.ts | Refactored to use CATALOG pattern; uses watch with immediate:true and onMounted for DOM sync; correctly guards localStorage in try/catch. |
| examples/bootstrap/src/main.ts | Refactored to use CATALOG/flavorMap pattern with dynamic vendor-grouped optgroup population; correctly handles localStorage guards and Bootstrap data-bs-theme synchronization. |
| examples/html-vanilla/index.html | Updated FOUC script and selector to cover all 24 themes; derives VALID_THEMES directly from the select element's options, keeping them in sync as a single source of truth. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer app] --> B{Build step?}
    B -- No --> C[Hardcoded CATALOG array]
    B -- Yes --> D{Filter strategy}
    D --> E[getThemesByVendor]
    D --> F[getThemesByAppearance]
    D --> G[themeIds all 24]
    C & E & F & G --> H[CATALOG]
    H --> I[Theme selector UI]
    H --> J{FOUC prevention}
    J -- Build step --> K[generateBlockingScript]
    J -- No build step --> L[Inline IIFE with VALID_THEMES]
    K & L --> M[Inline script in head]
    M --> N[Theme applied before first paint]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Consumer app] --> B{Build step?}
    B -- No --> C[Hardcoded CATALOG array]
    B -- Yes --> D{Filter strategy}
    D --> E[getThemesByVendor]
    D --> F[getThemesByAppearance]
    D --> G[themeIds all 24]
    C & E & F & G --> H[CATALOG]
    H --> I[Theme selector UI]
    H --> J{FOUC prevention}
    J -- Build step --> K[generateBlockingScript]
    J -- No build step --> L[Inline IIFE with VALID_THEMES]
    K & L --> M[Inline script in head]
    M --> N[Theme applied before first paint]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/site/src/content/docs/api-reference/themes.md`, line 879-886 ([link](https://github.com/lgtm-hq/turbo-themes/blob/9cb1c457493a06e21e963067e2d4112a671bc03c/apps/site/src/content/docs/api-reference/themes.md#L879-L886)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Tokyo Night Storm surface is darker than its base**

   The table lists Background Base as `#24283b` and Background Surface as `#1f2335`. In both the Tokyo Night Dark variant and every other dark theme in this file, Surface is lighter than Base (elevated UI elements appear brighter). Here Surface is the darker value, which is the reverse of the normal convention and may cause elevated elements to appear recessed rather than raised. Is this intentional for Storm, or are the two rows transposed?

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time! Are the Background Base (`#24283b`) and Background Surface (`#1f2335`) values for Tokyo Night Storm intentionally swapped relative to the convention used by all other dark themes in this file?

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fsite%2Fsrc%2Fcontent%2Fdocs%2Fapi-reference%2Fthemes.md%0ALine%3A%20879-886%0A%0AComment%3A%0A**Tokyo%20Night%20Storm%20surface%20is%20darker%20than%20its%20base**%0A%0AThe%20table%20lists%20Background%20Base%20as%20%60%2324283b%60%20and%20Background%20Surface%20as%20%60%231f2335%60.%20In%20both%20the%20Tokyo%20Night%20Dark%20variant%20and%20every%20other%20dark%20theme%20in%20this%20file%2C%20Surface%20is%20lighter%20than%20Base%20%28elevated%20UI%20elements%20appear%20brighter%29.%20Here%20Surface%20is%20the%20darker%20value%2C%20which%20is%20the%20reverse%20of%20the%20normal%20convention%20and%20may%20cause%20elevated%20elements%20to%20appear%20recessed%20rather%20than%20raised.%20Is%20this%20intentional%20for%20Storm%2C%20or%20are%20the%20two%20rows%20transposed%3F%0A%0A%20Are%20the%20Background%20Base%20%28%60%2324283b%60%29%20and%20Background%20Surface%20%28%60%231f2335%60%29%20values%20for%20Tokyo%20Night%20Storm%20intentionally%20swapped%20relative%20to%20the%20convention%20used%20by%20all%20other%20dark%20themes%20in%20this%20file%3F%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=565&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fsite%2Fsrc%2Fcontent%2Fdocs%2Fapi-reference%2Fthemes.md%0ALine%3A%20879-886%0A%0AComment%3A%0A**Tokyo%20Night%20Storm%20surface%20is%20darker%20than%20its%20base**%0A%0AThe%20table%20lists%20Background%20Base%20as%20%60%2324283b%60%20and%20Background%20Surface%20as%20%60%231f2335%60.%20In%20both%20the%20Tokyo%20Night%20Dark%20variant%20and%20every%20other%20dark%20theme%20in%20this%20file%2C%20Surface%20is%20lighter%20than%20Base%20%28elevated%20UI%20elements%20appear%20brighter%29.%20Here%20Surface%20is%20the%20darker%20value%2C%20which%20is%20the%20reverse%20of%20the%20normal%20convention%20and%20may%20cause%20elevated%20elements%20to%20appear%20recessed%20rather%20than%20raised.%20Is%20this%20intentional%20for%20Storm%2C%20or%20are%20the%20two%20rows%20transposed%3F%0A%0A%20Are%20the%20Background%20Base%20%28%60%2324283b%60%29%20and%20Background%20Surface%20%28%60%231f2335%60%29%20values%20for%20Tokyo%20Night%20Storm%20intentionally%20swapped%20relative%20to%20the%20convention%20used%20by%20all%20other%20dark%20themes%20in%20this%20file%3F%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=565&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F500-consumer-theme-docs-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F500-consumer-theme-docs-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fsite%2Fsrc%2Fcontent%2Fdocs%2Fapi-reference%2Fthemes.md%0ALine%3A%20879-886%0A%0AComment%3A%0A**Tokyo%20Night%20Storm%20surface%20is%20darker%20than%20its%20base**%0A%0AThe%20table%20lists%20Background%20Base%20as%20%60%2324283b%60%20and%20Background%20Surface%20as%20%60%231f2335%60.%20In%20both%20the%20Tokyo%20Night%20Dark%20variant%20and%20every%20other%20dark%20theme%20in%20this%20file%2C%20Surface%20is%20lighter%20than%20Base%20%28elevated%20UI%20elements%20appear%20brighter%29.%20Here%20Surface%20is%20the%20darker%20value%2C%20which%20is%20the%20reverse%20of%20the%20normal%20convention%20and%20may%20cause%20elevated%20elements%20to%20appear%20recessed%20rather%20than%20raised.%20Is%20this%20intentional%20for%20Storm%2C%20or%20are%20the%20two%20rows%20transposed%3F%0A%0A%20Are%20the%20Background%20Base%20%28%60%2324283b%60%29%20and%20Background%20Surface%20%28%60%231f2335%60%29%20values%20for%20Tokyo%20Night%20Storm%20intentionally%20swapped%20relative%20to%20the%20convention%20used%20by%20all%20other%20dark%20themes%20in%20this%20file%3F%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=565&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(examples): update bootstrap footer ..."](https://github.com/lgtm-hq/turbo-themes/commit/615db09fabf03979084672559a542d0fbde567f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45128486)</sub>

<!-- /greptile_comment -->