### PR TITLE
feat(selector): ship theme icon images in npm package

### DIFF
--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -416,27 +416,29 @@ node_modules/@lgtm-hq/turbo-themes/assets/img/
 
 ```bash
 # package.json postinstall, or build script:
-cp -r node_modules/@lgtm-hq/turbo-themes/assets/img public/assets/img
+mkdir -p public/assets
+cp -r node_modules/@lgtm-hq/turbo-themes/assets/img public/assets/
 ```
 
-Then pass your site's base URL to `wireFlavorSelector`:
+The selector reads the base URL from the `data-baseurl` attribute on `<html>`. With
+icons copied to `public/assets/img`, the default empty-string base URL works
+automatically:
 
 ```typescript
 import { wireFlavorSelector } from '@lgtm-hq/turbo-themes/selector';
 
-// icons resolve to: <baseUrl>/assets/img/<icon>
 await wireFlavorSelector(document, window);
 ```
 
-### Option 2 — Bundler asset import (Vite / webpack)
+### Option 2 — Bundler (Vite / webpack)
 
-```typescript
-// vite.config.ts — copy assets/img at build time
-import { defineConfig } from 'vite';
+Copy the icons during the build using a postinstall script or a copy plugin (e.g.
+`vite-plugin-static-copy`), then serve them from a known path:
 
-export default defineConfig({
-  assetsInclude: ['**/*.png', '**/*.webp'],
-});
+```bash
+# Same postinstall script as Option 1, runs before the bundler build:
+mkdir -p public/assets
+cp -r node_modules/@lgtm-hq/turbo-themes/assets/img public/assets/
 ```
 
 ### Option 3 — CDN / URL override

--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -376,7 +376,7 @@ onMounted(() => {
   onMount(() => {
     const stored = localStorage.getItem('turbo-theme');
     if (stored && themeIds.includes(stored)) {
-      currentTheme = stored;
+      setTheme(stored);
     }
   });
 </script>

--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -390,9 +390,8 @@ onMounted(() => {
 
 ## Theme Selector Icons
 
-The `@lgtm-hq/turbo-themes` npm package ships theme icon images under
-`assets/img/` so the selector is fully self-contained — no manual asset
-downloading required.
+The `@lgtm-hq/turbo-themes` npm package ships theme icon images under `assets/img/` so
+the selector is fully self-contained — no manual asset downloading required.
 
 ### Icons shipped with the package
 
@@ -442,8 +441,8 @@ export default defineConfig({
 
 ### Option 3 — CDN / URL override
 
-Pass a custom `baseUrl` via `data-turbo-base-url` on the `<script>` tag or
-configure the selector `baseUrl` option to point at any URL serving the icons.
+Pass a custom `baseUrl` via `data-turbo-base-url` on the `<script>` tag or configure the
+selector `baseUrl` option to point at any URL serving the icons.
 
 ## Next Steps
 

--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -443,8 +443,14 @@ cp -r node_modules/@lgtm-hq/turbo-themes/assets/img public/assets/
 
 ### Option 3 — CDN / URL override
 
-Pass a custom `baseUrl` via `data-turbo-base-url` on the `<script>` tag or configure the
-selector `baseUrl` option to point at any URL serving the icons.
+Set `data-baseurl` on the `<html>` element to point asset resolution at any same-origin
+path prefix serving the icons (protocol-relative and cross-origin URLs are rejected):
+
+```html
+<html data-baseurl="/my-app">
+  <!-- icons resolve to: /my-app/assets/img/<icon> -->
+</html>
+```
 
 ## Next Steps
 

--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -354,6 +354,97 @@ onMounted(() => {
 </template>
 ```
 
