### PR TITLE
ci: migrate E2E, build, and SBOM workflows to lgtm-ci reusables

### DIFF
--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -31,17 +31,62 @@ env:
   CHECKOUT_FETCH_DEPTH: 1
 
 jobs:
+  # Matrix build legs via the lgtm-ci build-artifact reusable (lgtm-ci#520).
+  # Org ruleset contexts: build / 🏗️ Build & Quality Checks (20) and (22).
+  # Matrix mode appends -<node-version> to the artifact name, so the legs
+  # upload js-dist-20 / js-dist-22; downstream consumers download js-dist-22.
+  # The node-22-only reporting side effects of the old matrix job (Codecov,
+  # coverage comment/badges, Pages coverage-html, SBOM artifact) are not
+  # expressible through the reusable's inputs and live in the reporting job.
   build:
-    name: 🏗️ Build & Quality Checks
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-artifact.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
+    with:
+      job-name: '🏗️ Build & Quality Checks'
+      node-version-matrix: '["20","22"]'
+      build-command: ./scripts/ci/bootstrap-build-quick.sh
+      artifact-name: js-dist
+      artifact-path: dist
+      retention-days: 7
+      timeout-minutes: 45
+      tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
+      egress-policy: block
+      # Complete enforced allowlist (pre-enforcement replace semantics):
+      # GitHub + npm/bun + uv/lintro (astral, PyPI) + test fixtures
+      # (bulma.io, cdn.jsdelivr.net).
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        pkg-containers.githubusercontent.com:443
+        uploads.github.com:443
+        registry.npmjs.org:443
+        npmjs.org:443
+        nodejs.org:443
+        bun.sh:443
+        bulma.io:443
+        cdn.jsdelivr.net:443
+        pypi.org:443
+        files.pythonhosted.org:443
+        astral.sh:443
+        releases.astral.sh:443
+    permissions:
+      contents: read
+
+  # Retained from the pre-migration node-22 matrix leg: coverage reporting,
+  # Pages artifacts, and the repo SBOM artifact. Not a required context.
+  reporting:
+    name: 📊 Coverage & Reporting
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22]
     steps:
       - name: Harden Runner
         if: ${{ !env.ACT }}
@@ -79,7 +124,7 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-env
         with:
-          node-version: '${{ matrix.node }}'
+          node-version: '22'
           skip-ruby: 'true'
 
       - name: Validate commit messages
@@ -91,15 +136,16 @@ jobs:
         run: ./scripts/ci/verify-semantic-release-trigger.sh
 
       - name: Validate version sync
-        if: matrix.node == 22
         run: ./scripts/ci/validate-version-sync.sh
 
+      # Lint already gates the build legs (and quality-lintro.yml); skip it
+      # here to avoid a third lintro pass.
       - name: Run CI pipeline
