### PR TITLE
fix(ci): remove dangerous workflow_run.head_sha checkout pattern

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -65,9 +65,7 @@ jobs:
             rubygems.org:443
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref:
-            ${{ github.event.inputs.branch || github.event.workflow_run.head_sha ||
-            github.ref }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
       - name: Setup environment
         uses: ./.github/actions/setup-env
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenSSF Scorecard flagged `Dangerous-Workflow` because `deploy-pages.yml` checked out `github.event.workflow_run.head_sha`. Replace that with a safe `inputs.branch || github.ref` expression; other scorecard items in #358 were already green on main.

## Type

- [x] 🐛 Bug fix (`fix:`)
- [x] 🔧 CI/CD (`ci:`)

## Changes Made

- Updated checkout `ref` in `.github/workflows/deploy-pages.yml` to drop untrusted `workflow_run.head_sha`

## Closes

- Closes #358

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses an OpenSSF Scorecard `Dangerous-Workflow` finding by removing `github.event.workflow_run.head_sha` from the `actions/checkout` `ref` expression in `deploy-pages.yml`.

- The checkout `ref` is simplified from `inputs.branch || workflow_run.head_sha || github.ref` to `inputs.branch || github.ref`, which eliminates the untrusted-SHA checkout vector.
- However, `github.event.workflow_run.head_sha` is still directly interpolated inline into a `run:` shell command at line 90 (`download-test-artifacts.sh \"${{ github.event.workflow_run.head_sha }}\"`), which is the same pattern OpenSSF Scorecard flags — the fix is incomplete.
- Swapping from the pinned SHA to `github.ref` also introduces a minor TOCTOU window where a new commit pushed to `main` between CI completion and deploy start could be deployed without having passed CI.
</details>


<h3>Confidence Score: 3/5</h3>

The PR partially fixes the Dangerous-Workflow finding but leaves the untrusted SHA inline in a shell run: step, meaning the security posture is not fully improved.

The checkout change is correct and safe, but workflow_run.head_sha is still inline-interpolated in the run: shell command at line 90 — exactly the pattern OpenSSF Scorecard flags. The fix is incomplete: the if guard limits practical risk to the base repo, but the remaining inline interpolation should be addressed before this is considered resolved.

.github/workflows/deploy-pages.yml line 90 — the download-test-artifacts.sh step still uses ${{ github.event.workflow_run.head_sha }} inline in a shell command.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pages.yml | Removes `workflow_run.head_sha` from the `checkout` ref (security fix), but the same value is still inline-interpolated in a `run:` shell command at line 90 — the pattern OpenSSF Scorecard flags as dangerous is not fully eliminated. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Pipeline (workflow_run)
    participant Dispatch as workflow_dispatch
    participant Build as build job
    participant Deploy as deploy job

    CI->>Build: workflow_run completed (main, same repo)
    Note over Build: if: head_branch==main AND head_repository==github.repository
    Build->>Build: checkout ref: github.ref
    Build->>Build: Setup env / build site
    Build->>Build: download-test-artifacts.sh still uses inline head_sha
    Build->>Deploy: upload pages artifact
    Deploy->>Deploy: actions/deploy-pages

    Dispatch->>Build: workflow_dispatch (manual)
    Note over Build: inputs.branch takes priority
    Build->>Build: checkout ref: inputs.branch
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Pipeline (workflow_run)
    participant Dispatch as workflow_dispatch
    participant Build as build job
    participant Deploy as deploy job

    CI->>Build: workflow_run completed (main, same repo)
    Note over Build: if: head_branch==main AND head_repository==github.repository
    Build->>Build: checkout ref: github.ref
    Build->>Build: Setup env / build site
    Build->>Build: download-test-artifacts.sh still uses inline head_sha
    Build->>Deploy: upload pages artifact
    Deploy->>Deploy: actions/deploy-pages

    Dispatch->>Build: workflow_dispatch (manual)
    Note over Build: inputs.branch takes priority
    Build->>Build: checkout ref: inputs.branch
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/deploy-pages.yml`, line 89-90 ([link](https://github.com/lgtm-hq/turbo-themes/blob/f8905bb317ac76538d30beb3516d2f83007efb13/.github/workflows/deploy-pages.yml#L89-L90)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Incomplete removal of `workflow_run.head_sha`**

   The fix removes `workflow_run.head_sha` from the `checkout` ref, but line 90 still injects it directly into a shell command via `${{ ... }}` string interpolation rather than through an environment variable. Passing GitHub expression output inline in `run:` blocks is the pattern OpenSSF Scorecard flags as dangerous—if the value were ever manipulated (or if the script is called in a context where the value is not a clean hex SHA), it creates a command-injection surface. The stated goal of this PR is to remove `workflow_run.head_sha` entirely, but this usage was left behind.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-pages.yml%0ALine%3A%2089-90%0A%0AComment%3A%0A**Incomplete%20removal%20of%20%60workflow_run.head_sha%60**%0A%0AThe%20fix%20removes%20%60workflow_run.head_sha%60%20from%20the%20%60checkout%60%20ref%2C%20but%20line%2090%20still%20injects%20it%20directly%20into%20a%20shell%20command%20via%20%60%24%7B%7B%20...%20%7D%7D%60%20string%20interpolation%20rather%20than%20through%20an%20environment%20variable.%20Passing%20GitHub%20expression%20output%20inline%20in%20%60run%3A%60%20blocks%20is%20the%20pattern%20OpenSSF%20Scorecard%20flags%20as%20dangerous%E2%80%94if%20the%20value%20were%20ever%20manipulated%20%28or%20if%20the%20script%20is%20called%20in%20a%20context%20where%20the%20value%20is%20not%20a%20clean%20hex%20SHA%29%2C%20it%20creates%20a%20command-injection%20surface.%20The%20stated%20goal%20of%20this%20PR%20is%20to%20remove%20%60workflow_run.head_sha%60%20entirely%2C%20but%20this%20usage%20was%20left%20behind.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-pages.yml%0ALine%3A%2089-90%0A%0AComment%3A%0A**Incomplete%20removal%20of%20%60workflow_run.head_sha%60**%0A%0AThe%20fix%20removes%20%60workflow_run.head_sha%60%20from%20the%20%60checkout%60%20ref%2C%20but%20line%2090%20still%20injects%20it%20directly%20into%20a%20shell%20command%20via%20%60%24%7B%7B%20...%20%7D%7D%60%20string%20interpolation%20rather%20than%20through%20an%20environment%20variable.%20Passing%20GitHub%20expression%20output%20inline%20in%20%60run%3A%60%20blocks%20is%20the%20pattern%20OpenSSF%20Scorecard%20flags%20as%20dangerous%E2%80%94if%20the%20value%20were%20ever%20manipulated%20%28or%20if%20the%20script%20is%20called%20in%20a%20context%20where%20the%20value%20is%20not%20a%20clean%20hex%20SHA%29%2C%20it%20creates%20a%20command-injection%20surface.%20The%20stated%20goal%20of%20this%20PR%20is%20to%20remove%20%60workflow_run.head_sha%60%20entirely%2C%20but%20this%20usage%20was%20left%20behind.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F358-scorecard-fixes-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F358-scorecard-fixes-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-pages.yml%0ALine%3A%2089-90%0A%0AComment%3A%0A**Incomplete%20removal%20of%20%60workflow_run.head_sha%60**%0A%0AThe%20fix%20removes%20%60workflow_run.head_sha%60%20from%20the%20%60checkout%60%20ref%2C%20but%20line%2090%20still%20injects%20it%20directly%20into%20a%20shell%20command%20via%20%60%24%7B%7B%20...%20%7D%7D%60%20string%20interpolation%20rather%20than%20through%20an%20environment%20variable.%20Passing%20GitHub%20expression%20output%20inline%20in%20%60run%3A%60%20blocks%20is%20the%20pattern%20OpenSSF%20Scorecard%20flags%20as%20dangerous%E2%80%94if%20the%20value%20were%20ever%20manipulated%20%28or%20if%20the%20script%20is%20called%20in%20a%20context%20where%20the%20value%20is%20not%20a%20clean%20hex%20SHA%29%2C%20it%20creates%20a%20command-injection%20surface.%20The%20stated%20goal%20of%20this%20PR%20is%20to%20remove%20%60workflow_run.head_sha%60%20entirely%2C%20but%20this%20usage%20was%20left%20behind.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. `.github/workflows/deploy-pages.yml`, line 84-90 ([link](https://github.com/lgtm-hq/turbo-themes/blob/f8905bb317ac76538d30beb3516d2f83007efb13/.github/workflows/deploy-pages.yml#L84-L90)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Pass `workflow_run.head_sha` through an environment variable instead of inline interpolation. This is the GitHub-recommended pattern to prevent script-injection attacks when GitHub context values are used in `run:` steps.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-pages.yml%0ALine%3A%2084-90%0A%0AComment%3A%0APass%20%60workflow_run.head_sha%60%20through%20an%20environment%20variable%20instead%20of%20inline%20interpolation.%20This%20is%20the%20GitHub-recommended%20pattern%20to%20prevent%20script-injection%20attacks%20when%20GitHub%20context%20values%20are%20used%20in%20%60run%3A%60%20steps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Download%20test%20artifacts%0A%20%20%20%20%20%20%20%20if%3A%20github.event_name%20%3D%3D%20'workflow_run'%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20GITHUB_TOKEN%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20HEAD_SHA%3A%20%24%7B%7B%20github.event.workflow_run.head_sha%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fci%2Fdownload-test-artifacts.sh%20%22%24HEAD_SHA%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-pages.yml%0ALine%3A%2084-90%0A%0AComment%3A%0APass%20%60workflow_run.head_sha%60%20through%20an%20environment%20variable%20instead%20of%20inline%20interpolation.%20This%20is%20the%20GitHub-recommended%20pattern%20to%20prevent%20script-injection%20attacks%20when%20GitHub%20context%20values%20are%20used%20in%20%60run%3A%60%20steps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Download%20test%20artifacts%0A%20%20%20%20%20%20%20%20if%3A%20github.event_name%20%3D%3D%20'workflow_run'%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20GITHUB_TOKEN%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20HEAD_SHA%3A%20%24%7B%7B%20github.event.workflow_run.head_sha%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fci%2Fdownload-test-artifacts.sh%20%22%24HEAD_SHA%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F358-scorecard-fixes-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F358-scorecard-fixes-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-pages.yml%0ALine%3A%2084-90%0A%0AComment%3A%0APass%20%60workflow_run.head_sha%60%20through%20an%20environment%20variable%20instead%20of%20inline%20interpolation.%20This%20is%20the%20GitHub-recommended%20pattern%20to%20prevent%20script-injection%20attacks%20when%20GitHub%20context%20values%20are%20used%20in%20%60run%3A%60%20steps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Download%20test%20artifacts%0A%20%20%20%20%20%20%20%20if%3A%20github.event_name%20%3D%3D%20'workflow_run'%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20GITHUB_TOKEN%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20HEAD_SHA%3A%20%24%7B%7B%20github.event.workflow_run.head_sha%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fci%2Fdownload-test-artifacts.sh%20%22%24HEAD_SHA%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A89-90%0A**Incomplete%20removal%20of%20%60workflow_run.head_sha%60**%0A%0AThe%20fix%20removes%20%60workflow_run.head_sha%60%20from%20the%20%60checkout%60%20ref%2C%20but%20line%2090%20still%20injects%20it%20directly%20into%20a%20shell%20command%20via%20%60%24%7B%7B%20...%20%7D%7D%60%20string%20interpolation%20rather%20than%20through%20an%20environment%20variable.%20Passing%20GitHub%20expression%20output%20inline%20in%20%60run%3A%60%20blocks%20is%20the%20pattern%20OpenSSF%20Scorecard%20flags%20as%20dangerous%E2%80%94if%20the%20value%20were%20ever%20manipulated%20%28or%20if%20the%20script%20is%20called%20in%20a%20context%20where%20the%20value%20is%20not%20a%20clean%20hex%20SHA%29%2C%20it%20creates%20a%20command-injection%20surface.%20The%20stated%20goal%20of%20this%20PR%20is%20to%20remove%20%60workflow_run.head_sha%60%20entirely%2C%20but%20this%20usage%20was%20left%20behind.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A84-90%0APass%20%60workflow_run.head_sha%60%20through%20an%20environment%20variable%20instead%20of%20inline%20interpolation.%20This%20is%20the%20GitHub-recommended%20pattern%20to%20prevent%20script-injection%20attacks%20when%20GitHub%20context%20values%20are%20used%20in%20%60run%3A%60%20steps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Download%20test%20artifacts%0A%20%20%20%20%20%20%20%20if%3A%20github.event_name%20%3D%3D%20'workflow_run'%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20GITHUB_TOKEN%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20HEAD_SHA%3A%20%24%7B%7B%20github.event.workflow_run.head_sha%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fci%2Fdownload-test-artifacts.sh%20%22%24HEAD_SHA%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A66-68%0A**Possible%20TOCTOU%20between%20CI%20and%20deploy%20checkout**%0A%0AWith%20the%20old%20expression%2C%20%60workflow_run.head_sha%60%20pinned%20the%20checkout%20to%20the%20exact%20commit%20that%20passed%20CI.%20With%20%60github.ref%60%2C%20the%20deploy%20job%20now%20checks%20out%20whatever%20HEAD%20on%20%60main%60%20is%20at%20run%20time.%20If%20a%20new%20commit%20is%20pushed%20to%20%60main%60%20between%20when%20the%20triggering%20CI%20run%20completes%20and%20when%20this%20deploy%20job%20executes%2C%20the%20site%20may%20deploy%20code%20that%20has%20not%20yet%20passed%20the%20CI%20gate.%20The%20risk%20is%20low%20in%20practice%20%28the%20%60if%60%20guard%20already%20scopes%20to%20%60main%60%29%2C%20but%20worth%20noting%20if%20the%20repo%20has%20active%20contributors.%0A%0A&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A89-90%0A**Incomplete%20removal%20of%20%60workflow_run.head_sha%60**%0A%0AThe%20fix%20removes%20%60workflow_run.head_sha%60%20from%20the%20%60checkout%60%20ref%2C%20but%20line%2090%20still%20injects%20it%20directly%20into%20a%20shell%20command%20via%20%60%24%7B%7B%20...%20%7D%7D%60%20string%20interpolation%20rather%20than%20through%20an%20environment%20variable.%20Passing%20GitHub%20expression%20output%20inline%20in%20%60run%3A%60%20blocks%20is%20the%20pattern%20OpenSSF%20Scorecard%20flags%20as%20dangerous%E2%80%94if%20the%20value%20were%20ever%20manipulated%20%28or%20if%20the%20script%20is%20called%20in%20a%20context%20where%20the%20value%20is%20not%20a%20clean%20hex%20SHA%29%2C%20it%20creates%20a%20command-injection%20surface.%20The%20stated%20goal%20of%20this%20PR%20is%20to%20remove%20%60workflow_run.head_sha%60%20entirely%2C%20but%20this%20usage%20was%20left%20behind.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A84-90%0APass%20%60workflow_run.head_sha%60%20through%20an%20environment%20variable%20instead%20of%20inline%20interpolation.%20This%20is%20the%20GitHub-recommended%20pattern%20to%20prevent%20script-injection%20attacks%20when%20GitHub%20context%20values%20are%20used%20in%20%60run%3A%60%20steps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Download%20test%20artifacts%0A%20%20%20%20%20%20%20%20if%3A%20github.event_name%20%3D%3D%20'workflow_run'%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20GITHUB_TOKEN%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20HEAD_SHA%3A%20%24%7B%7B%20github.event.workflow_run.head_sha%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fci%2Fdownload-test-artifacts.sh%20%22%24HEAD_SHA%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A66-68%0A**Possible%20TOCTOU%20between%20CI%20and%20deploy%20checkout**%0A%0AWith%20the%20old%20expression%2C%20%60workflow_run.head_sha%60%20pinned%20the%20checkout%20to%20the%20exact%20commit%20that%20passed%20CI.%20With%20%60github.ref%60%2C%20the%20deploy%20job%20now%20checks%20out%20whatever%20HEAD%20on%20%60main%60%20is%20at%20run%20time.%20If%20a%20new%20commit%20is%20pushed%20to%20%60main%60%20between%20when%20the%20triggering%20CI%20run%20completes%20and%20when%20this%20deploy%20job%20executes%2C%20the%20site%20may%20deploy%20code%20that%20has%20not%20yet%20passed%20the%20CI%20gate.%20The%20risk%20is%20low%20in%20practice%20%28the%20%60if%60%20guard%20already%20scopes%20to%20%60main%60%29%2C%20but%20worth%20noting%20if%20the%20repo%20has%20active%20contributors.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F358-scorecard-fixes-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F358-scorecard-fixes-6221%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A89-90%0A**Incomplete%20removal%20of%20%60workflow_run.head_sha%60**%0A%0AThe%20fix%20removes%20%60workflow_run.head_sha%60%20from%20the%20%60checkout%60%20ref%2C%20but%20line%2090%20still%20injects%20it%20directly%20into%20a%20shell%20command%20via%20%60%24%7B%7B%20...%20%7D%7D%60%20string%20interpolation%20rather%20than%20through%20an%20environment%20variable.%20Passing%20GitHub%20expression%20output%20inline%20in%20%60run%3A%60%20blocks%20is%20the%20pattern%20OpenSSF%20Scorecard%20flags%20as%20dangerous%E2%80%94if%20the%20value%20were%20ever%20manipulated%20%28or%20if%20the%20script%20is%20called%20in%20a%20context%20where%20the%20value%20is%20not%20a%20clean%20hex%20SHA%29%2C%20it%20creates%20a%20command-injection%20surface.%20The%20stated%20goal%20of%20this%20PR%20is%20to%20remove%20%60workflow_run.head_sha%60%20entirely%2C%20but%20this%20usage%20was%20left%20behind.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A84-90%0APass%20%60workflow_run.head_sha%60%20through%20an%20environment%20variable%20instead%20of%20inline%20interpolation.%20This%20is%20the%20GitHub-recommended%20pattern%20to%20prevent%20script-injection%20attacks%20when%20GitHub%20context%20values%20are%20used%20in%20%60run%3A%60%20steps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Download%20test%20artifacts%0A%20%20%20%20%20%20%20%20if%3A%20github.event_name%20%3D%3D%20'workflow_run'%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20GITHUB_TOKEN%3A%20%24%7B%7B%20secrets.GITHUB_TOKEN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20HEAD_SHA%3A%20%24%7B%7B%20github.event.workflow_run.head_sha%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fci%2Fdownload-test-artifacts.sh%20%22%24HEAD_SHA%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fdeploy-pages.yml%3A66-68%0A**Possible%20TOCTOU%20between%20CI%20and%20deploy%20checkout**%0A%0AWith%20the%20old%20expression%2C%20%60workflow_run.head_sha%60%20pinned%20the%20checkout%20to%20the%20exact%20commit%20that%20passed%20CI.%20With%20%60github.ref%60%2C%20the%20deploy%20job%20now%20checks%20out%20whatever%20HEAD%20on%20%60main%60%20is%20at%20run%20time.%20If%20a%20new%20commit%20is%20pushed%20to%20%60main%60%20between%20when%20the%20triggering%20CI%20run%20completes%20and%20when%20this%20deploy%20job%20executes%2C%20the%20site%20may%20deploy%20code%20that%20has%20not%20yet%20passed%20the%20CI%20gate.%20The%20risk%20is%20low%20in%20practice%20%28the%20%60if%60%20guard%20already%20scopes%20to%20%60main%60%29%2C%20but%20worth%20noting%20if%20the%20repo%20has%20active%20contributors.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove dangerous workflow\_run.h..."](https://github.com/lgtm-hq/turbo-themes/commit/f8905bb317ac76538d30beb3516d2f83007efb13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45128488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->