### PR TITLE
fix(release): retry transient push rejection for version PRs

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Create or update version PR
         id: create_pr
+        continue-on-error: true
         if: steps.guard.outputs.is_release != 'true' && steps.version.outputs.bump_needed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         env:
@@ -114,22 +115,49 @@ jobs:
             release-bump
           delete-branch: true
 
-      - name: Request CODEOWNER review
-        if: steps.create_pr.outputs.pull-request-number != ''
+      - name: Retry release branch push on transient rejection
+        id: push_retry
+        if: >-
+          steps.guard.outputs.is_release != 'true' &&
+          steps.version.outputs.bump_needed == 'true' &&
+          steps.create_pr.outcome == 'failure'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+          RELEASE_BRANCH: release/version-${{ steps.version.outputs.next_version }}
+          PR_TITLE: ${{ steps.version.outputs.pr_title }}
+          PR_BODY_FILE: ${{ steps.version.outputs.pr_body_file }}
+        run: ./scripts/ci/retry-release-branch-push.sh
+
+      - name: Fail if push could not be completed
+        if: >-
+          steps.create_pr.outcome == 'failure' &&
+          steps.push_retry.outcome != 'success'
+        run: ./scripts/ci/fail-release-push.sh
+
+      - name: Request CODEOWNER review
+        if: >-
+          steps.create_pr.outputs.pull-request-number != '' ||
+          steps.push_retry.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number || steps.push_retry.outputs.pull-request-number }}
         run: ./scripts/ci/request-codeowner-review.sh
 
       - name: Enable auto-merge