-        run: ./scripts/local/build.sh --quick
+        run: ./scripts/local/build.sh --quick --skip-lint
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-        if: matrix.node == 22 && !env.ACT
+        if: ${{ !env.ACT }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -110,7 +156,7 @@ jobs:
 
       - name: Upload coverage HTML for Pages
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: matrix.node == 22 && github.ref == 'refs/heads/main' && !env.ACT
+        if: github.ref == 'refs/heads/main' && !env.ACT
         with:
           name: coverage-html
           path: coverage/
@@ -118,11 +164,11 @@ jobs:
           overwrite: true
 
       - name: Generate coverage summary for PR comment
-        if: matrix.node == 22 && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: ./scripts/ci/generate-coverage-summary.sh
 
       - name: Post coverage comment on PR
-        if: matrix.node == 22 && github.event_name == 'pull_request' && !env.ACT
+        if: github.event_name == 'pull_request' && !env.ACT
         uses: ./.github/actions/post-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -135,24 +181,16 @@ jobs:
 
       - name: Upload coverage badges
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: matrix.node == 22 && always() && !env.ACT
+        if: always() && !env.ACT
         with:
           name: coverage-badges
           path: assets/static/badges
           if-no-files-found: ignore
           overwrite: true
 
-      - name: Upload JS dist artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: matrix.node == 22 && always() && !env.ACT
-        with:
-          name: js-dist
-          path: dist/
-          overwrite: true
-
       - name: Upload built site artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: matrix.node == 22 && always() && !env.ACT
+        if: always() && !env.ACT
         with:
           name: site-build
           path: apps/site/dist/
@@ -166,7 +204,7 @@ jobs:
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: matrix.node == 22 && always() && !env.ACT
+        if: always() && !env.ACT
         with:
           name: sbom-cyclonedx
           path: sbom.cyclonedx.json
@@ -217,7 +255,8 @@ jobs:
       - name: Download built JS artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: js-dist
+          # Matrix mode of reusable-build-artifact appends -<node-version>.
+          name: js-dist-22
           path: dist/
 
       - name: Build core packages

--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -52,8 +52,8 @@ jobs:
       tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
       egress-policy: block
       # Complete enforced allowlist (pre-enforcement replace semantics):
-      # GitHub + npm/bun + uv/lintro (astral, PyPI) + test fixtures
-      # (bulma.io, cdn.jsdelivr.net).
+      # GitHub (incl. uv release tarball + python-build-standalone downloads)
+      # + npm/bun + lintro (PyPI) + test fixtures (bulma.io, cdn.jsdelivr.net).
       allowed-endpoints: >-
         github.com:443
         api.github.com:443
@@ -73,8 +73,6 @@ jobs:
         cdn.jsdelivr.net:443
         pypi.org:443
         files.pythonhosted.org:443
-        astral.sh:443
-        releases.astral.sh:443
     permissions:
       contents: read
 

--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -22,10 +22,12 @@ concurrency:
 #   webServer timeout (120s) is too short for a cold `e2e:prep` build, so the
 #   heavy site/examples build is chained into test-command before Playwright
 #   runs (`bun run e2e:start` then only serves the prebuilt dist).
-# - The full suite includes @visual Jekyll snapshots; the runner's system Ruby
-#   (>= 3.1 satisfies the gemspec) plus a local-path bundle install makes
-#   `prepare-examples.mjs` build the Jekyll example, matching the old
-#   setup-env skip-ruby=false behaviour.
+# - The full suite includes @visual Jekyll snapshots; the hosted ubuntu-24.04
+#   image has no ruby/bundler on PATH (the old job used ruby/setup-ruby via
+#   setup-env skip-ruby=false), so scripts/ci/bootstrap-e2e-full.sh installs
+#   Ruby + bundler, vendors the bundle, runs e2e:prep, then execs the
+#   Playwright command forwarding the reusable's appended filter/reporter
+#   flags.
 # - allowed-endpoints is the complete enforced allowlist (pre-enforcement
 #   replace semantics, lgtm-ci#467): playwright preset + Playwright CDN
 #   fallbacks + Ubuntu apt mirrors (+ RubyGems on the full-suite leg).
@@ -36,11 +38,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
     with:
       job-name: '🎭 E2E Tests'
-      test-command: >-
-        bundle config set --local path vendor/bundle &&
-        bundle install &&
-        bun run e2e:prep &&
-        bun run e2e:ci
+      test-command: ./scripts/ci/bootstrap-e2e-full.sh
       node-version: '22'
       browsers: chromium
       package-manager: bun

--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -9,148 +9,156 @@ on:
 
 permissions:
   contents: read
-  actions: read
   pull-requests: write
 
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CHECKOUT_FETCH_DEPTH: 1
-  NODE_VERSION: 22
-
+# Thin callers over the lgtm-ci Playwright reusable (lgtm-ci#520).
+#
+# Notes on the migrated shape:
+# - The reusable has no dedicated "prep" hook and the playwright.config
+#   webServer timeout (120s) is too short for a cold `e2e:prep` build, so the
+#   heavy site/examples build is chained into test-command before Playwright
+#   runs (`bun run e2e:start` then only serves the prebuilt dist).
+# - The full suite includes @visual Jekyll snapshots; the runner's system Ruby
+#   (>= 3.1 satisfies the gemspec) plus a local-path bundle install makes
+#   `prepare-examples.mjs` build the Jekyll example, matching the old
+#   setup-env skip-ruby=false behaviour.
+# - allowed-endpoints is the complete enforced allowlist (pre-enforcement
+#   replace semantics, lgtm-ci#467): playwright preset + Playwright CDN
+#   fallbacks + Ubuntu apt mirrors (+ RubyGems on the full-suite leg).
 jobs:
-  e2e-matrix:
-    name: ${{ matrix.display_name }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: ${{ matrix.timeout }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - id: e2e
-            display_name: '🎭 E2E Tests'
-            run_command: 'bun run e2e:ci'
-            timeout: 30
-            artifact_prefix: 'playwright'
-            comment_marker: 'playwright-e2e-comment'
-            comment_file: 'playwright-e2e-comment.md'
-          - id: smoke
-            display_name: '🔥 E2E Smoke Tests'
-            run_command: 'bun run e2e:smoke'
-            timeout: 15
-            artifact_prefix: 'playwright-smoke'
-            comment_marker: 'playwright-e2e-smoke-comment'
-            comment_file: 'playwright-e2e-smoke-comment.md'
-          - id: a11y
-            display_name: '♿ E2E Accessibility Tests'
-            run_command: 'bun run e2e:a11y'
-            timeout: 15
-            artifact_prefix: 'playwright-a11y'
-            comment_marker: 'playwright-e2e-a11y-comment'
-            comment_file: 'playwright-e2e-a11y-comment.md'
-    steps:
-      - name: Harden Runner
-        if: ${{ !env.ACT }}
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            api.rubygems.org:443
-            archive.ubuntu.com:443
-            azure.archive.ubuntu.com:443
-            bun.sh:443
-            bundler.rubygems.org:443
-            cache.ruby-lang.org:443
-            cdn.playwright.dev:443
-            codeload.github.com:443
-            esm.ubuntu.com:443
-            files.pythonhosted.org:443
-            github-releases.githubusercontent.com:443
-            github.com:443
-            index.rubygems.org:443
-            motd.ubuntu.com:443
-            npmjs.org:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            pkg-containers.githubusercontent.com:443
-            playwright-akamai.azureedge.net:443
-            playwright-verizon.azureedge.net:443
-            playwright.azureedge.net:443
-            playwright.download.prss.microsoft.com:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            registry.npmjs.org:443
-            release-assets.githubusercontent.com:443
-            rubygems-downloads.global.ssl.fastly.net:443
-            rubygems.global.ssl.fastly.net:443
-            rubygems.org:443
-            security.ubuntu.com:443
-            storage.googleapis.com:443
-            uploads.github.com:443
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-        with:
-          node-version: '${{ env.NODE_VERSION }}'
-          skip-ruby: 'false'
-      - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-      - name: Install Playwright browsers
-        env:
-          PLAYWRIGHT_DOWNLOAD_HOST: https://cdn.playwright.dev
-        run: bun run e2e:install
-      - name: Build Astro site
-        run: bun run e2e:prep
-      - name: Run tests
-        run: ${{ matrix.run_command }}
-      - name: Generate Playwright PR comment
-        if: github.event_name == 'pull_request' && always()
-        run: ./scripts/ci/generate-playwright-comment.sh
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          COMMENT_MARKER: ${{ matrix.comment_marker }}
-          COMMENT_FILE: ${{ matrix.comment_file }}
-      - name: Post Playwright comment on PR
-        if: github.event_name == 'pull_request' && always()
-        uses: ./.github/actions/post-pr-comment
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-file: ${{ matrix.comment_file }}
-          marker: ${{ matrix.comment_marker }}
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: ${{ matrix.artifact_prefix }}-report
-          path: playwright-report/
-          retention-days: 30
-          if-no-files-found: ignore
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: e2e-${{ matrix.id }}-results
-          path: test-results/
-          retention-days: 30
-          if-no-files-found: ignore
-      - name: Validate action pinning (strict)
-        if: matrix.id == 'e2e'
-        run: ./scripts/ci/validate-action-pinning.sh --strict
-      - name: Validate action SHAs (strict)
-        if: matrix.id == 'e2e'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/ci/validate-action-shas.sh --strict
+  # Org ruleset context: e2e / 🎭 E2E Tests
+  e2e:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
+    with:
+      job-name: '🎭 E2E Tests'
+      test-command: >-
+        bundle config set --local path vendor/bundle &&
+        bundle install &&
+        bun run e2e:prep &&
+        bun run e2e:ci
+      node-version: '22'
+      browsers: chromium
+      package-manager: bun
+      comment-marker: playwright-e2e-comment
+      timeout-minutes: 30
+      tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
+      egress-policy: block
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+        cdn.playwright.dev:443
+        playwright.azureedge.net:443
+        playwright-akamai.azureedge.net:443
+        playwright-verizon.azureedge.net:443
+        playwright.download.prss.microsoft.com:443
+        storage.googleapis.com:443
+        archive.ubuntu.com:80
+        security.ubuntu.com:80
+        azure.archive.ubuntu.com:80
+        esm.ubuntu.com:443
+        packages.microsoft.com:443
+        rubygems.org:443
+        api.rubygems.org:443
+        index.rubygems.org:443
+        bundler.rubygems.org:443
+        rubygems.global.ssl.fastly.net:443
+        rubygems-downloads.global.ssl.fastly.net:443
+    permissions:
+      contents: read
+      pull-requests: write
+
+  # Org ruleset context: smoke / 🔥 E2E Smoke Tests
+  smoke:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
+    with:
+      job-name: '🔥 E2E Smoke Tests'
+      test-command: >-
+        bun run e2e:prep &&
+        bun run e2e:ci
+      grep: '@smoke'
+      node-version: '22'
+      browsers: chromium
+      package-manager: bun
+      comment-marker: playwright-e2e-smoke-comment
+      timeout-minutes: 15
+      tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
+      egress-policy: block
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+        cdn.playwright.dev:443
+        playwright.azureedge.net:443
+        playwright-akamai.azureedge.net:443
+        playwright-verizon.azureedge.net:443
+        playwright.download.prss.microsoft.com:443
+        storage.googleapis.com:443
+        archive.ubuntu.com:80
+        security.ubuntu.com:80
+        azure.archive.ubuntu.com:80
+        esm.ubuntu.com:443
+        packages.microsoft.com:443
+    permissions:
+      contents: read
+      pull-requests: write
+
+  # Org ruleset context: a11y / ♿ E2E Accessibility Tests
+  a11y:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
+    with:
+      job-name: '♿ E2E Accessibility Tests'
+      test-command: >-
+        bun run e2e:prep &&
+        bun run e2e:ci
+      grep: '@a11y'
+      node-version: '22'
+      browsers: chromium
+      package-manager: bun
+      comment-marker: playwright-e2e-a11y-comment
+      timeout-minutes: 15
+      tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
+      egress-policy: block
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+        cdn.playwright.dev:443
+        playwright.azureedge.net:443
+        playwright-akamai.azureedge.net:443
+        playwright-verizon.azureedge.net:443
+        playwright.download.prss.microsoft.com:443
+        storage.googleapis.com:443
+        archive.ubuntu.com:80
+        security.ubuntu.com:80
+        azure.archive.ubuntu.com:80
+        esm.ubuntu.com:443
+        packages.microsoft.com:443
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -20,19 +20,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  sbom:
-    name: 📋 Generate & Sign SBOM
-    uses: ./.github/workflows/reusable-sbom.yml
-    permissions:
-      contents: read
-      id-token: write
-
   # Note: npm, PyPI, and RubyGems publishing are handled by separate workflows
   # (publish-npm.yml, publish-python.yml, publish-gem.yml) triggered on tag push
 
   github-release:
     name: 🚀 Create GitHub Release
-    needs: [sbom]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -56,26 +48,10 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - name: Download SBOM artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: sbom-all-formats
-          path: sbom/
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           token: ${{ steps.app-token.outputs.token }}
-          files: |
-            sbom/sbom.cyclonedx.json
-            sbom/sbom.cyclonedx.json.sig
-            sbom/sbom.cyclonedx.json.cert
-            sbom/sbom.spdx.json
-            sbom/sbom.spdx.json.sig
-            sbom/sbom.spdx.json.cert
-            sbom/sbom.cyclonedx.xml
-            sbom/sbom.cyclonedx.xml.sig
-            sbom/sbom.cyclonedx.xml.cert
           body: |
             ## 📦 @turbocoder13/turbo-themes ${{ github.ref_name }}
 
@@ -84,9 +60,9 @@ jobs:
             ### 📋 Software Bill of Materials (SBOM)
 
             This release includes signed SBOM files in multiple formats:
-            - **CycloneDX JSON**: `sbom.cyclonedx.json` (+ signature & certificate)
-            - **SPDX JSON**: `sbom.spdx.json` (+ signature & certificate)
-            - **CycloneDX XML**: `sbom.cyclonedx.xml` (+ signature & certificate)
+            - **CycloneDX JSON**: `sbom.cyclonedx.json` (+ signature bundle)
+            - **SPDX JSON**: `sbom.spdx.json` (+ signature bundle)
+            - **CycloneDX XML**: `sbom.cyclonedx.xml` (+ signature bundle)
 
             All SBOM files are signed using [Sigstore](https://www.sigstore.dev/) keyless signing.
 
@@ -106,3 +82,25 @@ jobs:
             echo "## GitHub Release Summary"
             echo "✅ Release ${{ github.ref_name }} published and released"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Generate multi-format SBOMs at the release tag, cosign-sign them, and
+  # attach them to the release created above (lgtm-ci reusable-sbom.yml
+  # release-assets mode; lgtm-ci#520).
+  sbom:
+    needs: [github-release]
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
+    with:
+      mode: release-assets
+      job-name: '📋 Generate & Sign SBOM'
+      target: .
+      target-type: dir
+      formats: 'spdx-json,cyclonedx-json,cyclonedx-xml'
+      sign: true
+      release-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
+      egress-policy: block
+      egress-preset: sbom
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -59,7 +59,9 @@ jobs:
 
             ### 📋 Software Bill of Materials (SBOM)
 
-            This release includes signed SBOM files in multiple formats:
+            Signed SBOM files are attached to this release by the SBOM job
+            immediately after publish (allow a few minutes for the assets to
+            appear), in multiple formats:
             - **CycloneDX JSON**: `sbom.cyclonedx.json` (+ signature bundle)
             - **SPDX JSON**: `sbom.spdx.json` (+ signature bundle)
             - **CycloneDX XML**: `sbom.cyclonedx.xml` (+ signature bundle)

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -17,11 +17,13 @@ concurrency:
 
 jobs:
   # Org ruleset (checks-turbo-themes): sbom / 📋 SBOM & Supply Chain
-  # Release-asset SBOMs (multi-format + cosign signatures) are still produced
-  # by the local reusable-sbom.yml called from the publish workflows.
+  # Release-asset SBOMs (multi-format + cosign signatures) are produced by the
+  # lgtm-ci reusable-sbom.yml release-assets mode in release-publish-pr.yml;
+  # the local reusable-sbom.yml remains only for the publish-* workflows until
+  # the release-flow migration (lgtm-ci#520 follow-up).
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@443a687caa93b3afa306a066aae8d8a2b4e60c3c # v0.59.0
     with:
       job-name: '📋 SBOM & Supply Chain'
       target: .
@@ -32,12 +34,12 @@ jobs:
       # reusable-sbom.yml for disabling the severity gate entirely (not a
       # severity level — valid levels are critical/high/medium/low/none).
       # Pre-migration posture preserved — the hand-rolled SBOM job never
-      # gated on scan findings. Default in v0.52 is critical; revisit once
+      # gated on scan findings. Default in v0.59 is critical; revisit once
       # the vulnerability baseline is clean.
       fail-on-severity: ''
       create-attestation: true
       runner-image: ubuntu-24.04
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c' # v0.59.0
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/scripts/ci/bootstrap-build-quick.sh
+++ b/scripts/ci/bootstrap-build-quick.sh
@@ -13,9 +13,22 @@ if ! command -v bun >/dev/null 2>&1; then
 fi
 echo "bun version: $(bun --version)"
 
+# Pinned uv release with checksum verification (no curl | sh), consistent
+# with the repo's SHA-pinning posture. Bump version + sha256 together.
+UV_VERSION="0.11.29"
+UV_SHA256="04f8b82f5d47f0512dcd32c67a4a6f16a0ea27c81537c338fd0ad6b23cebe829"
+UV_TARBALL="uv-x86_64-unknown-linux-gnu.tar.gz"
+
 if ! command -v uv >/dev/null 2>&1; then
-  echo "Installing uv..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  echo "Installing uv ${UV_VERSION}..."
+  tmpdir="$(mktemp -d)"
+  curl -LsSf -o "${tmpdir}/${UV_TARBALL}" \
+    "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TARBALL}"
+  echo "${UV_SHA256}  ${tmpdir}/${UV_TARBALL}" | sha256sum -c -
+  tar -xzf "${tmpdir}/${UV_TARBALL}" -C "${tmpdir}"
+  mkdir -p "${HOME}/.local/bin"
+  install -m 0755 "${tmpdir}/uv-x86_64-unknown-linux-gnu/uv" "${HOME}/.local/bin/uv"
+  rm -rf "${tmpdir}"
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 echo "uv version: $(uv --version)"

--- a/scripts/ci/bootstrap-build-quick.sh
+++ b/scripts/ci/bootstrap-build-quick.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Bootstrap the toolchain on a bare Node.js runner, then run the quick CI
+# pipeline. Used as the build-command for the lgtm-ci reusable-build-artifact
+# caller in quality-ci-main.yml, which provisions Node.js only — the pipeline
+# itself needs bun (package manager) and uv (lintro lint gate, Python tests).
+# Usage: bootstrap-build-quick.sh
+
+set -euo pipefail
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Installing bun..."
+  npm install -g bun
+fi
+echo "bun version: $(bun --version)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+echo "uv version: $(uv --version)"
+
+./scripts/local/build.sh --quick

--- a/scripts/ci/bootstrap-e2e-full.sh
+++ b/scripts/ci/bootstrap-e2e-full.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Full-suite E2E entrypoint for the lgtm-ci Playwright reusable caller in
+# quality-e2e.yml. The reusable provisions Node + Bun only, but the full suite's
+# @visual Jekyll snapshots need `bundle exec jekyll build` during e2e:prep. The
+# pre-migration job provisioned Ruby via ruby/setup-ruby (setup-env,
+# skip-ruby=false); the hosted ubuntu-24.04 image exposes no ruby/bundler on
+# PATH, so install them here (apt Ruby satisfies the gemspec's >= 3.1).
+#
+# Trailing arguments are the Playwright filter/reporter flags appended by
+# lgtm-ci's run-playwright-tests.sh; forward them to the playwright command.
+# Usage: bootstrap-e2e-full.sh [playwright-args...]
+
+set -euo pipefail
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "Installing Ruby via apt..."
+  sudo apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ruby-full
+fi
+echo "ruby: $(ruby --version)"
+
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "Installing bundler..."
+  sudo gem install bundler --no-document
+fi
+echo "bundler: $(bundle --version)"
+
+# Vendor the bundle locally so `bundle exec jekyll build` (prepare-examples.mjs)
+# resolves gems without writing to system paths.
+bundle config set --local path vendor/bundle
+bundle install
+
+# Heavy prep build up front: the playwright.config webServer timeout (120s) is
+# too short for a cold e2e:prep, so the webServer then only serves the dist.
+bun run e2e:prep
+
+exec bun run e2e:ci "$@"


### PR DESCRIPTION
## Summary

Migrates turbo-themes' bespoke CI onto lgtm-ci reusable workflows, all pinned to `443a687caa93b3afa306a066aae8d8a2b4e60c3c` (v0.59.0), with `tooling-ref` passed everywhere it is accepted.

- **E2E** (`quality-e2e.yml`): the 3-leg hand-rolled Playwright matrix is now three thin callers over `reusable-test-e2e-playwright.yml` (`e2e` / `smoke` / `a11y`), package-manager bun, chromium, Node 22. Smoke/a11y are expressed via the reusable's `grep` input (`@smoke` / `@a11y`); the full suite runs `bun run e2e:ci` (= `playwright test`). PR summary comment markers are preserved via `comment-marker` (`playwright-e2e-comment`, `playwright-e2e-smoke-comment`, `playwright-e2e-a11y-comment`). Workflow-level concurrency group unchanged.
- **Build matrix** (`quality-ci-main.yml`): the Node 20/22 build legs now call `reusable-build-artifact.yml` with `node-version-matrix: '["20","22"]'` and `job-name: '🏗️ Build & Quality Checks'`. Matrix mode appends `-<node-version>`, so the legs upload `js-dist-20` / `js-dist-22`; `📦 Validate Examples` keeps its own logic (it is a Playwright test job, not build-artifact-shaped) and now downloads `js-dist-22`. A new `scripts/ci/bootstrap-build-quick.sh` bootstraps bun + uv on the reusable's bare Node runner before `./scripts/local/build.sh --quick`.
- **SBOM**: `security-sbom.yml` bumped v0.52.3 → v0.59.0 (same caller job id `sbom`, same inner name, so the required context is unchanged). The release-asset SBOM path in `release-publish-pr.yml` now uses lgtm-ci `reusable-sbom.yml` **release-assets mode** (spdx-json, cyclonedx-json, cyclonedx-xml + cosign keyless signing, uploaded to the GitHub Release after `github-release` creates it).

## Required-context changes

Old context → new context for every required check affected (feeds the org-ruleset swap):

| Old required context | New required context |
| --- | --- |
| `🎭 E2E Tests` | `e2e / 🎭 E2E Tests` |
| `🔥 E2E Smoke Tests` | `smoke / 🔥 E2E Smoke Tests` |
| `♿ E2E Accessibility Tests` | `a11y / ♿ E2E Accessibility Tests` |
| `🏗️ Build & Quality Checks (20)` | `build / 🏗️ Build & Quality Checks (20)` |
| `🏗️ Build & Quality Checks (22)` | `build / 🏗️ Build & Quality Checks (22)` |
| `📦 Validate Examples` | `📦 Validate Examples` (unchanged) |
| `sbom / 📋 SBOM & Supply Chain` | `sbom / 📋 SBOM & Supply Chain` (unchanged; pin bump only) |

## Behaviors not expressible through the reusables' inputs

- **E2E prep build**: the reusable has no build/prep hook and the `playwright.config.ts` webServer timeout (120 s) is too short for a cold `e2e:prep`, so the prep build runs inside `test-command` (chained for smoke/a11y; via the bootstrap script for the full suite).
- **Jekyll example on the full suite**: the old workflow provisioned Ruby via `ruby/setup-ruby` (through `setup-env`) for the `@visual` Jekyll snapshots; the hosted ubuntu-24.04 image exposes no ruby/bundler on PATH and the reusable cannot install Ruby. The `e2e` leg's `test-command` is `scripts/ci/bootstrap-e2e-full.sh`, which apt-installs Ruby, installs bundler, vendors the bundle, runs `e2e:prep`, then execs the Playwright command forwarding the reusable's appended filter/reporter flags. RubyGems + apt endpoints are on that leg's allowlist.
- **Strict action-pinning steps** (`validate-action-pinning.sh --strict`, `validate-action-shas.sh --strict`) previously ran on the `e2e` matrix leg; not expressible through the reusable. Coverage remains via `quality-validate-action-pinning.yml` (lgtm-ci reusable) and `test/validate-action-shas.test.ts`.
- **Node-22-only reporting side effects** of the old build matrix (Codecov upload, PR coverage comment, coverage badges, `coverage-html` Pages artifact consumed by `deploy-pages.yml`, `site-build`, `sbom-cyclonedx` artifact, commit-message / semantic-release-trigger / version-sync validation) are not expressible through `reusable-build-artifact.yml`. They live in a retained `📊 Coverage & Reporting` job (non-required context) that runs `build.sh --quick --skip-lint` once on Node 22, preserving the `Quality Check - CI Pipeline` → `deploy-pages.yml` `workflow_run` handoff.
- **Draft PRs**: the reusables default `draft-pr-skip: true`; the old E2E matrix also ran on drafts. Left at the lgtm-ci default.
- **PR comment format**: Playwright PR comments now use the lgtm-ci test-summary format instead of `generate-playwright-comment.sh`; markers are preserved so existing comments upsert.

## Deliberately out of scope

- Release flow / `reusable-release-multi-ecosystem` migration (separate follow-up). Consequently the **local `reusable-sbom.yml` is kept**: it is still referenced by `publish-npm.yml`, `publish-npm-test.yml`, and `publish-gem.yml`; it can be deleted when those migrate.
- Other existing lgtm-ci callers (quality-lintro, codeql, scorecards, dependency-review, semantic-pr-title, pr-auto-assign, vuln-suppression, validate-action-pinning) stay on their current pins — `maintenance-auto-bump-refs.yml` handles routine bumps.

## Validation

- `uv run lintro fmt` + `uv run lintro chk`: 0 issues
- `actionlint` on all touched workflows: clean
- `./scripts/ci/validate-action-pinning.sh --strict`: pass
- `bunx vitest run test/validate-action-shas.test.ts`: 5/5 pass

Part of lgtm-hq/lgtm-ci#520

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates turbo-themes' bespoke CI workflows onto pinned lgtm-ci reusable callers (`v0.59.0` / `443a687`), replacing the hand-rolled Playwright matrix, the Node 20/22 build matrix, and the SBOM release-asset job. All prior review concerns have been addressed: the `uv` installer now uses a pinned version with SHA256 checksum verification, the release body has been softened to acknowledge the SBOM-attach delay, and the egress allowlists document their pre-enforcement semantics.

- **E2E** (`quality-e2e.yml`): Three thin callers replace the old matrix — `e2e` (full suite + Ruby/Jekyll via `bootstrap-e2e-full.sh`), `smoke` / `a11y` (inline prep + grep filter, no Ruby dependency). Org-ruleset contexts updated to the new `<job>/<name>` form.
- **Build** (`quality-ci-main.yml`): `reusable-build-artifact.yml` with `node-version-matrix: ["20","22"]` uploads `js-dist-20`/`js-dist-22`; a retained `reporting` job handles coverage, Pages artifact, and the SBOM artifact without a `needs: [build]` dependency. The `examples` job correctly downloads `js-dist-22`.
- **SBOM/release** (`release-publish-pr.yml`, `security-sbom.yml`): SBOM now runs in `release-assets` mode after `github-release`, cosign-signing all three formats and attaching them to the release. The periodic security scan is bumped to v0.59.0.
</details>

<h3>Confidence Score: 5/5</h3>

The migration is well-scoped: all changed jobs have correct needs chains, egress allowlists are documented with pre-enforcement semantics, and the previously flagged supply-chain and timing issues were addressed before this review.

The three new reusable callers and two bootstrap scripts are straightforward thin wrappers. The uv installer in bootstrap-build-quick.sh is properly pinned with a version and SHA256. The artifact rename from js-dist to js-dist-22 is correctly propagated to the examples download step. The reporting job preserves all node-22-only side effects without disturbing the build reusable's clean interface. The only non-trivial change is bundler being installed without a version pin in bootstrap-e2e-full.sh, which is a consistency nit rather than a blocking issue.

No files require special attention. bootstrap-e2e-full.sh has a minor bundler version-pin gap noted in the inline comment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/bootstrap-build-quick.sh | New bootstrap script for the lgtm-ci build-artifact reusable; installs bun via npm and uv with a pinned version + SHA256 integrity check — correctly follows the repo's action-pinning posture after the previous review cycle. |
| scripts/ci/bootstrap-e2e-full.sh | New E2E bootstrap for the full-suite leg; installs Ruby via apt and bundler via gem (unpinned) before running e2e:prep + e2e:ci. Bundler version is not pinned, unlike the uv install in bootstrap-build-quick.sh. |
| .github/workflows/quality-e2e.yml | Three thin callers over reusable-test-e2e-playwright.yml; full suite uses bootstrap-e2e-full.sh (Ruby), smoke/a11y use inline prep + grep filter. Prior review issues are documented and partially addressed. |
| .github/workflows/quality-ci-main.yml | Build matrix migrated to reusable-build-artifact.yml; retained reporting job for coverage/Codecov/Pages/SBOM with --skip-lint. Artifact rename to js-dist-22 correctly threaded through the examples job's download step. |
| .github/workflows/release-publish-pr.yml | SBOM generation moved to lgtm-ci reusable-sbom.yml in release-assets mode; github-release now runs first then sbom attaches assets. Release body text updated to acknowledge the post-publish delay. |
| .github/workflows/security-sbom.yml | Minimal change: pin bump from v0.52.3 to v0.59.0 on both the reusable ref and tooling-ref, with updated comment. No logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PR as Push / PR
    participant B as build (reusable-build-artifact)
    participant R as reporting (Coverage)
    participant E as examples (Validate)
    participant E2E as e2e / smoke / a11y
    participant GR as github-release
    participant S as sbom (release-assets)

    PR->>B: trigger (Node 20 + 22 matrix)
    PR->>R: trigger (parallel, no dependency)
    B-->>E: js-dist-22 artifact
    B->>E: needs: [build]
    E->>E: Validate examples (Playwright)
    PR->>E2E: trigger (3 parallel callers)
    Note over E2E: e2e: bootstrap-e2e-full.sh (Ruby + bundle + e2e:prep + e2e:ci)
    Note over E2E: smoke/a11y: e2e:prep + e2e:ci --grep
    PR->>GR: on tag push / workflow_dispatch
    GR-->>S: github-release creates release
    S->>S: needs: [github-release]
    S->>GR: attach SBOM assets (spdx-json, cyclonedx-json, cyclonedx-xml + cosign sig)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PR as Push / PR
    participant B as build (reusable-build-artifact)
    participant R as reporting (Coverage)
    participant E as examples (Validate)
    participant E2E as e2e / smoke / a11y
    participant GR as github-release
    participant S as sbom (release-assets)

    PR->>B: trigger (Node 20 + 22 matrix)
    PR->>R: trigger (parallel, no dependency)
    B-->>E: js-dist-22 artifact
    B->>E: needs: [build]
    E->>E: Validate examples (Playwright)
    PR->>E2E: trigger (3 parallel callers)
    Note over E2E: e2e: bootstrap-e2e-full.sh (Ruby + bundle + e2e:prep + e2e:ci)
    Note over E2E: smoke/a11y: e2e:prep + e2e:ci --grep
    PR->>GR: on tag push / workflow_dispatch
    GR-->>S: github-release creates release
    S->>S: needs: [github-release]
    S->>GR: attach SBOM assets (spdx-json, cyclonedx-json, cyclonedx-xml + cosign sig)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: bootstrap Ruby for full E2E suite an..."](https://github.com/lgtm-hq/turbo-themes/commit/1606e61e4b40a4e8369f39f2c8c6cb2f8e65a11a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45294303)</sub>

<!-- /greptile_comment -->