### PR TITLE
fix(site): add consistent data-testid attributes to interactive elements

### DIFF
--- a/apps/site/src/components/ExampleCard.astro
+++ b/apps/site/src/components/ExampleCard.astro
@@ -7,12 +7,14 @@ export interface Props {
   playgroundUrl: string | null;
   tags: string[];
   size: string;
+  slug?: string;
 }
 
-const { name, description, icon, sourceUrl, playgroundUrl, tags, size } = Astro.props;
+const { name, description, icon, sourceUrl, playgroundUrl, tags, size, slug } = Astro.props;
+const cardSlug = slug ?? name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 ---
 
-<article class="example-card">
+<article class="example-card" data-testid={`example-card-${cardSlug}`}>
   <div class="example-bubble">
     <span class="example-icon" set:html={icon} /></div>
   <div class="example-body">
@@ -25,7 +27,7 @@ const { name, description, icon, sourceUrl, playgroundUrl, tags, size } = Astro.
       <span class="example-size">{size}</span>
     </div>
     <div class="example-actions">
-      <a href={sourceUrl} class="btn btn-outline" target="_blank" rel="noopener">
+      <a href={sourceUrl} class="btn btn-outline" target="_blank" rel="noopener" data-testid={`example-card-source-${cardSlug}`}>
         View Source
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
@@ -34,7 +36,7 @@ const { name, description, icon, sourceUrl, playgroundUrl, tags, size } = Astro.
         </svg>
       </a>
       {playgroundUrl && (
-        <a href={playgroundUrl} class="btn btn-primary" target="_blank" rel="noopener">
+        <a href={playgroundUrl} class="btn btn-primary" target="_blank" rel="noopener" data-testid={`example-card-stackblitz-${cardSlug}`}>
           Try in StackBlitz
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>

--- a/apps/site/src/components/Footer.astro
+++ b/apps/site/src/components/Footer.astro
@@ -25,13 +25,14 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
         href="https://github.com/lgtm-hq/turbo-themes"
         target="_blank"
         rel="noopener"
+        data-testid="footer-link-github"
       >
         GitHub
       </a>
       <span class="footer-separator">·</span>
-      <a href={`${baseUrl}/docs/`}>Documentation</a>
+      <a href={`${baseUrl}/docs/`} data-testid="footer-link-docs">Documentation</a>
       <span class="footer-separator">·</span>
-      <a href={`${baseUrl}/themes/`}>Themes</a>
+      <a href={`${baseUrl}/themes/`} data-testid="footer-link-themes">Themes</a>
     </div>
     <p class="footer-copyright">Made with care. MIT License.</p>
   </div>

--- a/apps/site/src/components/StackBlitzEmbed.astro
+++ b/apps/site/src/components/StackBlitzEmbed.astro
@@ -38,6 +38,7 @@ const frameTitle = title || `${example} example on StackBlitz`;
   <iframe
     src={embedUrl}
     title={frameTitle}
+    data-testid={`stackblitz-embed-${example}`}
     loading="lazy"
     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; microphone; midi; payment; usb; vr; xr-spatial-tracking"
     sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"

--- a/apps/site/src/components/docs/Breadcrumbs.astro
+++ b/apps/site/src/components/docs/Breadcrumbs.astro
@@ -18,17 +18,17 @@ const showTitle = title !== categoryLabel;
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <ol class="breadcrumb-list">
     <li class="breadcrumb-item">
-      <a href={`${baseUrl}/`} class="breadcrumb-link">Home</a>
+      <a href={`${baseUrl}/`} class="breadcrumb-link" data-testid="docs-breadcrumb-home">Home</a>
     </li>
     <li class="breadcrumb-separator" aria-hidden="true">/</li>
     <li class="breadcrumb-item">
-      <a href={`${baseUrl}/docs/`} class="breadcrumb-link">Docs</a>
+      <a href={`${baseUrl}/docs/`} class="breadcrumb-link" data-testid="docs-breadcrumb-docs">Docs</a>
     </li>
     <li class="breadcrumb-separator" aria-hidden="true">/</li>
     {showTitle ? (
       <>
         <li class="breadcrumb-item">
-          <a href={`${baseUrl}/docs/${category}/`} class="breadcrumb-link">{categoryLabel}</a>
+          <a href={`${baseUrl}/docs/${category}/`} class="breadcrumb-link" data-testid="docs-breadcrumb-category">{categoryLabel}</a>
         </li>
         <li class="breadcrumb-separator" aria-hidden="true">/</li>
         <li class="breadcrumb-item" aria-current="page">

--- a/apps/site/src/components/docs/Breadcrumbs.astro
+++ b/apps/site/src/components/docs/Breadcrumbs.astro
@@ -28,7 +28,7 @@ const showTitle = title !== categoryLabel;
     {showTitle ? (
       <>
         <li class="breadcrumb-item">
-          <a href={`${baseUrl}/docs/${category}/`} class="breadcrumb-link" data-testid="docs-breadcrumb-category">{categoryLabel}</a>
+          <a href={`${baseUrl}/docs/${category}/`} class="breadcrumb-link" data-testid={`docs-breadcrumb-category-${category}`}>{categoryLabel}</a>
         </li>
         <li class="breadcrumb-separator" aria-hidden="true">/</li>
         <li class="breadcrumb-item" aria-current="page">

--- a/apps/site/src/components/docs/PrevNext.astro
+++ b/apps/site/src/components/docs/PrevNext.astro
@@ -22,7 +22,7 @@ const nextDoc = next ? allDocs.find(d => d.id === next) : null;
   <nav class="prev-next" aria-label="Previous and next pages">
     <div class="prev-next-inner">
       {prevDoc ? (
-        <a href={`${baseUrl}/docs/${prevDoc.id}/`} class="prev-next-link prev">
+        <a href={`${baseUrl}/docs/${prevDoc.id}/`} class="prev-next-link prev" data-testid="docs-prev-link">
           <span class="prev-next-direction">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M19 12H5M12 19l-7-7 7-7"/>
@@ -34,7 +34,7 @@ const nextDoc = next ? allDocs.find(d => d.id === next) : null;
       ) : <div />}
 
       {nextDoc ? (
-        <a href={`${baseUrl}/docs/${nextDoc.id}/`} class="prev-next-link next">
+        <a href={`${baseUrl}/docs/${nextDoc.id}/`} class="prev-next-link next" data-testid="docs-next-link">
           <span class="prev-next-direction">
             Next
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/apps/site/src/pages/components.astro
+++ b/apps/site/src/pages/components.astro
@@ -48,6 +48,7 @@ const tabs = [
           aria-selected={index === 0 ? 'true' : 'false'}
           aria-controls={`panel-${tab.id}`}
           tabindex={index === 0 ? 0 : -1}
+          data-testid={`components-tab-${tab.id}`}
         >
           {tab.label}
         </button>

--- a/apps/site/src/pages/examples.astro
+++ b/apps/site/src/pages/examples.astro
@@ -115,7 +115,7 @@ const examples = [
         <h4 class="examples-category">{section.category}</h4>
         <div class="examples-grid">
           {section.items.map((example) => (
-            <ExampleCard {...example} slug={example.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')} />
+            <ExampleCard {...example} />
           ))}
         </div>
       </div>

--- a/apps/site/src/pages/examples.astro
+++ b/apps/site/src/pages/examples.astro
@@ -102,7 +102,7 @@ const examples = [
 
 <BaseLayout title="Home">
   <div class="examples-hero">
-    <h1>Examples</h1>
+    <h1 data-testid="examples-heading">Examples</h1>
     <p class="examples-subtitle">
       Complete, working examples showing Turbo Themes integrated with popular frameworks.
       Each example includes theme switching, localStorage persistence, and FOUC prevention.
@@ -115,7 +115,7 @@ const examples = [
         <h4 class="examples-category">{section.category}</h4>
         <div class="examples-grid">
           {section.items.map((example) => (
-            <ExampleCard {...example} />
+            <ExampleCard {...example} slug={example.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')} />
           ))}
         </div>
       </div>
@@ -128,7 +128,7 @@ const examples = [
       We welcome new examples! If you've integrated Turbo Themes with a framework not listed here,
       consider contributing it to help others.
     </p>
-    <a href="https://github.com/lgtm-hq/turbo-themes/blob/main/CONTRIBUTING.md" class="btn btn-primary" target="_blank" rel="noopener">
+    <a href="https://github.com/lgtm-hq/turbo-themes/blob/main/CONTRIBUTING.md" class="btn btn-primary" target="_blank" rel="noopener" data-testid="examples-cta-contribute">
       Contribution Guide
     </a>
   </section>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -35,10 +35,10 @@ const previewCode = `const theme = {
         A design token system with {themeCount} curated color themes. Switch themes instantly with CSS custom properties.
       </p>
       <div class="hero-actions">
-        <a href={`${baseUrl}/docs/`} class="btn btn-primary btn-lg">
+        <a href={`${baseUrl}/docs/`} class="btn btn-primary btn-lg" data-testid="hero-cta-get-started">
           Get Started
         </a>
-        <a href={`${baseUrl}/themes/`} class="btn btn-outline btn-lg">
+        <a href={`${baseUrl}/themes/`} class="btn btn-outline btn-lg" data-testid="hero-cta-explore-themes">
           Explore Themes
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -49,38 +49,38 @@ const previewCode = `const theme = {
       <div class="hero-theme-strip">
         <span class="hero-theme-label">Try a theme:</span>
         <div class="hero-theme-options">
-          <button class="hero-theme-btn" data-theme-preview="catppuccin-mocha" title="Catppuccin Mocha">
+          <button class="hero-theme-btn" data-theme-preview="catppuccin-mocha" data-testid="hero-theme-preview-catppuccin-mocha" title="Catppuccin Mocha">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/catppuccin-logo-macchiato.png`} alt="Catppuccin Mocha" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="dracula" title="Dracula">
+          <button class="hero-theme-btn" data-theme-preview="dracula" data-testid="hero-theme-preview-dracula" title="Dracula">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/dracula-logo.png`} alt="Dracula" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="gruvbox-dark" title="Gruvbox Dark">
+          <button class="hero-theme-btn" data-theme-preview="gruvbox-dark" data-testid="hero-theme-preview-gruvbox-dark" title="Gruvbox Dark">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/gruvbox-dark.png`} alt="Gruvbox Dark" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="github-dark" title="GitHub Dark">
+          <button class="hero-theme-btn" data-theme-preview="github-dark" data-testid="hero-theme-preview-github-dark" title="GitHub Dark">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/github-logo-dark.png`} alt="GitHub Dark" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="bulma-dark" title="Bulma Dark">
+          <button class="hero-theme-btn" data-theme-preview="bulma-dark" data-testid="hero-theme-preview-bulma-dark" title="Bulma Dark">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/turbo-themes-logo-dark.png`} alt="Bulma Dark" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="nord" title="Nord">
+          <button class="hero-theme-btn" data-theme-preview="nord" data-testid="hero-theme-preview-nord" title="Nord">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/nord.png`} alt="Nord" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="solarized-dark" title="Solarized Dark">
+          <button class="hero-theme-btn" data-theme-preview="solarized-dark" data-testid="hero-theme-preview-solarized-dark" title="Solarized Dark">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/solarized-dark.png`} alt="Solarized Dark" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="tokyo-night-dark" title="Tokyo Night">
+          <button class="hero-theme-btn" data-theme-preview="tokyo-night-dark" data-testid="hero-theme-preview-tokyo-night-dark" title="Tokyo Night">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/tokyo-night.png`} alt="Tokyo Night" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="rose-pine" title="Rosé Pine">
+          <button class="hero-theme-btn" data-theme-preview="rose-pine" data-testid="hero-theme-preview-rose-pine" title="Rosé Pine">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/rose-pine.png`} alt="Rosé Pine" width="28" height="28" />
           </button>
-          <button class="hero-theme-btn" data-theme-preview="catppuccin-latte" title="Catppuccin Latte">
+          <button class="hero-theme-btn" data-theme-preview="catppuccin-latte" data-testid="hero-theme-preview-catppuccin-latte" title="Catppuccin Latte">
             <img class="hero-theme-icon" src={`${baseUrl}/assets/img/catppuccin-logo-latte.png`} alt="Catppuccin Latte" width="28" height="28" />
           </button>
         </div>
-        <a href={`${baseUrl}/themes/`} class="hero-theme-more">View all</a>
+        <a href={`${baseUrl}/themes/`} class="hero-theme-more" data-testid="hero-link-view-all-themes">View all</a>
       </div>
     </div>
   </section>
@@ -184,7 +184,7 @@ const previewCode = `const theme = {
       </div>
 
       <div class="install-cta">
-        <a href={`${baseUrl}/docs/installation/`} class="btn btn-ghost">
+        <a href={`${baseUrl}/docs/installation/`} class="btn btn-ghost" data-testid="hero-link-install">
           View full installation guide
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -261,7 +261,7 @@ const previewCode = `const theme = {
       </div>
 
       <div class="section-footer">
-        <a href={`${baseUrl}/components/`} class="btn btn-ghost">
+        <a href={`${baseUrl}/components/`} class="btn btn-ghost" data-testid="hero-link-components">
           View all components
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -324,10 +324,10 @@ const previewCode = `const theme = {
         <h2 class="cta-title">Ready to get started?</h2>
         <p class="cta-subtitle">Install Turbo Themes and start building beautiful, themeable interfaces.</p>
         <div class="cta-actions">
-          <a href={`${baseUrl}/docs/`} class="btn btn-primary btn-lg">
+          <a href={`${baseUrl}/docs/`} class="btn btn-primary btn-lg" data-testid="hero-cta-docs">
             Read the Docs
           </a>
-          <a href="https://github.com/lgtm-hq/turbo-themes" class="btn btn-outline btn-lg" target="_blank" rel="noopener">
+          <a href="https://github.com/lgtm-hq/turbo-themes" class="btn btn-outline btn-lg" target="_blank" rel="noopener" data-testid="hero-cta-github">
             View on GitHub
           </a>
         </div>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -184,7 +184,7 @@ const previewCode = `const theme = {
       </div>
 
       <div class="install-cta">
-        <a href={`${baseUrl}/docs/installation/`} class="btn btn-ghost" data-testid="hero-link-install">
+        <a href={`${baseUrl}/docs/installation/`} class="btn btn-ghost" data-testid="installation-cta-guide">
           View full installation guide
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -261,7 +261,7 @@ const previewCode = `const theme = {
       </div>
 
       <div class="section-footer">
-        <a href={`${baseUrl}/components/`} class="btn btn-ghost" data-testid="hero-link-components">
+        <a href={`${baseUrl}/components/`} class="btn btn-ghost" data-testid="components-link-view-all">
           View all components
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -324,10 +324,10 @@ const previewCode = `const theme = {
         <h2 class="cta-title">Ready to get started?</h2>
         <p class="cta-subtitle">Install Turbo Themes and start building beautiful, themeable interfaces.</p>
         <div class="cta-actions">
-          <a href={`${baseUrl}/docs/`} class="btn btn-primary btn-lg" data-testid="hero-cta-docs">
+          <a href={`${baseUrl}/docs/`} class="btn btn-primary btn-lg" data-testid="ready-cta-docs">
             Read the Docs
           </a>
-          <a href="https://github.com/lgtm-hq/turbo-themes" class="btn btn-outline btn-lg" target="_blank" rel="noopener" data-testid="hero-cta-github">
+          <a href="https://github.com/lgtm-hq/turbo-themes" class="btn btn-outline btn-lg" target="_blank" rel="noopener" data-testid="ready-cta-github">
             View on GitHub
           </a>
         </div>

--- a/apps/site/src/pages/themes.astro
+++ b/apps/site/src/pages/themes.astro
@@ -23,7 +23,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       <h3 class="sidebar-title">Theme Families</h3>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-catppuccin">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/catppuccin-logo-macchiato.png`} alt="" width="24" height="24" />
             <span class="family-name">Catppuccin</span>
@@ -31,19 +31,19 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">4</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="catppuccin-mocha">
+          <button class="theme-option" data-theme="catppuccin-mocha" data-testid="theme-option-catppuccin-mocha">
             <span class="theme-dot" style="background: #1e1e2e"></span>
             Mocha
           </button>
-          <button class="theme-option" data-theme="catppuccin-macchiato">
+          <button class="theme-option" data-theme="catppuccin-macchiato" data-testid="theme-option-catppuccin-macchiato">
             <span class="theme-dot" style="background: #24273a"></span>
             Macchiato
           </button>
-          <button class="theme-option" data-theme="catppuccin-frappe">
+          <button class="theme-option" data-theme="catppuccin-frappe" data-testid="theme-option-catppuccin-frappe">
             <span class="theme-dot" style="background: #303446"></span>
             Frappé
           </button>
-          <button class="theme-option" data-theme="catppuccin-latte">
+          <button class="theme-option" data-theme="catppuccin-latte" data-testid="theme-option-catppuccin-latte">
             <span class="theme-dot" style="background: #eff1f5"></span>
             Latte
           </button>
@@ -51,7 +51,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-dracula">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/dracula-logo.png`} alt="" width="24" height="24" />
             <span class="family-name">Dracula</span>
@@ -59,7 +59,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">1</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="dracula">
+          <button class="theme-option" data-theme="dracula" data-testid="theme-option-dracula">
             <span class="theme-dot" style="background: #282a36"></span>
             Dracula
           </button>
@@ -67,7 +67,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-gruvbox">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/gruvbox-dark.png`} alt="" width="24" height="24" />
             <span class="family-name">Gruvbox</span>
@@ -75,27 +75,27 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">6</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="gruvbox-dark-hard">
+          <button class="theme-option" data-theme="gruvbox-dark-hard" data-testid="theme-option-gruvbox-dark-hard">
             <span class="theme-dot" style="background: #1d2021"></span>
             Dark Hard
           </button>
-          <button class="theme-option" data-theme="gruvbox-dark">
+          <button class="theme-option" data-theme="gruvbox-dark" data-testid="theme-option-gruvbox-dark">
             <span class="theme-dot" style="background: #282828"></span>
             Dark
           </button>
-          <button class="theme-option" data-theme="gruvbox-dark-soft">
+          <button class="theme-option" data-theme="gruvbox-dark-soft" data-testid="theme-option-gruvbox-dark-soft">
             <span class="theme-dot" style="background: #32302f"></span>
             Dark Soft
           </button>
-          <button class="theme-option" data-theme="gruvbox-light-hard">
+          <button class="theme-option" data-theme="gruvbox-light-hard" data-testid="theme-option-gruvbox-light-hard">
             <span class="theme-dot" style="background: #f9f5d7"></span>
             Light Hard
           </button>
-          <button class="theme-option" data-theme="gruvbox-light">
+          <button class="theme-option" data-theme="gruvbox-light" data-testid="theme-option-gruvbox-light">
             <span class="theme-dot" style="background: #fbf1c7"></span>
             Light
           </button>
-          <button class="theme-option" data-theme="gruvbox-light-soft">
+          <button class="theme-option" data-theme="gruvbox-light-soft" data-testid="theme-option-gruvbox-light-soft">
             <span class="theme-dot" style="background: #f2e5bc"></span>
             Light Soft
           </button>
@@ -103,7 +103,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-github">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/github-logo-light.png`} alt="" width="24" height="24" />
             <span class="family-name">GitHub</span>
@@ -111,11 +111,11 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">2</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="github-dark">
+          <button class="theme-option" data-theme="github-dark" data-testid="theme-option-github-dark">
             <span class="theme-dot" style="background: #0d1117"></span>
             Dark
           </button>
-          <button class="theme-option" data-theme="github-light">
+          <button class="theme-option" data-theme="github-light" data-testid="theme-option-github-light">
             <span class="theme-dot" style="background: #ffffff"></span>
             Light
           </button>
@@ -123,7 +123,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-bulma">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/turbo-themes-logo.png`} alt="" width="24" height="24" />
             <span class="family-name">Bulma</span>
@@ -131,11 +131,11 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">2</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="bulma-dark">
+          <button class="theme-option" data-theme="bulma-dark" data-testid="theme-option-bulma-dark">
             <span class="theme-dot" style="background: #141414"></span>
             Dark
           </button>
-          <button class="theme-option" data-theme="bulma-light">
+          <button class="theme-option" data-theme="bulma-light" data-testid="theme-option-bulma-light">
             <span class="theme-dot" style="background: #ffffff"></span>
             Light
           </button>
@@ -143,7 +143,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-nord">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/nord.png`} alt="" width="24" height="24" />
             <span class="family-name">Nord</span>
@@ -151,7 +151,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">1</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="nord">
+          <button class="theme-option" data-theme="nord" data-testid="theme-option-nord">
             <span class="theme-dot" style="background: #2e3440"></span>
             Nord
           </button>
@@ -159,7 +159,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-solarized">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/solarized-dark.png`} alt="" width="24" height="24" />
             <span class="family-name">Solarized</span>
@@ -167,11 +167,11 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">2</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="solarized-dark">
+          <button class="theme-option" data-theme="solarized-dark" data-testid="theme-option-solarized-dark">
             <span class="theme-dot" style="background: #002b36"></span>
             Dark
           </button>
-          <button class="theme-option" data-theme="solarized-light">
+          <button class="theme-option" data-theme="solarized-light" data-testid="theme-option-solarized-light">
             <span class="theme-dot" style="background: #fdf6e3"></span>
             Light
           </button>
@@ -179,7 +179,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-tokyo-night">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/tokyo-night.png`} alt="" width="24" height="24" />
             <span class="family-name">Tokyo Night</span>
@@ -187,15 +187,15 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">3</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="tokyo-night-dark">
+          <button class="theme-option" data-theme="tokyo-night-dark" data-testid="theme-option-tokyo-night-dark">
             <span class="theme-dot" style="background: #1a1b26"></span>
             Night
           </button>
-          <button class="theme-option" data-theme="tokyo-night-storm">
+          <button class="theme-option" data-theme="tokyo-night-storm" data-testid="theme-option-tokyo-night-storm">
             <span class="theme-dot" style="background: #24283b"></span>
             Storm
           </button>
-          <button class="theme-option" data-theme="tokyo-night-light">
+          <button class="theme-option" data-theme="tokyo-night-light" data-testid="theme-option-tokyo-night-light">
             <span class="theme-dot" style="background: #e6e7ed"></span>
             Light
           </button>
@@ -203,7 +203,7 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
       </div>
 
       <div class="theme-family">
-        <button class="family-header" aria-expanded="true">
+        <button class="family-header" aria-expanded="true" data-testid="theme-family-rose-pine">
           <span class="family-label">
             <img class="family-icon" src={`${baseUrl}/assets/img/rose-pine.png`} alt="" width="24" height="24" />
             <span class="family-name">Rosé Pine</span>
@@ -211,15 +211,15 @@ const themeExplorerMetaJson = JSON.stringify(themeExplorerMeta);
           <span class="family-count">3</span>
         </button>
         <div class="family-themes">
-          <button class="theme-option" data-theme="rose-pine">
+          <button class="theme-option" data-theme="rose-pine" data-testid="theme-option-rose-pine">
             <span class="theme-dot" style="background: #191724"></span>
             Rosé Pine
           </button>
-          <button class="theme-option" data-theme="rose-pine-moon">
+          <button class="theme-option" data-theme="rose-pine-moon" data-testid="theme-option-rose-pine-moon">
             <span class="theme-dot" style="background: #232136"></span>
             Moon
           </button>
-          <button class="theme-option" data-theme="rose-pine-dawn">
+          <button class="theme-option" data-theme="rose-pine-dawn" data-testid="theme-option-rose-pine-dawn">
             <span class="theme-dot" style="background: #faf4ed"></span>
             Dawn
           </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add stable `data-testid` attributes across interactive site elements (footer, breadcrumbs, prev/next, embeds, cards, CTAs, theme explorer controls) to improve E2E/locator reliability.

## Type

- [x] 🐛 Bug fix (`fix:`)
- [x] ✅ Tests (`test:`)

## Changes Made

- data-testid coverage on Footer, Breadcrumbs, PrevNext, StackBlitzEmbed, ExampleCard, and key page controls
- Avoided reworking DocsLayout/TOC (covered by #555)

## Closes

- Closes #363

## Testing

- [x] All tests pass locally (`bun run test`)

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7051-6847-7b16-aaed-29acdb9f6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage and reliability across the site with more precise targeting for example cards, navigation, footer links, documentation controls, component tabs, theme selectors, embeds, and key call-to-action elements.
* **Enhancements**
  * Example cards now support stable identifiers derived from their names or supplied slugs, enabling more consistent linking and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds stable `data-testid` attributes to interactive elements across the site — footer links, breadcrumbs, prev/next navigation, StackBlitz embeds, example cards, component tabs, theme selector buttons, and hero/CTA actions — to improve E2E locator reliability.

- `ExampleCard` gains an optional `slug` prop with an inline regex fallback (`name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')`) so every card renders a unique, slug-keyed testid on its article, source link, and StackBlitz link.
- Breadcrumbs were updated to embed the `category` value in `data-testid`, making each breadcrumb distinct across doc sections; prev/next links use stable static ids (`docs-prev-link` / `docs-next-link`) appropriate for their single-per-page usage.
- `StackBlitzEmbed` uses the typed `ExampleName` string (always a safe, lowercase, hyphenated value) in its testid.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive HTML attribute additions with no logic mutations.

Every change is a pure attribute addition (data-testid) to existing elements. No rendering logic, routing, state management, or data fetching is touched. The one new piece of logic — the cardSlug fallback in ExampleCard — is a straightforward regex on an already-typed name string, and all current callers let it fall back naturally since none of the example data objects carry a slug field. There are no missing guards, no behavioural regressions, and the attribute values are all safe, lowercase, hyphenated strings suitable for test selectors.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/components/ExampleCard.astro | Adds optional slug prop with inline name-to-slug regex fallback; uses cardSlug in three new testids (article, source link, StackBlitz link). Logic is correct and all example names produce unique, safe attribute values. |
| apps/site/src/components/Footer.astro | Three static testids added to footer links (GitHub, Docs, Themes). Straightforward and correct. |
| apps/site/src/components/StackBlitzEmbed.astro | Adds data-testid to the iframe using the typed ExampleName value — all values are lowercase, hyphenated, and safe as attribute content. |
| apps/site/src/components/docs/Breadcrumbs.astro | Home and Docs links get static testids; category link now embeds the category slug, giving each breadcrumb a unique locator across doc sections. |
| apps/site/src/components/docs/PrevNext.astro | Static docs-prev-link and docs-next-link testids added. Appropriate for single-per-page navigation — tests can click the link and verify resulting URL. |
| apps/site/src/pages/components.astro | Tab buttons gain components-tab-{tab.id} testids — dynamic and unique per tab. No issues. |
| apps/site/src/pages/examples.astro | Adds testid to h1 heading and contribute CTA. Example items don't include a slug field, so ExampleCard always falls back to computing from name — correct behaviour. |
| apps/site/src/pages/index.astro | Hero CTAs, theme-preview buttons, and footer-section CTAs get unique, descriptive testids. All are static or derived from the existing data-theme-preview value. |
| apps/site/src/pages/themes.astro | Theme family collapse buttons and individual theme-option buttons all receive unique testids mirroring their data-theme value. Complete coverage across all families. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ExampleCard.astro] -->|slug prop provided?| B{slug ?? name regex}
    B -->|yes| C[cardSlug = slug]
    B -->|no| D[cardSlug = name.toLowerCase+replace]
    C --> E[data-testid: example-card-cardSlug]
    D --> E
    E --> F[article testid]
    E --> G[source link testid]
    E --> H[stackblitz link testid]

    I[Breadcrumbs.astro] --> J[home: docs-breadcrumb-home]
    I --> K[docs: docs-breadcrumb-docs]
    I --> L[category: docs-breadcrumb-category-category]

    M[PrevNext.astro] --> N[docs-prev-link]
    M --> O[docs-next-link]

    P[StackBlitzEmbed.astro] --> Q[data-testid: stackblitz-embed-ExampleName]

    R[themes.astro] --> S[theme-family-familyName]
    R --> T[theme-option-themeValue]

    U[index.astro] --> V[hero-cta-get-started]
    U --> W[hero-theme-preview-themeName]
    U --> X[ready-cta-docs / ready-cta-github]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ExampleCard.astro] -->|slug prop provided?| B{slug ?? name regex}
    B -->|yes| C[cardSlug = slug]
    B -->|no| D[cardSlug = name.toLowerCase+replace]
    C --> E[data-testid: example-card-cardSlug]
    D --> E
    E --> F[article testid]
    E --> G[source link testid]
    E --> H[stackblitz link testid]

    I[Breadcrumbs.astro] --> J[home: docs-breadcrumb-home]
    I --> K[docs: docs-breadcrumb-docs]
    I --> L[category: docs-breadcrumb-category-category]

    M[PrevNext.astro] --> N[docs-prev-link]
    M --> O[docs-next-link]

    P[StackBlitzEmbed.astro] --> Q[data-testid: stackblitz-embed-ExampleName]

    R[themes.astro] --> S[theme-family-familyName]
    R --> T[theme-option-themeValue]

    U[index.astro] --> V[hero-cta-get-started]
    U --> W[hero-theme-preview-themeName]
    U --> X[ready-cta-docs / ready-cta-github]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(site): use section-specific testid n..."](https://github.com/lgtm-hq/turbo-themes/commit/da14006daa20ff9d009bf080c12c940a5d12c365) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45180270)</sub>

<!-- /greptile_comment -->