-        if: steps.create_pr.outputs.pull-request-number
+        if: >-
+          steps.create_pr.outputs.pull-request-number ||
+          steps.push_retry.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} --auto --squash
+        run: |
+          PR="${{ steps.create_pr.outputs.pull-request-number || steps.push_retry.outputs.pull-request-number }}"
+          gh pr merge "${PR}" --auto --squash
 
       - name: Generate Version PR Summary
         if: always()
         env:
           BUMP_NEEDED: ${{ steps.version.outputs.bump_needed }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+          PUSH_RETRY_TRIGGERED: ${{ steps.create_pr.outcome == 'failure' && steps.push_retry.outcome == 'success' }}
+          JOB_STATUS: ${{ job.status }}
         run: ./scripts/ci/generate-version-pr-summary.sh

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -159,5 +159,5 @@ jobs:
           BUMP_NEEDED: ${{ steps.version.outputs.bump_needed }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           PUSH_RETRY_TRIGGERED: ${{ steps.create_pr.outcome == 'failure' && steps.push_retry.outcome == 'success' }}
-          JOB_STATUS: ${{ job.status }}
+          PUSH_FAILED: ${{ steps.create_pr.outcome == 'failure' && steps.push_retry.outcome != 'success' }}
         run: ./scripts/ci/generate-version-pr-summary.sh

--- a/scripts/ci/fail-release-push.sh
+++ b/scripts/ci/fail-release-push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Terminal failure marker for the release version-PR workflow —
+# invoked when both the primary branch push and the transient-rejection
+# retry have failed.
+
+set -euo pipefail
+
+echo "❌ Release branch push failed — primary attempt and transient retry both failed." >&2
+exit 1

--- a/scripts/ci/generate-version-pr-summary.sh
+++ b/scripts/ci/generate-version-pr-summary.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 # Generate a GitHub Step Summary for the Release Version PR workflow.
-# Expected env vars: BUMP_NEEDED, NEXT_VERSION
+# Expected env vars: BUMP_NEEDED, NEXT_VERSION, JOB_STATUS, PUSH_RETRY_TRIGGERED
 set -euo pipefail
 
 {
   echo "## Release Version PR Status"
   if [ "${BUMP_NEEDED:-}" = "true" ]; then
-    echo "Version PR created/updated for v${NEXT_VERSION}"
+    if [ "${JOB_STATUS:-}" = "failure" ]; then
+      echo "❌ **Push failed** — release branch for v${NEXT_VERSION} could not be pushed."
+      echo ""
+      echo "Both the primary push attempt and the transient-error retry failed."
+      echo "Check the workflow logs and re-run the workflow once the underlying issue is resolved."
+    elif [ "${PUSH_RETRY_TRIGGERED:-}" = "true" ]; then
+      echo "⚠️ Version PR created/updated for v${NEXT_VERSION} (recovered via push retry)"
+    else
+      echo "✅ Version PR created/updated for v${NEXT_VERSION}"
+    fi
   else
-    echo "No version bump needed"
+    echo "✅ No version bump needed"
   fi
 } >>"${GITHUB_STEP_SUMMARY}"

--- a/scripts/ci/generate-version-pr-summary.sh
+++ b/scripts/ci/generate-version-pr-summary.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Generate a GitHub Step Summary for the Release Version PR workflow.
-# Expected env vars: BUMP_NEEDED, NEXT_VERSION, JOB_STATUS, PUSH_RETRY_TRIGGERED
+# Expected env vars: BUMP_NEEDED, NEXT_VERSION, PUSH_FAILED, PUSH_RETRY_TRIGGERED
 set -euo pipefail
 
 {
   echo "## Release Version PR Status"
   if [ "${BUMP_NEEDED:-}" = "true" ]; then
-    if [ "${JOB_STATUS:-}" = "failure" ]; then
+    if [ "${PUSH_FAILED:-}" = "true" ]; then
       echo "❌ **Push failed** — release branch for v${NEXT_VERSION} could not be pushed."
       echo ""
       echo "Both the primary push attempt and the transient-error retry failed."

--- a/scripts/ci/push-with-retry.sh
+++ b/scripts/ci/push-with-retry.sh
@@ -16,7 +16,12 @@ REFSPEC="${2:?usage: push-with-retry.sh <remote> <refspec>}"
 
 MAX_RETRIES="${MAX_RETRIES:-3}"
 INITIAL_DELAY="${INITIAL_DELAY:-5}"
+# BACKOFF_MULTIPLIER must be a positive integer; bash $((...)) truncates floats silently.
 BACKOFF_MULTIPLIER="${BACKOFF_MULTIPLIER:-2}"
+if ! [[ "${BACKOFF_MULTIPLIER}" =~ ^[0-9]+$ ]]; then
+  echo "❌ BACKOFF_MULTIPLIER must be a non-negative integer, got: '${BACKOFF_MULTIPLIER}'"
+  exit 1
+fi
 
 attempt=1
 delay="${INITIAL_DELAY}"

--- a/scripts/ci/push-with-retry.sh
+++ b/scripts/ci/push-with-retry.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Retry git push with exponential backoff to handle transient GitHub remote rejections
+# (e.g. "remote: fatal error in commit_refs", "! [remote rejected]").
+#
+# Usage: push-with-retry.sh <remote> <refspec>
+#
+# Configuration (env vars):
+#   MAX_RETRIES         Maximum push attempts (default: 3)
+#   INITIAL_DELAY       Seconds before first retry (default: 5)
+#   BACKOFF_MULTIPLIER  Delay multiplier for each retry (default: 2)
+
+set -euo pipefail
+
+REMOTE="${1:?usage: push-with-retry.sh <remote> <refspec>}"
+REFSPEC="${2:?usage: push-with-retry.sh <remote> <refspec>}"
+
+MAX_RETRIES="${MAX_RETRIES:-3}"
+INITIAL_DELAY="${INITIAL_DELAY:-5}"
+BACKOFF_MULTIPLIER="${BACKOFF_MULTIPLIER:-2}"
+
+attempt=1
+delay="${INITIAL_DELAY}"
+
+echo "🚀 Pushing ${REFSPEC} to ${REMOTE} (max ${MAX_RETRIES} attempts)..."
+
+while true; do
+  if git push --force-with-lease "${REMOTE}" "${REFSPEC}"; then
+    echo "✅ Push succeeded on attempt ${attempt}"
+    exit 0
+  fi
+
+  if [[ ${attempt} -ge ${MAX_RETRIES} ]]; then
+    echo "❌ Push failed after ${MAX_RETRIES} attempts"
+    exit 1
+  fi
+
+  echo "⚠️  Attempt ${attempt}/${MAX_RETRIES} failed. Retrying in ${delay}s..."
+  sleep "${delay}"
+
+  attempt=$((attempt + 1))
+  delay=$((delay * BACKOFF_MULTIPLIER))
+done

--- a/scripts/ci/retry-release-branch-push.sh
+++ b/scripts/ci/retry-release-branch-push.sh
@@ -65,4 +65,4 @@ else
 fi
 
 echo "✅ PR #${PR_NUMBER} ready"
-echo "pull-request-number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+echo "pull-request-number=${PR_NUMBER}" >>"${GITHUB_OUTPUT}"

--- a/scripts/ci/retry-release-branch-push.sh
+++ b/scripts/ci/retry-release-branch-push.sh
@@ -47,21 +47,19 @@ if [[ -n "${EXISTING_PR}" ]]; then
   gh pr edit "${EXISTING_PR}" \
     --repo "${GITHUB_REPOSITORY}" \
     --title "${PR_TITLE}" \
-    --body-file "${PR_BODY_FILE}"
+    --body-file "${PR_BODY_FILE}" \
+    --add-label "release-bump"
   PR_NUMBER="${EXISTING_PR}"
 else
   echo "🆕 Creating new PR for '${RELEASE_BRANCH}'..."
-  gh pr create \
+  PR_URL=$(gh pr create \
     --repo "${GITHUB_REPOSITORY}" \
     --base main \
     --head "${RELEASE_BRANCH}" \
     --title "${PR_TITLE}" \
     --body-file "${PR_BODY_FILE}" \
-    --label "release-bump"
-  PR_NUMBER=$(gh pr view "${RELEASE_BRANCH}" \
-    --repo "${GITHUB_REPOSITORY}" \
-    --json number \
-    --jq '.number')
+    --label "release-bump")
+  PR_NUMBER="${PR_URL##*/}"
 fi
 
 echo "✅ PR #${PR_NUMBER} ready"

--- a/scripts/ci/retry-release-branch-push.sh
+++ b/scripts/ci/retry-release-branch-push.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Recovery script: push the release branch (with retry) and create/update the PR.
+# Called when peter-evans/create-pull-request fails due to a transient push rejection.
+#
+# Expects the local release branch to already exist (created by create-pull-request
+# before its push step failed). Retries the push via push-with-retry.sh, then
+# creates or updates the PR via the GitHub CLI.
+#
+# Required env vars (set by workflow step):
+#   RELEASE_BRANCH      e.g. release/version-1.2.3
+#   PR_TITLE            Pull request title
+#   PR_BODY_FILE        Path to file containing PR body markdown
+#   GH_TOKEN            GitHub App installation token with PR write access
+#   GITHUB_REPOSITORY   owner/repo  (injected by Actions runner)
+#   GITHUB_OUTPUT       Path to GITHUB_OUTPUT file  (injected by Actions runner)
+
+set -euo pipefail
+
+RELEASE_BRANCH="${RELEASE_BRANCH:?RELEASE_BRANCH is required}"
+PR_TITLE="${PR_TITLE:?PR_TITLE is required}"
+PR_BODY_FILE="${PR_BODY_FILE:?PR_BODY_FILE is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+chmod +x "${SCRIPT_DIR}/push-with-retry.sh"
+
+# Verify the local branch was created before the push failed.
+if ! git rev-parse --verify "refs/heads/${RELEASE_BRANCH}" &>/dev/null; then
+  echo "❌ Local branch '${RELEASE_BRANCH}' not found."
+  echo "   create-pull-request may have failed before creating the branch."
+  exit 1
+fi
+
+echo "🔁 Retrying push of '${RELEASE_BRANCH}' after transient rejection..."
+"${SCRIPT_DIR}/push-with-retry.sh" origin "${RELEASE_BRANCH}"
+
+# Create or update the PR.
+echo "🔍 Checking for an existing open PR for '${RELEASE_BRANCH}'..."
+EXISTING_PR=$(gh pr list \
+  --repo "${GITHUB_REPOSITORY}" \
+  --head "${RELEASE_BRANCH}" \
+  --state open \
+  --json number \
+  --jq '.[0].number // empty')
+
+if [[ -n "${EXISTING_PR}" ]]; then
+  echo "📝 Updating existing PR #${EXISTING_PR}..."
+  gh pr edit "${EXISTING_PR}" \
+    --repo "${GITHUB_REPOSITORY}" \
+    --title "${PR_TITLE}" \
+    --body-file "${PR_BODY_FILE}"
+  PR_NUMBER="${EXISTING_PR}"
+else
+  echo "🆕 Creating new PR for '${RELEASE_BRANCH}'..."
+  gh pr create \
+    --repo "${GITHUB_REPOSITORY}" \
+    --base main \
+    --head "${RELEASE_BRANCH}" \
+    --title "${PR_TITLE}" \
+    --body-file "${PR_BODY_FILE}" \
+    --label "release-bump"
+  PR_NUMBER=$(gh pr view "${RELEASE_BRANCH}" \
+    --repo "${GITHUB_REPOSITORY}" \
+    --json number \
+    --jq '.number')
+fi
+
+echo "✅ PR #${PR_NUMBER} ready"
+echo "pull-request-number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardening `release-version-pr.yml` so a transient `git push` rejection during `create-pull-request` is retried (with PR create/update recovery) instead of failing the release job with a stale branch.

## Type

- [x] 🐛 Bug fix (`fix:`)
- [x] 🔧 CI/CD (`ci:`)

## Changes Made

- Added `scripts/ci/push-with-retry.sh` and `retry-release-branch-push.sh`
- Wired continue-on-error + retry + hard-fail steps into `release-version-pr.yml`
- Improved version PR job summary messaging

## Closes

- Closes #535

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation resilience when release-branch pushes are temporarily rejected.
  * Added automatic retry with exponential backoff for transient push failures.
  * Updated recovery behavior to reuse an existing version PR when available, and to create one when not.
  * Ensured PR auto-merge continues to work after retry outcomes.
* **Documentation**
  * Enhanced the release workflow step summary with clearer statuses for success, push failure, retry recovery, and no-bump-needed cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens `release-version-pr.yml` against transient `git push` rejections by wrapping `peter-evans/create-pull-request` with `continue-on-error: true`, then running a retry script (`push-with-retry.sh` with exponential backoff) and a hard-fail step when recovery is not possible. All four issues flagged in the previous review round have been addressed.

- **Retry loop** (`push-with-retry.sh`): three attempts with configurable exponential backoff; `BACKOFF_MULTIPLIER` is now validated as a positive integer.
- **Recovery path** (`retry-release-branch-push.sh`): pushes the pre-created local branch, then finds or creates the version PR, writing `pull-request-number` to `$GITHUB_OUTPUT` so downstream steps (CODEOWNER review, auto-merge) work identically to the primary path.
- **Step summary** (`generate-version-pr-summary.sh`): adds distinct ✅/⚠️/❌ status lines for the success, retry-recovery, and failure cases.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the retry logic is well-scoped and all previously flagged correctness issues have been resolved.

The workflow conditional expressions, outcome checks, and output-forwarding are all logically consistent. The retry loop exits cleanly on both success and exhaustion, and the hard-fail step correctly gates on the combination of create_pr failure and push_retry non-success. The only remaining gap is that MAX_RETRIES and INITIAL_DELAY lack the same integer-format guard added for BACKOFF_MULTIPLIER, which would only bite on explicit misconfiguration.

scripts/ci/push-with-retry.sh — missing integer guards on MAX_RETRIES and INITIAL_DELAY

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-version-pr.yml | Wires the retry logic via continue-on-error on create_pr, a push_retry step, and a hard-fail step; conditional expressions and output fallbacks are all logically correct. |
| scripts/ci/push-with-retry.sh | Implements exponential-backoff retry for git push; adds integer guard for BACKOFF_MULTIPLIER but leaves MAX_RETRIES and INITIAL_DELAY unvalidated — non-integer values would abort under set -e. |
| scripts/ci/retry-release-branch-push.sh | Recovery script that verifies local branch, retries the push, then creates or updates the PR using the correct PR number extraction and label consistency; previous thread issues all resolved. |
| scripts/ci/generate-version-pr-summary.sh | Adds PUSH_FAILED and PUSH_RETRY_TRIGGERED branches to the step summary; correctly reads boolean strings from GitHub Actions expression outputs. |
| scripts/ci/fail-release-push.sh | Minimal terminal-failure marker script; correct and straightforward. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push to main] --> B[Create or update version PR\ncontinue-on-error: true]
    B -->|outcome: success| C[Request CODEOWNER Review]
    B -->|outcome: failure| D[Retry release branch push\npush-with-retry.sh with\nexponential backoff]
    D -->|push succeeds| E{Existing PR?}
    E -->|Yes| F[gh pr edit --title --body-file\n--add-label release-bump]
    E -->|No| G[gh pr create --label release-bump]
    F --> H[Write pull-request-number\nto GITHUB_OUTPUT]
    G --> H
    H --> C
    D -->|all retries fail| I[Fail if push could not\nbe completed\nfail-release-push.sh exit 1]
    C --> J[Enable auto-merge\ngh pr merge --auto --squash]
    J --> K[Generate Version PR Summary]
    I --> K
    B -->|outcome: success| K
    K -->|PUSH_FAILED=true| L[❌ Push failed summary]
    K -->|PUSH_RETRY_TRIGGERED=true| M[⚠️ Recovered via retry summary]
    K -->|normal| N[✅ PR created/updated summary]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[push to main] --> B[Create or update version PR\ncontinue-on-error: true]
    B -->|outcome: success| C[Request CODEOWNER Review]
    B -->|outcome: failure| D[Retry release branch push\npush-with-retry.sh with\nexponential backoff]
    D -->|push succeeds| E{Existing PR?}
    E -->|Yes| F[gh pr edit --title --body-file\n--add-label release-bump]
    E -->|No| G[gh pr create --label release-bump]
    F --> H[Write pull-request-number\nto GITHUB_OUTPUT]
    G --> H
    H --> C
    D -->|all retries fail| I[Fail if push could not\nbe completed\nfail-release-push.sh exit 1]
    C --> J[Enable auto-merge\ngh pr merge --auto --squash]
    J --> K[Generate Version PR Summary]
    I --> K
    B -->|outcome: success| K
    K -->|PUSH_FAILED=true| L[❌ Push failed summary]
    K -->|PUSH_RETRY_TRIGGERED=true| M[⚠️ Recovered via retry summary]
    K -->|normal| N[✅ PR created/updated summary]
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(release): address review feedback — ..."](https://github.com/lgtm-hq/turbo-themes/commit/2983d9e052a5c230fbf4b0aa13abba6c84d47242) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45149496)</sub>

<!-- /greptile_comment -->