+### With Svelte
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { themeIds, DEFAULT_THEME } from '@lgtm-hq/turbo-themes';
+
+  let currentTheme: string = DEFAULT_THEME;
+
+  function setTheme(theme: string) {
+    currentTheme = theme;
+    localStorage.setItem('turbo-theme', theme);
+
+    const link = document.getElementById('theme-css') as HTMLLinkElement;
+    if (link) {
+      link.href = `/css/themes/turbo/${theme}.css`;
+    }
+  }
+
+  onMount(() => {
+    const stored = localStorage.getItem('turbo-theme');
+    if (stored && themeIds.includes(stored)) {
+      currentTheme = stored;
+    }
+  });
+</script>
+
+<select bind:value={currentTheme} on:change={() => setTheme(currentTheme)}>
+  {#each themeIds as theme}
+    <option value={theme}>{theme}</option>
+  {/each}
+</select>
+```
+
+## Theme Selector Icons
+
+The `@lgtm-hq/turbo-themes` npm package ships theme icon images under
+`assets/img/` so the selector is fully self-contained — no manual asset
+downloading required.
+
+### Icons shipped with the package
+
+```
+node_modules/@lgtm-hq/turbo-themes/assets/img/
+  turbo-themes-logo.png
+  catppuccin-logo-latte.png
+  catppuccin-logo-macchiato.png
+  dracula-logo.png
+  gruvbox-light.png / gruvbox-dark.png
+  github-logo-light.png / github-logo-dark.png
+  nord.png
+  rose-pine-dawn.png / rose-pine.png
+  solarized-light.png / solarized-dark.png
+  tokyo-night.png
+  … (plus .webp variants for every PNG)
+```
+
+### Serving icons in your app
+
+### Option 1 — Copy to your public directory (recommended for static sites)
+
+```bash
+# package.json postinstall, or build script:
+cp -r node_modules/@lgtm-hq/turbo-themes/assets/img public/assets/img
+```
+
+Then pass your site's base URL to `wireFlavorSelector`:
+
+```typescript
+import { wireFlavorSelector } from '@lgtm-hq/turbo-themes/selector';
+
+// icons resolve to: <baseUrl>/assets/img/<icon>
+await wireFlavorSelector(document, window);
+```
+
+### Option 2 — Bundler asset import (Vite / webpack)
+
+```typescript
+// vite.config.ts — copy assets/img at build time
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  assetsInclude: ['**/*.png', '**/*.webp'],
+});
+```
+
+### Option 3 — CDN / URL override
+
+Pass a custom `baseUrl` via `data-turbo-base-url` on the `<script>` tag or
+configure the selector `baseUrl` option to point at any URL serving the icons.
+
 ## Next Steps
 
 - Explore [theme switching guide](/docs/guides/theme-switching/)

--- a/package.json
+++ b/package.json
@@ -99,7 +99,9 @@
     "packages/adapters/*/dist/**",
     "assets/css/themes/*.css",
     "assets/css/turbo-core.css",
-    "assets/css/adapters/*.css"
+    "assets/css/adapters/*.css",
+    "assets/img/*.png",
+    "assets/img/*.webp"
   ],
   "scripts": {
     "build": "bun run build:tokens && bun run build:packages && bun run theme:sync && bun run build:root && node scripts/copy-adapters.mjs && bun run generate:css",

--- a/packages/theme-selector/src/persistence.ts
+++ b/packages/theme-selector/src/persistence.ts
@@ -65,6 +65,9 @@ export function needsCssUpdate(
   return themeId !== defaultTheme;
 }
 
+/** Default fallback icon filename used when no theme-specific icon is found. */
+export const FALLBACK_ICON_FILE = 'catppuccin-logo-macchiato.png';
+
 /**
  * Builds the theme icon image src path.
  */
@@ -72,7 +75,7 @@ export function buildThemeIconSrc(
   baseUrl: string,
   themeIcons: Record<string, string>,
   themeId: string,
-  fallbackIcon: string = 'catppuccin-logo-macchiato.png',
+  fallbackIcon: string = FALLBACK_ICON_FILE,
 ): string {
   return `${baseUrl}/assets/img/${themeIcons[themeId] || fallbackIcon}`;
 }

--- a/packages/theme-selector/src/theme-mapper.ts
+++ b/packages/theme-selector/src/theme-mapper.ts
@@ -43,12 +43,12 @@ const VENDOR_FAMILY_MAP: Record<string, ThemeFamily> = {
 const DEFAULT_FAMILY: ThemeFamily = 'bulma';
 
 /** Icon configuration - string for single icon, object for appearance-specific */
-interface AppearanceIcons {
+export interface AppearanceIcons {
   light: string;
   dark: string;
 }
 
-const VENDOR_ICON_MAP: Record<string, string | AppearanceIcons> = {
+export const VENDOR_ICON_MAP: Record<string, string | AppearanceIcons> = {
   bulma: 'assets/img/turbo-themes-logo.png',
   catppuccin: {
     light: 'assets/img/catppuccin-logo-latte.png',

--- a/packages/theme-selector/test/theme-icon-npm.test.ts
+++ b/packages/theme-selector/test/theme-icon-npm.test.ts
@@ -11,26 +11,31 @@ import { join } from 'node:path';
 import { createRequire } from 'node:module';
 import { describe, expect, it } from 'vitest';
 import { VENDOR_ICON_MAP, type AppearanceIcons } from '../src/theme-mapper.js';
+import { FALLBACK_ICON_FILE } from '../src/persistence.js';
 
 const require = createRequire(import.meta.url);
 
 // Repo root is 3 levels up from packages/theme-selector/test/
 const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
 
-/** Fallback icon used by buildThemeIconSrc when no themeIcons entry exists */
-const FALLBACK_ICON = 'catppuccin-logo-macchiato.png';
-
 /** Globs from package.json `files` that should cover assets/img/ */
 const IMG_GLOBS = ['assets/img/*.png', 'assets/img/*.webp'];
 
 function isAppearanceIcons(v: string | AppearanceIcons): v is AppearanceIcons {
-  return typeof v === 'object' && v !== null && 'light' in v && 'dark' in v;
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'light' in v &&
+    'dark' in v &&
+    typeof (v as AppearanceIcons).light === 'string' &&
+    typeof (v as AppearanceIcons).dark === 'string'
+  );
 }
 
 /** Collect every relative path referenced in VENDOR_ICON_MAP */
 function collectIconPaths(): string[] {
   const paths = new Set<string>();
-  paths.add(`assets/img/${FALLBACK_ICON}`);
+  paths.add(`assets/img/${FALLBACK_ICON_FILE}`);
   for (const config of Object.values(VENDOR_ICON_MAP)) {
     if (typeof config === 'string') {
       paths.add(config);
@@ -44,11 +49,16 @@ function collectIconPaths(): string[] {
 
 /** Check whether a relative asset path is covered by the files globs */
 function coveredByFilesGlob(relativePath: string): boolean {
-  // Simple glob match: `assets/img/*.ext` covers any file directly in assets/img/
+  // Match `assets/img/*.ext`: file must be directly in assets/img/ (no subdirectories)
   return IMG_GLOBS.some(glob => {
     const prefix = glob.slice(0, glob.lastIndexOf('/') + 1); // "assets/img/"
     const suffix = glob.slice(glob.lastIndexOf('*') + 1); // ".png" or ".webp"
-    return relativePath.startsWith(prefix) && relativePath.endsWith(suffix);
+    const fileName = relativePath.slice(prefix.length);
+    return (
+      relativePath.startsWith(prefix) &&
+      relativePath.endsWith(suffix) &&
+      !fileName.includes('/')
+    );
   });
 }
 

--- a/packages/theme-selector/test/theme-icon-npm.test.ts
+++ b/packages/theme-selector/test/theme-icon-npm.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Drift-prevention test: every icon referenced by VENDOR_ICON_MAP and the
+ * buildThemeIconSrc fallback must exist on disk AND be matched by the
+ * `files` glob in the root package.json.
+ *
+ * Prevents the npm tarball from shipping without the icons it references.
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+import { VENDOR_ICON_MAP, type AppearanceIcons } from '../src/theme-mapper.js';
+
+const require = createRequire(import.meta.url);
+
+// Repo root is 3 levels up from packages/theme-selector/test/
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+/** Fallback icon used by buildThemeIconSrc when no themeIcons entry exists */
+const FALLBACK_ICON = 'catppuccin-logo-macchiato.png';
+
+/** Globs from package.json `files` that should cover assets/img/ */
+const IMG_GLOBS = ['assets/img/*.png', 'assets/img/*.webp'];
+
+function isAppearanceIcons(v: string | AppearanceIcons): v is AppearanceIcons {
+  return typeof v === 'object' && v !== null && 'light' in v && 'dark' in v;
+}
+
+/** Collect every relative path referenced in VENDOR_ICON_MAP */
+function collectIconPaths(): string[] {
+  const paths = new Set<string>();
+  paths.add(`assets/img/${FALLBACK_ICON}`);
+  for (const config of Object.values(VENDOR_ICON_MAP)) {
+    if (typeof config === 'string') {
+      paths.add(config);
+    } else if (isAppearanceIcons(config)) {
+      paths.add(config.light);
+      paths.add(config.dark);
+    }
+  }
+  return [...paths];
+}
+
+/** Check whether a relative asset path is covered by the files globs */
+function coveredByFilesGlob(relativePath: string): boolean {
+  // Simple glob match: `assets/img/*.ext` covers any file directly in assets/img/
+  return IMG_GLOBS.some(glob => {
+    const prefix = glob.slice(0, glob.lastIndexOf('/') + 1); // "assets/img/"
+    const suffix = glob.slice(glob.lastIndexOf('*') + 1); // ".png" or ".webp"
+    return relativePath.startsWith(prefix) && relativePath.endsWith(suffix);
+  });
+}
+
+describe('icon npm packaging', () => {
+  const iconPaths = collectIconPaths();
+
+  it('VENDOR_ICON_MAP references at least the core icon set', () => {
+    expect(iconPaths.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it.each(iconPaths)('icon file exists on disk: %s', (iconPath) => {
+    const absPath = join(REPO_ROOT, iconPath);
+    expect(existsSync(absPath), `Expected ${iconPath} to exist at ${absPath}`).toBe(true);
+  });
+
+  it.each(iconPaths)('icon path is covered by package.json files glob: %s', (iconPath) => {
+    expect(coveredByFilesGlob(iconPath), `Expected ${iconPath} to match one of ${IMG_GLOBS.join(', ')}`).toBe(true);
+  });
+
+  it('package.json files field contains assets/img/*.png', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require(join(REPO_ROOT, 'package.json')) as { files: string[] };
+    expect(pkg.files).toContain('assets/img/*.png');
+  });
+
+  it('package.json files field contains assets/img/*.webp', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require(join(REPO_ROOT, 'package.json')) as { files: string[] };
+    expect(pkg.files).toContain('assets/img/*.webp');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Include theme icon assets in the published npm package `files` list and export icon maps so consumers can resolve vendor icons without copying assets manually. Adds a drift-prevention test.

## Type

- [x] ✨ Feature (`feat:`)

## Changes Made

- Added `assets/img/*.{png,webp}` to package `files`
- Exported `VENDOR_ICON_MAP` / `AppearanceIcons` from theme-mapper
- Drift test + JS API docs note

## Closes

- Closes #365

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme selector icons are now shipped with the package (PNG/WebP) for easier customization.
  * Theme selection can be persisted in the example via `localStorage`.
  * Theme icon mappings are now exposed for integrations.
* **Documentation**
  * Expanded JavaScript API docs with a “With Svelte” theme example and a dedicated “Theme Selector Icons” section describing common ways to serve icons (local, build-time, or URL override).
* **Packaging / Tests**
  * Updated published package file whitelist to include the shipped icon assets.
  * Added a packaging drift-prevention test to verify referenced icons exist and are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ships theme icon assets (`assets/img/*.png` and `*.webp`) in the npm package, exports `VENDOR_ICON_MAP` and `AppearanceIcons` from `theme-mapper.ts`, and adds a drift-prevention test that ensures every referenced icon file exists on disk and is matched by the `files` glob.

- **`package.json`** adds the two `assets/img/` globs to the `files` whitelist; the drift test in `theme-icon-npm.test.ts` validates correctness with a subdirectory-safe glob matcher.
- **`persistence.ts`** extracts the hardcoded fallback filename into an exported `FALLBACK_ICON_FILE` constant; `theme-mapper.ts` makes `VENDOR_ICON_MAP` and `AppearanceIcons` part of the public API.
- **`javascript-api.md`** adds a Svelte usage example and an icon-serving guide (Options 1–3); the Svelte example contains two bugs that silently prevent theme switching from working (wrong CSS link element ID and wrong stylesheet path).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after correcting the Svelte example's CSS link ID and stylesheet path, which currently make theme switching a silent no-op for anyone following the docs verbatim.

The packaging change and the new drift-prevention test are solid. The exported VENDOR_ICON_MAP and FALLBACK_ICON_FILE work correctly in the existing internal code paths. The one concrete defect is in the newly added Svelte documentation example: document.getElementById('theme-css') always returns null (the real element ID is 'turbo-theme-css'), and the stylesheet path /css/themes/turbo/${theme}.css is missing the /assets/ segment. Both mistakes together mean any developer following the example will find that selecting a theme updates localStorage but leaves the page appearance unchanged.

apps/site/src/content/docs/api-reference/javascript-api.md — Svelte example uses the wrong CSS link element ID and an incorrect stylesheet path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/content/docs/api-reference/javascript-api.md | Adds Svelte example and icon-serving docs; Svelte example contains two bugs: wrong CSS link element ID ('theme-css' vs 'turbo-theme-css') and wrong asset path ('/css/…' vs '/assets/css/…'), causing silent no-op on theme switch. |
| package.json | Adds assets/img/*.png and assets/img/*.webp to the npm files list; straightforward and correct. |
| packages/theme-selector/src/persistence.ts | Extracts the hardcoded fallback filename into an exported FALLBACK_ICON_FILE constant; minimal, correct change. |
| packages/theme-selector/src/theme-mapper.ts | Exports VENDOR_ICON_MAP and AppearanceIcons as public API; VENDOR_ICON_MAP values use full paths ('assets/img/xxx.png') while FALLBACK_ICON_FILE is a bare filename, creating an inconsistent public API convention. |
| packages/theme-selector/test/theme-icon-npm.test.ts | New drift-prevention test verifying icon files exist on disk and are covered by the npm files globs; logic is correct and subdirectory-path false-positive fixed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm install @lgtm-hq/turbo-themes] --> B[assets/img/*.png + *.webp\nshipped in tarball]
    B --> C{How to serve icons?}
    C --> D[Option 1: cp to public/]
    C --> E[Option 2: bundler copy plugin]
    C --> F[Option 3: data-baseurl on html]
    D & E & F --> G[wireFlavorSelector\ncalls getBaseUrl]
    G --> H[reads data-baseurl\nfrom html element]
    H --> I[resolveAssetPath\nbaseUrl + assets/img/icon]

    J[VENDOR_ICON_MAP\nexported from theme-mapper.ts] -->|vendor to full path\nassets/img/xxx.png| K[Consumer icon lookup]
    L[FALLBACK_ICON_FILE\nexported from persistence.ts] -->|bare filename\nxxx.png| M[buildThemeIconSrc\nprepends /assets/img/]

    style J fill:#d4edda
    style L fill:#fff3cd
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[npm install @lgtm-hq/turbo-themes] --> B[assets/img/*.png + *.webp\nshipped in tarball]
    B --> C{How to serve icons?}
    C --> D[Option 1: cp to public/]
    C --> E[Option 2: bundler copy plugin]
    C --> F[Option 3: data-baseurl on html]
    D & E & F --> G[wireFlavorSelector\ncalls getBaseUrl]
    G --> H[reads data-baseurl\nfrom html element]
    H --> I[resolveAssetPath\nbaseUrl + assets/img/icon]

    J[VENDOR_ICON_MAP\nexported from theme-mapper.ts] -->|vendor to full path\nassets/img/xxx.png| K[Consumer icon lookup]
    L[FALLBACK_ICON_FILE\nexported from persistence.ts] -->|bare filename\nxxx.png| M[buildThemeIconSrc\nprepends /assets/img/]

    style J fill:#d4edda
    style L fill:#fff3cd
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fsite%2Fsrc%2Fcontent%2Fdocs%2Fapi-reference%2Fjavascript-api.md%3A370-373%0AThe%20CSS%20link%20element%20ID%20and%20the%20stylesheet%20path%20are%20both%20wrong%2C%20making%20theme%20switching%20a%20silent%20no-op.%20%60document.getElementById%28'theme-css'%29%60%20always%20returns%20%60null%60%20because%20the%20actual%20element%20ID%20is%20%60'turbo-theme-css'%60%20%28the%20%60CSS_LINK_ID%60%20constant%20in%20%60constants.ts%60%29.%20Even%20if%20the%20ID%20were%20corrected%2C%20%60%2Fcss%2Fthemes%2Fturbo%2F%24%7Btheme%7D.css%60%20is%20missing%20the%20%60%2Fassets%2F%60%20segment%20%E2%80%94%20the%20real%20path%20produced%20by%20%60buildThemeCssHref%60%20is%20%60%2Fassets%2Fcss%2Fthemes%2Fturbo%2F%24%7BthemeId%7D.css%60.%20With%20both%20bugs%2C%20%60localStorage%60%20is%20updated%20but%20the%20visible%20stylesheet%20never%20changes.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20link%20%3D%20document.getElementById%28'turbo-theme-css'%29%20as%20HTMLLinkElement%3B%0A%20%20%20%20if%20%28link%29%20%7B%0A%20%20%20%20%20%20link.href%20%3D%20%60%2Fassets%2Fcss%2Fthemes%2Fturbo%2F%24%7Btheme%7D.css%60%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=575&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fsite%2Fsrc%2Fcontent%2Fdocs%2Fapi-reference%2Fjavascript-api.md%3A370-373%0AThe%20CSS%20link%20element%20ID%20and%20the%20stylesheet%20path%20are%20both%20wrong%2C%20making%20theme%20switching%20a%20silent%20no-op.%20%60document.getElementById%28'theme-css'%29%60%20always%20returns%20%60null%60%20because%20the%20actual%20element%20ID%20is%20%60'turbo-theme-css'%60%20%28the%20%60CSS_LINK_ID%60%20constant%20in%20%60constants.ts%60%29.%20Even%20if%20the%20ID%20were%20corrected%2C%20%60%2Fcss%2Fthemes%2Fturbo%2F%24%7Btheme%7D.css%60%20is%20missing%20the%20%60%2Fassets%2F%60%20segment%20%E2%80%94%20the%20real%20path%20produced%20by%20%60buildThemeCssHref%60%20is%20%60%2Fassets%2Fcss%2Fthemes%2Fturbo%2F%24%7BthemeId%7D.css%60.%20With%20both%20bugs%2C%20%60localStorage%60%20is%20updated%20but%20the%20visible%20stylesheet%20never%20changes.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20link%20%3D%20document.getElementById%28'turbo-theme-css'%29%20as%20HTMLLinkElement%3B%0A%20%20%20%20if%20%28link%29%20%7B%0A%20%20%20%20%20%20link.href%20%3D%20%60%2Fassets%2Fcss%2Fthemes%2Fturbo%2F%24%7Btheme%7D.css%60%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=575&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22cursor%2F365-theme-icon-npm-6221%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2F365-theme-icon-npm-6221%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fsite%2Fsrc%2Fcontent%2Fdocs%2Fapi-reference%2Fjavascript-api.md%3A370-373%0AThe%20CSS%20link%20element%20ID%20and%20the%20stylesheet%20path%20are%20both%20wrong%2C%20making%20theme%20switching%20a%20silent%20no-op.%20%60document.getElementById%28'theme-css'%29%60%20always%20returns%20%60null%60%20because%20the%20actual%20element%20ID%20is%20%60'turbo-theme-css'%60%20%28the%20%60CSS_LINK_ID%60%20constant%20in%20%60constants.ts%60%29.%20Even%20if%20the%20ID%20were%20corrected%2C%20%60%2Fcss%2Fthemes%2Fturbo%2F%24%7Btheme%7D.css%60%20is%20missing%20the%20%60%2Fassets%2F%60%20segment%20%E2%80%94%20the%20real%20path%20produced%20by%20%60buildThemeCssHref%60%20is%20%60%2Fassets%2Fcss%2Fthemes%2Fturbo%2F%24%7BthemeId%7D.css%60.%20With%20both%20bugs%2C%20%60localStorage%60%20is%20updated%20but%20the%20visible%20stylesheet%20never%20changes.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20link%20%3D%20document.getElementById%28'turbo-theme-css'%29%20as%20HTMLLinkElement%3B%0A%20%20%20%20if%20%28link%29%20%7B%0A%20%20%20%20%20%20link.href%20%3D%20%60%2Fassets%2Fcss%2Fthemes%2Fturbo%2F%24%7Btheme%7D.css%60%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=575&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["docs(site): apply stored theme on mount ..."](https://github.com/lgtm-hq/turbo-themes/commit/4291453b96f1cd96d3e3c3b7deb8cefbb0fe2072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45180261)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->