### PR TITLE
fix(release): request CODEOWNER review on release version PRs

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -7,7 +7,7 @@ name: PR - Auto Assign
 
 'on':
   pull_request_target:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions: {}
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   assign:
+    # Skip release-bump PRs — release-version-pr.yml requests CODEOWNER review directly.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release-bump') }}
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -110,6 +110,17 @@ jobs:
             release-bump
           delete-branch: true
 
+      - name: Request CODEOWNER review
+        if: steps.create_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+        run: |
+          reviewer=$(grep -m1 '^\*' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
+          if [ -n "$reviewer" ]; then
+            gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer"
+          fi
+
       - name: Enable auto-merge
         if: steps.create_pr.outputs.pull-request-number
         env:

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -116,7 +116,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         run: |
-          reviewer=$(grep -m1 '^\*' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
+          reviewer=$(grep -m1 '^[*][[:space:]]' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
           if [ -n "$reviewer" ]; then
             gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer"
           fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Signing for release version PR commits was already landed (#545). This finishes #494 by having the release bot request CODEOWNER review and skipping auto-assign for `release-bump` PRs to avoid duplicate reviewer noise.

## Type

- [x] 🐛 Bug fix (`fix:`)
- [x] 🔧 CI/CD (`ci:`)

## Changes Made

- CODEOWNER reviewer step on `release-version-pr.yml`
- Skip `pr-auto-assign` when label `release-bump` is present

## Closes

- Closes #494
- Relates to #545

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes the release-bot reviewer flow by adding a "Request CODEOWNER review" step to `release-version-pr.yml` and teaching `pr-auto-assign.yml` to skip `release-bump` PRs so the bot and the auto-assigner don't both pile reviewers onto the same PR.

- **`release-version-pr.yml`**: A new step parses `.github/CODEOWNERS` with a tightly anchored pattern (`^[*][[:space:]]`) to extract the global wildcard owner and calls `gh pr edit --add-reviewer` after the release PR is created; the empty-reviewer guard is correct.
- **`pr-auto-assign.yml`**: The `labeled` event type is added alongside `opened`, and the `assign` job is gated on `release-bump` not being present — but this gate fires for *every* label added to *any* PR, not just `release-bump` additions, which can re-run auto-assign on regular PRs that receive labels.
</details>

<h3>Confidence Score: 4/5</h3>

The release-version-pr.yml half is safe to merge; pr-auto-assign.yml needs the labeled trigger constrained to avoid unintended re-runs on every label addition across all PRs.

The release-version-pr.yml changes are well-implemented and introduce no issues. The pr-auto-assign.yml change achieves its goal for the release-bump race window but has a side-effect: adding any label to any non-release PR re-triggers auto-assign, which could shuffle or duplicate reviewer assignments on ordinary PRs.

.github/workflows/pr-auto-assign.yml — the labeled trigger needs to be constrained so it only fires when the release-bump label specifically is involved, rather than for every label addition across all PRs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-auto-assign.yml | Adds `labeled` trigger and `release-bump` skip condition; the `labeled` event fires for every label on every PR, causing unintended auto-assign re-runs on non-release PRs. |
| .github/workflows/release-version-pr.yml | Adds a CODEOWNER review-request step after PR creation using a well-anchored grep pattern (`^[*][[:space:]]`) and `gh pr edit --add-reviewer`; logic is correct and handles the empty-reviewer case gracefully. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant main as main branch
    participant bot as release-version-pr.yml
    participant GH as GitHub API
    participant aa as pr-auto-assign.yml
    participant co as CODEOWNER

    main->>bot: push event
    bot->>GH: create-pull-request (label: release-bump)
    GH-->>bot: pull-request-number
    Note over GH,aa: opened event fires (no label yet)
    aa->>aa: !contains([], 'release-bump') true
    aa->>GH: auto-assign runs
    Note over GH,aa: labeled event fires (release-bump applied)
    aa->>aa: !contains(['release-bump'], 'release-bump') false
    aa->>aa: job skipped
    bot->>GH: gh pr edit --add-reviewer CODEOWNER
    GH-->>co: review requested
    bot->>GH: enable auto-merge
    co->>GH: approves PR
    GH->>main: auto-squash merge
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant main as main branch
    participant bot as release-version-pr.yml
    participant GH as GitHub API
    participant aa as pr-auto-assign.yml
    participant co as CODEOWNER

    main->>bot: push event
    bot->>GH: create-pull-request (label: release-bump)
    GH-->>bot: pull-request-number
    Note over GH,aa: opened event fires (no label yet)
    aa->>aa: !contains([], 'release-bump') true
    aa->>GH: auto-assign runs
    Note over GH,aa: labeled event fires (release-bump applied)
    aa->>aa: !contains(['release-bump'], 'release-bump') false
    aa->>aa: job skipped
    bot->>GH: gh pr edit --add-reviewer CODEOWNER
    GH-->>co: review requested
    bot->>GH: enable auto-merge
    co->>GH: approves PR
    GH->>main: auto-squash merge
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(release): add labeled trigger and fi..."](https://github.com/lgtm-hq/turbo-themes/commit/10c5338a94e0ef2579458d06ead3d802e3ac40af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45180268)</sub>

<!-- /greptile_comment -->