### PR TITLE
fix(ci): bucket docs/style/refactor/perf/test/chore under Changed

### DIFF
--- a/scripts/ci/version-bump.mjs
+++ b/scripts/ci/version-bump.mjs
@@ -33,6 +33,16 @@ const CONFIG = {
   packageFile: join(projectRoot, 'package.json'),
 };
 
+// Enforce the invariant: every fixType must also be a patchType.
+for (const t of CONFIG.fixTypes) {
+  if (!CONFIG.patchTypes.includes(t)) {
+    throw new Error(
+      `CONFIG invariant violated: fixType "${t}" is not present in patchTypes. ` +
+        'Add it to patchTypes or remove it from fixTypes.',
+    );
+  }
+}
+
 /**
  * Parse conventional commit message
  */

--- a/scripts/ci/version-bump.mjs
+++ b/scripts/ci/version-bump.mjs
@@ -24,6 +24,9 @@ const CONFIG = {
   // The matching logic uses parseCommit() which extracts type from "type(scope):"
   minorTypes: ['feat', 'feature'],
   patchTypes: ['fix', 'bugfix', 'patch', 'docs', 'style', 'refactor', 'perf', 'test', 'chore'],
+  // Subset of patchTypes that represent true defect fixes (→ "🐛 Fixed" changelog bucket).
+  // All other patchTypes (docs, style, refactor, perf, test, chore) go to "🔧 Changed".
+  fixTypes: ['fix', 'bugfix', 'patch'],
   ignoreTypes: ['ci', 'build', 'release'],
   ignorePatterns: ['chore(release):'], // Full prefix patterns to skip entirely
   changelogFile: join(projectRoot, 'CHANGELOG.md'),
@@ -192,9 +195,10 @@ function generateChangelogEntry(commits, version, bumpType) {
       breaking.push(entry);
     } else if (CONFIG.minorTypes.includes(parsed.type)) {
       features.push(entry);
-    } else if (CONFIG.patchTypes.includes(parsed.type)) {
+    } else if (CONFIG.fixTypes.includes(parsed.type)) {
       fixes.push(entry);
     } else {
+      // docs, style, refactor, perf, test, chore → "### 🔧 Changed"
       others.push(entry);
     }
   }

--- a/test/validate-action-shas.test.ts
+++ b/test/validate-action-shas.test.ts
@@ -13,16 +13,20 @@ describe('validate-action-shas.sh', () => {
     expect(result).toBe('');
   });
 
