### PR TITLE
chore(ci): fix Playwright CDN mirror fallback and DEP0066 E2E warning

### DIFF
--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -107,6 +107,8 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - name: Install Playwright browsers
+        env:
+          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev
         run: bun run e2e:install
       - name: Build Astro site
         run: bun run e2e:prep

--- a/scripts/e2e-serve.mjs
+++ b/scripts/e2e-serve.mjs
@@ -2,7 +2,7 @@
 
 /**
  * Cross-platform script to prepare and serve the Astro site for E2E tests.
- * This script runs the build prep and then starts http-server.
+ * This script runs the build prep and then starts astro preview.
  */
 
 import { execSync, spawn } from 'child_process';
@@ -36,49 +36,47 @@ try {
     });
   }
 
-  // Step 2: Start http-server
+  // Step 2: Start astro preview
   const host = process.env.HOST ?? '127.0.0.1';
   const port = Number(process.env.PORT ?? 4173);
   if (isNaN(port) || port < 1 || port > 65535) {
     console.error(`Invalid PORT: ${process.env.PORT}. Must be a number between 1 and 65535.`);
     process.exit(1);
   }
-  console.log(`Starting http-server on http://${host}:${port}...`);
+  console.log(`Starting astro preview on http://${host}:${port}...`);
   const bunxCmd = process.platform === 'win32' ? 'bunx.cmd' : 'bunx';
   const serverArgs = [
     '--no-install',
-    'http-server',
-    'apps/site/dist',
-    '-a',
-    host,
-    '-p',
+    'astro',
+    'preview',
+    '--port',
     String(port),
-    '-c-1',
-    '-s',
+    '--host',
+    host,
   ];
   const serverProcess = spawn(bunxCmd, serverArgs, {
-    cwd: rootDir,
+    cwd: join(rootDir, 'apps', 'site'),
     stdio: 'inherit',
   });
   // Handle spawn errors
   serverProcess.on('error', (error) => {
-    console.error('Failed to start http-server:', error.message);
+    console.error('Failed to start astro preview:', error.message);
     process.exit(1);
   });
 
   // Handle server process exit
   serverProcess.on('exit', (code, signal) => {
     if (signal) {
-      console.log(`http-server terminated by signal: ${signal}`);
+      console.log(`astro preview terminated by signal: ${signal}`);
     } else if (code !== null && code !== 0) {
-      console.error(`http-server exited with code: ${code}`);
+      console.error(`astro preview exited with code: ${code}`);
       process.exit(code);
     }
   });
 
   // Shutdown handling: kill server on process termination
   const shutdown = (signal) => {
-    console.log(`\nReceived ${signal}, shutting down http-server...`);
+    console.log(`\nReceived ${signal}, shutting down astro preview...`);
     if (serverProcess && !serverProcess.killed) {
       serverProcess.kill(signal);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pin Playwright browser downloads to the direct CDN host (avoid dbazure mirror ECONNREFUSED behind harden-runner) and replace `http-server` with `astro preview` for E2E serving to eliminate DEP0066 `_headers` warnings.

## Type

- [x] 🔧 CI/CD (`ci:`)
- [x] 🔨 Chore (`chore:`)

## Changes Made

- `PLAYWRIGHT_DOWNLOAD_HOST` in E2E install step
- `scripts/e2e-serve.mjs` uses Astro preview instead of http-server

## Closes

- Closes #540

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two CI reliability issues: it pins Playwright browser downloads to `cdn.playwright.dev` (avoiding Azure CDN mirrors that fail under harden-runner's egress block) and replaces the `http-server`-based E2E serving script with `astro preview`.

- **Workflow change** (`.github/workflows/quality-e2e.yml`): adds `PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev` as a step-scoped env var on the "Install Playwright browsers" step; `cdn.playwright.dev:443` was already in the harden-runner allowed-endpoints list, so no allow-list update is required.
- **Serve script change** (`scripts/e2e-serve.mjs`): migrates from `bunx http-server apps/site/dist` (spawned from repo root) to `bunx astro preview --port … --host …` (spawned from `apps/site`), eliminating the `DEP0066 _headers` deprecation warning triggered by `http-server`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are targeted CI fixes with no effect on application code or test logic.

The workflow change is self-consistent: the new download host is already in the harden-runner allow-list, so no egress policy gap is introduced. The serve-script migration to astro preview correctly updates the spawn cwd, command arguments, and all log/error strings. The only remaining artifact is four now-redundant Azure CDN entries in the allow-list, which is harmless dead config rather than a functional defect.

No files require special attention. The four stale Azure CDN allow-list entries in .github/workflows/quality-e2e.yml are worth cleaning up but pose no risk.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/quality-e2e.yml | Adds PLAYWRIGHT_DOWNLOAD_HOST env var scoped to the browser install step; cdn.playwright.dev is already in harden-runner's allowed-endpoints, making the fix self-consistent. Stale Azure CDN entries remain in the allow-list but are harmless. |
| scripts/e2e-serve.mjs | Replaces bunx http-server with bunx astro preview, updating cwd to apps/site and switching flags to Astro's --port/--host interface; all signal and exit handlers updated consistently. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant HR as Harden Runner
    participant CDN as cdn.playwright.dev
    participant BUN as bun / bunx
    participant AP as astro preview

    GH->>HR: Start job (egress-policy: block)
    Note over HR: allowed: cdn.playwright.dev:443

    GH->>BUN: bun run e2e:install
    Note over BUN: PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.playwright.dev
    BUN->>CDN: Download browser binaries
    CDN-->>BUN: Browser binaries

    GH->>BUN: bun run e2e:prep (Astro build)
    BUN-->>GH: dist/ ready

    GH->>BUN: node scripts/e2e-serve.mjs
    BUN->>AP: bunx astro preview --port 4173 --host 127.0.0.1
    Note over AP: cwd: apps/site
    AP-->>GH: Serving on http://127.0.0.1:4173

    GH->>GH: bun run e2e:ci / e2e:smoke / e2e:a11y
    GH->>AP: HTTP requests (Playwright tests)
    AP-->>GH: Responses

    GH->>AP: SIGTERM (shutdown)
    AP-->>GH: Exit 0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant HR as Harden Runner
    participant CDN as cdn.playwright.dev
    participant BUN as bun / bunx
    participant AP as astro preview

    GH->>HR: Start job (egress-policy: block)
    Note over HR: allowed: cdn.playwright.dev:443

    GH->>BUN: bun run e2e:install
    Note over BUN: PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.playwright.dev
    BUN->>CDN: Download browser binaries
    CDN-->>BUN: Browser binaries

    GH->>BUN: bun run e2e:prep (Astro build)
    BUN-->>GH: dist/ ready

    GH->>BUN: node scripts/e2e-serve.mjs
    BUN->>AP: bunx astro preview --port 4173 --host 127.0.0.1
    Note over AP: cwd: apps/site
    AP-->>GH: Serving on http://127.0.0.1:4173

    GH->>GH: bun run e2e:ci / e2e:smoke / e2e:a11y
    GH->>AP: HTTP requests (Playwright tests)
    AP-->>GH: Responses

    GH->>AP: SIGTERM (shutdown)
    AP-->>GH: Exit 0
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/quality-e2e.yml`, line 79-82 ([link](https://github.com/lgtm-hq/turbo-themes/blob/ae122eca6d16723bcaa555c5df8fb190fac7e7b5/.github/workflows/quality-e2e.yml#L79-L82)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Now that `PLAYWRIGHT_DOWNLOAD_HOST` is pinned to `cdn.playwright.dev`, the four Azure CDN entries below are never reached. Leaving them in the allow-list widens the permitted egress surface unnecessarily and may cause confusion for future maintainers trying to understand why they exist.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fquality-e2e.yml%0ALine%3A%2079-82%0A%0AComment%3A%0ANow%20that%20%60PLAYWRIGHT_DOWNLOAD_HOST%60%20is%20pinned%20to%20%60cdn.playwright.dev%60%2C%20the%20four%20Azure%20CDN%20entries%20below%20are%20never%20reached.%20Leaving%20them%20in%20the%20allow-list%20widens%20the%20permitted%20egress%20surface%20unnecessarily%20and%20may%20cause%20confusion%20for%20future%20maintainers%20trying%20to%20understand%20why%20they%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Azure%20CDN%20mirrors%20removed%20%E2%80%94%20PLAYWRIGHT_DOWNLOAD_HOST%20pins%20downloads%20to%20cdn.playwright.dev%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fquality-e2e.yml%0ALine%3A%2079-82%0A%0AComment%3A%0ANow%20that%20%60PLAYWRIGHT_DOWNLOAD_HOST%60%20is%20pinned%20to%20%60cdn.playwright.dev%60%2C%20the%20four%20Azure%20CDN%20entries%20below%20are%20never%20reached.%20Leaving%20them%20in%20the%20allow-list%20widens%20the%20permitted%20egress%20surface%20unnecessarily%20and%20may%20cause%20confusion%20for%20future%20maintainers%20trying%20to%20understand%20why%20they%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Azure%20CDN%20mirrors%20removed%20%E2%80%94%20PLAYWRIGHT_DOWNLOAD_HOST%20pins%20downloads%20to%20cdn.playwright.dev%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F540-playwright-warnings-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F540-playwright-warnings-6221%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fquality-e2e.yml%0ALine%3A%2079-82%0A%0AComment%3A%0ANow%20that%20%60PLAYWRIGHT_DOWNLOAD_HOST%60%20is%20pinned%20to%20%60cdn.playwright.dev%60%2C%20the%20four%20Azure%20CDN%20entries%20below%20are%20never%20reached.%20Leaving%20them%20in%20the%20allow-list%20widens%20the%20permitted%20egress%20surface%20unnecessarily%20and%20may%20cause%20confusion%20for%20future%20maintainers%20trying%20to%20understand%20why%20they%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Azure%20CDN%20mirrors%20removed%20%E2%80%94%20PLAYWRIGHT_DOWNLOAD_HOST%20pins%20downloads%20to%20cdn.playwright.dev%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fquality-e2e.yml%3A79-82%0ANow%20that%20%60PLAYWRIGHT_DOWNLOAD_HOST%60%20is%20pinned%20to%20%60cdn.playwright.dev%60%2C%20the%20four%20Azure%20CDN%20entries%20below%20are%20never%20reached.%20Leaving%20them%20in%20the%20allow-list%20widens%20the%20permitted%20egress%20surface%20unnecessarily%20and%20may%20cause%20confusion%20for%20future%20maintainers%20trying%20to%20understand%20why%20they%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Azure%20CDN%20mirrors%20removed%20%E2%80%94%20PLAYWRIGHT_DOWNLOAD_HOST%20pins%20downloads%20to%20cdn.playwright.dev%0A%60%60%60%0A%0A&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fquality-e2e.yml%3A79-82%0ANow%20that%20%60PLAYWRIGHT_DOWNLOAD_HOST%60%20is%20pinned%20to%20%60cdn.playwright.dev%60%2C%20the%20four%20Azure%20CDN%20entries%20below%20are%20never%20reached.%20Leaving%20them%20in%20the%20allow-list%20widens%20the%20permitted%20egress%20surface%20unnecessarily%20and%20may%20cause%20confusion%20for%20future%20maintainers%20trying%20to%20understand%20why%20they%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Azure%20CDN%20mirrors%20removed%20%E2%80%94%20PLAYWRIGHT_DOWNLOAD_HOST%20pins%20downloads%20to%20cdn.playwright.dev%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F540-playwright-warnings-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F540-playwright-warnings-6221%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fquality-e2e.yml%3A79-82%0ANow%20that%20%60PLAYWRIGHT_DOWNLOAD_HOST%60%20is%20pinned%20to%20%60cdn.playwright.dev%60%2C%20the%20four%20Azure%20CDN%20entries%20below%20are%20never%20reached.%20Leaving%20them%20in%20the%20allow-list%20widens%20the%20permitted%20egress%20surface%20unnecessarily%20and%20may%20cause%20confusion%20for%20future%20maintainers%20trying%20to%20understand%20why%20they%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Azure%20CDN%20mirrors%20removed%20%E2%80%94%20PLAYWRIGHT_DOWNLOAD_HOST%20pins%20downloads%20to%20cdn.playwright.dev%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(e2e): replace http-server with astro..."](https://github.com/lgtm-hq/turbo-themes/commit/ae122eca6d16723bcaa555c5df8fb190fac7e7b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45149510)</sub>

<!-- /greptile_comment -->