-  test('validates SHA format in workflow files', () => {
-    // Run the script in format validation mode (should pass for our workflows)
-    const result = execSync(`bash "${scriptPath}"`, {
-      encoding: 'utf8',
-      env: { ...process.env, GITHUB_TOKEN: '' }, // No token to avoid API calls
-    });
+  test(
+    'validates SHA format in workflow files',
+    () => {
+      // Run the script in format validation mode (should pass for our workflows)
+      const result = execSync(`bash "${scriptPath}"`, {
+        encoding: 'utf8',
+        env: { ...process.env, GITHUB_TOKEN: '' }, // No token to avoid API calls
+      });
 
-    expect(result).toContain('✅ All SHAs pass format validation');
-    expect(result).toContain('Total unique SHAs found:');
-  });
+      expect(result).toContain('✅ All SHAs pass format validation');
+      expect(result).toContain('Total unique SHAs found:');
+    },
+    30_000,
+  );
 
   test('handles invalid arguments gracefully', () => {
     try {

--- a/test/version-bump.test.ts
+++ b/test/version-bump.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for generateChangelogEntry() bucketing logic in scripts/ci/version-bump.mjs.
+ *
+ * Regression coverage for GitHub issue #546: docs/style/refactor/perf/test/chore
+ * commits were incorrectly bucketed under "🐛 Fixed" instead of "🔧 Changed".
+ */
+import { describe, expect, it } from 'vitest';
+
+// version-bump.mjs is a plain Node ESM script; Vitest runs in Node so the
+// import is straightforward. The module only calls main() when import.meta.url
+// matches process.argv[1], so importing it here has no side-effects.
+const { generateChangelogEntry, determineBumpType } = await import(
+  '../scripts/ci/version-bump.mjs'
+);
+
+/**
+ * Simulate a git-log --oneline line the way getCommitsSinceLastTag() produces it.
+ */
+function fakeCommit(type: string, description: string, scope?: string): string {
+  const scopePart = scope ? `(${scope})` : '';
+  return `abc1234 ${type}${scopePart}: ${description}`;
+}
+
+describe('generateChangelogEntry – changelog section bucketing', () => {
+  describe('true fix types → ### 🐛 Fixed', () => {
+    it.each(['fix', 'bugfix', 'patch'] as const)(
+      '"%s" commit appears under Fixed',
+      (type) => {
+        const commits = [fakeCommit(type, 'resolve null pointer')];
+        const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
+        expect(entry).toContain('### 🐛 Fixed');
+        expect(entry).toContain('- resolve null pointer');
+        expect(entry).not.toContain('### 🔧 Changed');
+      },
+    );
+  });
+
+  describe('non-fix patch types → ### 🔧 Changed (not ### 🐛 Fixed)', () => {
+    it.each(['docs', 'style', 'refactor', 'perf', 'test', 'chore'] as const)(
+      '"%s" commit appears under Changed, not Fixed',
+      (type) => {
+        const commits = [fakeCommit(type, `update ${type} thing`)];
+        const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
+        expect(entry).toContain('### 🔧 Changed');
+        expect(entry).toContain(`- update ${type} thing`);
+        expect(entry).not.toContain('### 🐛 Fixed');
+      },
+    );
+  });
+
+  describe('issue #546 regression: docs-only release', () => {
+    it('docs commit is NOT listed under Fixed (reproduces 0.22.1 misclassification)', () => {
+      const commits = [
+        fakeCommit('docs', 'add AGENTS.md with Cursor Cloud dev environment instructions (#542)'),
+      ];
+      const entry = generateChangelogEntry(commits, '0.22.1', 'patch');
+
+      expect(entry).not.toContain('### 🐛 Fixed');
+      expect(entry).toContain('### 🔧 Changed');
+      expect(entry).toContain(
+        '- add AGENTS.md with Cursor Cloud dev environment instructions (#542)',
+      );
+    });
+  });
+
+  describe('feat types → ### ✨ Added', () => {
+    it.each(['feat', 'feature'] as const)('"%s" commit appears under Added', (type) => {
+      const commits = [fakeCommit(type, 'add dark mode toggle')];
+      const entry = generateChangelogEntry(commits, '1.1.0', 'minor');
+      expect(entry).toContain('### ✨ Added');
+      expect(entry).toContain('- add dark mode toggle');
+      expect(entry).not.toContain('### 🐛 Fixed');
+      expect(entry).not.toContain('### 🔧 Changed');
+    });
+  });
+
+  describe('ignored types are omitted entirely', () => {
+    it.each(['ci', 'build', 'release'] as const)(
+      '"%s" commits do not appear in changelog',
+      (type) => {
+        const commits = [
+          fakeCommit(type, 'update workflow'),
+          fakeCommit('fix', 'real fix'), // ensure bumpType is non-null
+        ];
+        const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
+        expect(entry).not.toContain('update workflow');
+      },
+    );
+  });
+
+  describe('mixed release with multiple types', () => {
+    it('routes each type to the correct section', () => {
+      const commits = [
+        fakeCommit('feat', 'add theme export'),
+        fakeCommit('fix', 'fix token import'),
+        fakeCommit('docs', 'update README'),
+        fakeCommit('chore', 'bump deps'),
+        fakeCommit('refactor', 'simplify renderer'),
+        fakeCommit('ci', 'add lint job'), // should be ignored
+      ];
+      const entry = generateChangelogEntry(commits, '1.1.1', 'minor');
+
+      expect(entry).toContain('### ✨ Added');
+      expect(entry).toContain('- add theme export');
+
+      expect(entry).toContain('### 🐛 Fixed');
+      expect(entry).toContain('- fix token import');
+
+      expect(entry).toContain('### 🔧 Changed');
+      expect(entry).toContain('- update README');
+      expect(entry).toContain('- bump deps');
+      expect(entry).toContain('- simplify renderer');
+
+      expect(entry).not.toContain('add lint job');
+    });
+  });
+
+  describe('scoped commits', () => {
+    it('docs(site) commit goes to Changed, not Fixed', () => {
+      const commits = [fakeCommit('docs', 'add API reference', 'site')];
+      const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
+      expect(entry).toContain('### 🔧 Changed');
+      expect(entry).not.toContain('### 🐛 Fixed');
+    });
+
+    it('fix(core) commit goes to Fixed', () => {
+      const commits = [fakeCommit('fix', 'resolve token lookup', 'core')];
+      const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
+      expect(entry).toContain('### 🐛 Fixed');
+      expect(entry).not.toContain('### 🔧 Changed');
+    });
+  });
+});
+
+describe('determineBumpType – patchTypes still trigger patch bump', () => {
+  it.each(['docs', 'style', 'refactor', 'perf', 'test', 'chore'] as const)(
+    '"%s" commit triggers a patch bump',
+    (type) => {
+      const commits = [fakeCommit(type, 'some change')];
+      const bumpType = determineBumpType(commits);
+      expect(bumpType).toBe('patch');
+    },
+  );
+
+  it.each(['fix', 'bugfix', 'patch'] as const)(
+    '"%s" commit triggers a patch bump',
+    (type) => {
+      const commits = [fakeCommit(type, 'some fix')];
+      const bumpType = determineBumpType(commits);
+      expect(bumpType).toBe('patch');
+    },
+  );
+});

--- a/test/version-bump.test.ts
+++ b/test/version-bump.test.ts
@@ -80,7 +80,7 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
       (type) => {
         const commits = [
           fakeCommit(type, 'update workflow'),
-          fakeCommit('fix', 'real fix'), // ensure bumpType is non-null
+          fakeCommit('fix', 'real fix'), // included so the entry is non-empty (ignored types produce no output)
         ];
         const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
         expect(entry).not.toContain('update workflow');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changelog generation was dumping non-feature patch types under Features/Fixed incorrectly. Route true fix types to Fixed and other patch-triggering types (docs/style/refactor/perf/test/chore) to Changed, without altering bump-type logic.

## Type

- [x] 🐛 Bug fix (`fix:`)
- [x] 🔧 CI/CD (`ci:`)

## Changes Made

- `scripts/ci/version-bump.mjs` changelog bucketing via `fixTypes`
- Added `test/version-bump.test.ts` covering the 0.22.1 regression scenario

## Closes

- Closes #546

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changelog**
  * Improved release notes categorization so true bug fixes appear under **Fixed**.
  * Documentation, styling, refactoring, performance, testing, and maintenance changes now appear under **Changed**.
  * Feature additions continue to appear under **Added**, while internal release-management entries remain excluded.

* **Tests**
  * Added coverage for scoped commits, mixed releases, ignored commit types, and regression scenarios to ensure accurate changelog sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes changelog bucketing in `scripts/ci/version-bump.mjs` by introducing a `fixTypes` subset of `patchTypes`, so `docs`/`style`/`refactor`/`perf`/`test`/`chore` commits are correctly routed to "🔧 Changed" rather than "🐛 Fixed". A module-level invariant guard ensures `fixTypes` stays a valid subset of `patchTypes` at import time.

- **`scripts/ci/version-bump.mjs`**: adds `fixTypes: ['fix', 'bugfix', 'patch']` to `CONFIG`, replaces the `patchTypes` check in `generateChangelogEntry` with `fixTypes`, and adds a startup invariant that throws if any `fixType` is absent from `patchTypes`.
- **`test/version-bump.test.ts`** (new): full regression suite covering each bucket, the exact #546 scenario, scoped commits, mixed releases, and `determineBumpType` patch-trigger verification.
- **`test/validate-action-shas.test.ts`**: adds an explicit 30-second timeout to the slow bash-script test, preventing flaky failures in CI.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, targeted bucketing fix with no impact on version-bump logic, and is fully covered by a new regression test suite.

The diff touches only the changelog section-assignment branch in `generateChangelogEntry` and adds a defensive invariant. The `determineBumpType` path is entirely unchanged, so version bumps are unaffected. The new test file directly reproduces the #546 regression scenario and covers every commit type in both buckets.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/version-bump.mjs | Correctly scopes changelog "Fixed" bucket to true fix types via `fixTypes`; adds module-level invariant guard; bump-type logic is unchanged. |
| test/version-bump.test.ts | Comprehensive regression suite for the bucketing fix; covers all patch subtypes, scoped commits, mixed releases, and the exact #546 scenario. |
| test/validate-action-shas.test.ts | Adds explicit 30 s timeout to the SHA-validation test to prevent flaky CI failures on slower runners. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[commit] --> B{parseCommit}
    B -->|null| Z[skip]
    B -->|parsed| C{in ignoreTypes?}
    C -->|yes| Z
    C -->|no| D{matches ignorePatterns?}
    D -->|yes| Z
    D -->|no| E{breaking change?}
    E -->|yes| F["⚠️ BREAKING CHANGES"]
    E -->|no| G{in minorTypes?}
    G -->|yes| H["✨ Added"]
    G -->|no| I{in fixTypes?\nfix / bugfix / patch}
    I -->|yes| J["🐛 Fixed"]
    I -->|no| K["🔧 Changed\ndocs / style / refactor\nperf / test / chore"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[commit] --> B{parseCommit}
    B -->|null| Z[skip]
    B -->|parsed| C{in ignoreTypes?}
    C -->|yes| Z
    C -->|no| D{matches ignorePatterns?}
    D -->|yes| Z
    D -->|no| E{breaking change?}
    E -->|yes| F["⚠️ BREAKING CHANGES"]
    E -->|no| G{in minorTypes?}
    G -->|yes| H["✨ Added"]
    G -->|no| I{in fixTypes?\nfix / bugfix / patch}
    I -->|yes| J["🐛 Fixed"]
    I -->|no| K["🔧 Changed\ndocs / style / refactor\nperf / test / chore"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): fix misleading test comment and..."](https://github.com/lgtm-hq/turbo-themes/commit/ff81083282f099f00ec2a17da576907b0e0636d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45149503)</sub>

<!-- /greptile_comment -->