### PR TITLE
fix(release): regenerate committed tokens.json artifacts to 27 themes

### DIFF
--- a/packages/core/src/themes/tokens.json
+++ b/packages/core/src/themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
-  "$description": "Turbo Themes - Flat tokens for 24 themes",
+  "$description": "Turbo Themes - Flat tokens for 27 themes",
   "$version": "0.28.2",
-  "$generated": "b3da67d991753dc075eead57d47de7dc091026dfecbcb1e7514f0c5037861915",
+  "$generated": "af7638d05b7647137edbcc683d0a32debd8c30e0bbd5f287db36e4ee75400759",
   "meta": {
     "themeIds": [
       "bulma-dark",
@@ -21,16 +21,19 @@
       "gruvbox-light-soft",
       "gruvbox-light",
       "nord",
+      "one-dark",
+      "one-light",
       "rose-pine-dawn",
       "rose-pine-moon",
       "rose-pine",
       "solarized-dark",
       "solarized-light",
+      "terminal",
       "tokyo-night-dark",
       "tokyo-night-light",
       "tokyo-night-storm"
     ],
-    "totalThemes": 24
+    "totalThemes": 27
   },
   "shared": {
     "spacing": {
@@ -1896,6 +1899,174 @@
         }
       }
     },
+    "one-dark": {
+      "id": "one-dark",
+      "label": "One Dark",
+      "vendor": "one-dark",
+      "appearance": "dark",
+      "tokens": {
+        "background": {
+          "base": "#282c34",
+          "surface": "#2c313a",
+          "overlay": "#3e4451"
+        },
+        "text": {
+          "primary": "#abb2bf",
+          "secondary": "#828997",
+          "inverse": "#282c34"
+        },
+        "brand": {
+          "primary": "#61afef"
+        },
+        "state": {
+          "info": "#56b6c2",
+          "success": "#98c379",
+          "warning": "#e5c07b",
+          "danger": "#e06c75"
+        },
+        "border": {
+          "default": "#3e4451"
+        },
+        "accent": {
+          "link": "#61afef"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+            "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#61afef",
+            "h2": "#c678dd",
+            "h3": "#98c379",
+            "h4": "#e5c07b",
+            "h5": "#d19a66",
+            "h6": "#56b6c2"
+          },
+          "body": {
+            "primary": "#abb2bf",
+            "secondary": "#828997"
+          },
+          "link": {
+            "default": "#61afef"
+          },
+          "selection": {
+            "fg": "#abb2bf",
+            "bg": "#3e4451"
+          },
+          "blockquote": {
+            "border": "#3e4451",
+            "fg": "#828997",
+            "bg": "#2c313a"
+          },
+          "codeInline": {
+            "fg": "#c678dd",
+            "bg": "#2c313a"
+          },
+          "codeBlock": {
+            "fg": "#abb2bf",
+            "bg": "#21252b"
+          },
+          "table": {
+            "border": "#3e4451",
+            "stripe": "#2c313a",
+            "theadBg": "#3e4451"
+          }
+        }
+      }
+    },
+    "one-light": {
+      "id": "one-light",
+      "label": "One Light",
+      "vendor": "one-dark",
+      "appearance": "light",
+      "tokens": {
+        "background": {
+          "base": "#fafafa",
+          "surface": "#f0f0f0",
+          "overlay": "#e5e5e6"
+        },
+        "text": {
+          "primary": "#383a42",
+          "secondary": "#696c77",
+          "inverse": "#fafafa"
+        },
+        "brand": {
+          "primary": "#4078f2"
+        },
+        "state": {
+          "info": "#0184bc",
+          "success": "#50a14f",
+          "warning": "#c18401",
+          "danger": "#e45649",
+          "infoText": "#000000",
+          "successText": "#000000",
+          "warningText": "#000000",
+          "dangerText": "#000000"
+        },
+        "border": {
+          "default": "#d0d0d1"
+        },
+        "accent": {
+          "link": "#4078f2"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+            "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#4078f2",
+            "h2": "#a626a4",
+            "h3": "#50a14f",
+            "h4": "#c18401",
+            "h5": "#986801",
+            "h6": "#0184bc"
+          },
+          "body": {
+            "primary": "#383a42",
+            "secondary": "#696c77"
+          },
+          "link": {
+            "default": "#4078f2"
+          },
+          "selection": {
+            "fg": "#383a42",
+            "bg": "#dfe1e5"
+          },
+          "blockquote": {
+            "border": "#d0d0d1",
+            "fg": "#696c77",
+            "bg": "#f0f0f0"
+          },
+          "codeInline": {
+            "fg": "#a626a4",
+            "bg": "#e5e5e6"
+          },
+          "codeBlock": {
+            "fg": "#383a42",
+            "bg": "#e5e5e6"
+          },
+          "table": {
+            "border": "#d0d0d1",
+            "stripe": "#f0f0f0",
+            "theadBg": "#e5e5e6"
+          }
+        }
+      }
+    },
     "rose-pine-dawn": {
       "id": "rose-pine-dawn",
       "label": "Rosé Pine Dawn",
@@ -2406,6 +2577,88 @@
         }
       }
     },
+    "terminal": {
+      "id": "terminal",
+      "label": "Terminal",
+      "vendor": "turbo",
+      "appearance": "dark",
+      "tokens": {
+        "background": {
+          "base": "#0d0d0d",
+          "surface": "#080808",
+          "overlay": "#111111"
+        },
+        "text": {
+          "primary": "#c8ffc8",
+          "secondary": "#8fbc8f",
+          "inverse": "#0d0d0d"
+        },
+        "brand": {
+          "primary": "#39ff14"
+        },
+        "state": {
+          "info": "#7dd3fc",
+          "success": "#39ff14",
+          "warning": "#ffb000",
+          "danger": "#ff4444"
+        },
+        "border": {
+          "default": "#1f3d1f"
+        },
+        "accent": {
+          "link": "#7dd3fc"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
+            "mono": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#39ff14",
+            "h2": "#7dd3fc",
+            "h3": "#ffb000",
+            "h4": "#39ff14",
+            "h5": "#8fbc8f",
+            "h6": "#c8ffc8"
+          },
+          "body": {
+            "primary": "#c8ffc8",
+            "secondary": "#8fbc8f"
+          },
+          "link": {
+            "default": "#7dd3fc"
+          },
+          "selection": {
+            "fg": "#0d0d0d",
+            "bg": "#39ff14"
+          },
+          "blockquote": {
+            "border": "#39ff14",
+            "fg": "#8fbc8f",
+            "bg": "#111111"
+          },
+          "codeInline": {
+            "fg": "#ffb000",
+            "bg": "#111111"
+          },
+          "codeBlock": {
+            "fg": "#c8ffc8",
+            "bg": "#080808"
+          },
+          "table": {
+            "border": "#1f3d1f",
+            "stripe": "#111111",
+            "theadBg": "#080808",
+            "headerFg": "#c8ffc8"
+          }
+        }
+      }
+    },
     "tokyo-night-dark": {
       "id": "tokyo-night-dark",
       "label": "Tokyo Night Dark",
@@ -2706,6 +2959,14 @@
         "nord"
       ]
     },
+    "one-dark": {
+      "name": "One",
+      "homepage": "https://github.com/Binaryify/OneDark-Pro",
+      "themes": [
+        "one-dark",
+        "one-light"
+      ]
+    },
     "rose-pine": {
       "name": "Rosé Pine (synced)",
       "homepage": "https://rosepinetheme.com/",
@@ -2721,6 +2982,13 @@
       "themes": [
         "solarized-dark",
         "solarized-light"
+      ]
+    },
+    "turbo": {
+      "name": "Terminal",
+      "homepage": "https://github.com/lgtm-hq/turbo-themes",
+      "themes": [
+        "terminal"
       ]
     },
     "tokyo-night": {

--- a/python/src/turbo_themes/tokens.json
+++ b/python/src/turbo_themes/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
-  "$description": "Turbo Themes - Flat tokens for 24 themes",
+  "$description": "Turbo Themes - Flat tokens for 27 themes",
   "$version": "0.28.2",
-  "$generated": "b3da67d991753dc075eead57d47de7dc091026dfecbcb1e7514f0c5037861915",
+  "$generated": "af7638d05b7647137edbcc683d0a32debd8c30e0bbd5f287db36e4ee75400759",
   "meta": {
     "themeIds": [
       "bulma-dark",
@@ -21,16 +21,19 @@
       "gruvbox-light-soft",
       "gruvbox-light",
       "nord",
+      "one-dark",
+      "one-light",
       "rose-pine-dawn",
       "rose-pine-moon",
       "rose-pine",
       "solarized-dark",
       "solarized-light",
+      "terminal",
       "tokyo-night-dark",
       "tokyo-night-light",
       "tokyo-night-storm"
     ],
-    "totalThemes": 24
+    "totalThemes": 27
   },
   "shared": {
     "spacing": {
@@ -1896,6 +1899,174 @@
         }
       }
     },
+    "one-dark": {
+      "id": "one-dark",
+      "label": "One Dark",
+      "vendor": "one-dark",
+      "appearance": "dark",
+      "tokens": {
+        "background": {
+          "base": "#282c34",
+          "surface": "#2c313a",
+          "overlay": "#3e4451"
+        },
+        "text": {
+          "primary": "#abb2bf",
+          "secondary": "#828997",
+          "inverse": "#282c34"
+        },
+        "brand": {
+          "primary": "#61afef"
+        },
+        "state": {
+          "info": "#56b6c2",
+          "success": "#98c379",
+          "warning": "#e5c07b",
+          "danger": "#e06c75"
+        },
+        "border": {
+          "default": "#3e4451"
+        },
+        "accent": {
+          "link": "#61afef"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+            "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#61afef",
+            "h2": "#c678dd",
+            "h3": "#98c379",
+            "h4": "#e5c07b",
+            "h5": "#d19a66",
+            "h6": "#56b6c2"
+          },
+          "body": {
+            "primary": "#abb2bf",
+            "secondary": "#828997"
+          },
+          "link": {
+            "default": "#61afef"
+          },
+          "selection": {
+            "fg": "#abb2bf",
+            "bg": "#3e4451"
+          },
+          "blockquote": {
+            "border": "#3e4451",
+            "fg": "#828997",
+            "bg": "#2c313a"
+          },
+          "codeInline": {
+            "fg": "#c678dd",
+            "bg": "#2c313a"
+          },
+          "codeBlock": {
+            "fg": "#abb2bf",
+            "bg": "#21252b"
+          },
+          "table": {
+            "border": "#3e4451",
+            "stripe": "#2c313a",
+            "theadBg": "#3e4451"
+          }
+        }
+      }
+    },
+    "one-light": {
+      "id": "one-light",
+      "label": "One Light",
+      "vendor": "one-dark",
+      "appearance": "light",
+      "tokens": {
+        "background": {
+          "base": "#fafafa",
+          "surface": "#f0f0f0",
+          "overlay": "#e5e5e6"
+        },
+        "text": {
+          "primary": "#383a42",
+          "secondary": "#696c77",
+          "inverse": "#fafafa"
+        },
+        "brand": {
+          "primary": "#4078f2"
+        },
+        "state": {
+          "info": "#0184bc",
+          "success": "#50a14f",
+          "warning": "#c18401",
+          "danger": "#e45649",
+          "infoText": "#000000",
+          "successText": "#000000",
+          "warningText": "#000000",
+          "dangerText": "#000000"
+        },
+        "border": {
+          "default": "#d0d0d1"
+        },
+        "accent": {
+          "link": "#4078f2"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+            "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#4078f2",
+            "h2": "#a626a4",
+            "h3": "#50a14f",
+            "h4": "#c18401",
+            "h5": "#986801",
+            "h6": "#0184bc"
+          },
+          "body": {
+            "primary": "#383a42",
+            "secondary": "#696c77"
+          },
+          "link": {
+            "default": "#4078f2"
+          },
+          "selection": {
+            "fg": "#383a42",
+            "bg": "#dfe1e5"
+          },
+          "blockquote": {
+            "border": "#d0d0d1",
+            "fg": "#696c77",
+            "bg": "#f0f0f0"
+          },
+          "codeInline": {
+            "fg": "#a626a4",
+            "bg": "#e5e5e6"
+          },
+          "codeBlock": {
+            "fg": "#383a42",
+            "bg": "#e5e5e6"
+          },
+          "table": {
+            "border": "#d0d0d1",
+            "stripe": "#f0f0f0",
+            "theadBg": "#e5e5e6"
+          }
+        }
+      }
+    },
     "rose-pine-dawn": {
       "id": "rose-pine-dawn",
       "label": "Rosé Pine Dawn",
@@ -2406,6 +2577,88 @@
         }
       }
     },
+    "terminal": {
+      "id": "terminal",
+      "label": "Terminal",
+      "vendor": "turbo",
+      "appearance": "dark",
+      "tokens": {
+        "background": {
+          "base": "#0d0d0d",
+          "surface": "#080808",
+          "overlay": "#111111"
+        },
+        "text": {
+          "primary": "#c8ffc8",
+          "secondary": "#8fbc8f",
+          "inverse": "#0d0d0d"
+        },
+        "brand": {
+          "primary": "#39ff14"
+        },
+        "state": {
+          "info": "#7dd3fc",
+          "success": "#39ff14",
+          "warning": "#ffb000",
+          "danger": "#ff4444"
+        },
+        "border": {
+          "default": "#1f3d1f"
+        },
+        "accent": {
+          "link": "#7dd3fc"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
+            "mono": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#39ff14",
+            "h2": "#7dd3fc",
+            "h3": "#ffb000",
+            "h4": "#39ff14",
+            "h5": "#8fbc8f",
+            "h6": "#c8ffc8"
+          },
+          "body": {
+            "primary": "#c8ffc8",
+            "secondary": "#8fbc8f"
+          },
+          "link": {
+            "default": "#7dd3fc"
+          },
+          "selection": {
+            "fg": "#0d0d0d",
+            "bg": "#39ff14"
+          },
+          "blockquote": {
+            "border": "#39ff14",
+            "fg": "#8fbc8f",
+            "bg": "#111111"
+          },
+          "codeInline": {
+            "fg": "#ffb000",
+            "bg": "#111111"
+          },
+          "codeBlock": {
+            "fg": "#c8ffc8",
+            "bg": "#080808"
+          },
+          "table": {
+            "border": "#1f3d1f",
+            "stripe": "#111111",
+            "theadBg": "#080808",
+            "headerFg": "#c8ffc8"
+          }
+        }
+      }
+    },
     "tokyo-night-dark": {
       "id": "tokyo-night-dark",
       "label": "Tokyo Night Dark",
@@ -2706,6 +2959,14 @@
         "nord"
       ]
     },
+    "one-dark": {
+      "name": "One",
+      "homepage": "https://github.com/Binaryify/OneDark-Pro",
+      "themes": [
+        "one-dark",
+        "one-light"
+      ]
+    },
     "rose-pine": {
       "name": "Rosé Pine (synced)",
       "homepage": "https://rosepinetheme.com/",
@@ -2721,6 +2982,13 @@
       "themes": [
         "solarized-dark",
         "solarized-light"
+      ]
+    },
+    "turbo": {
+      "name": "Terminal",
+      "homepage": "https://github.com/lgtm-hq/turbo-themes",
+      "themes": [
+        "terminal"
       ]
     },
     "tokyo-night": {

--- a/swift/Sources/TurboThemes/Resources/tokens.json
+++ b/swift/Sources/TurboThemes/Resources/tokens.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://design-tokens.org/schema.json",
-  "$description": "Turbo Themes - Flat tokens for 24 themes",
+  "$description": "Turbo Themes - Flat tokens for 27 themes",
   "$version": "0.28.2",
-  "$generated": "b3da67d991753dc075eead57d47de7dc091026dfecbcb1e7514f0c5037861915",
+  "$generated": "af7638d05b7647137edbcc683d0a32debd8c30e0bbd5f287db36e4ee75400759",
   "meta": {
     "themeIds": [
       "bulma-dark",
@@ -21,16 +21,19 @@
       "gruvbox-light-soft",
       "gruvbox-light",
       "nord",
+      "one-dark",
+      "one-light",
       "rose-pine-dawn",
       "rose-pine-moon",
       "rose-pine",
       "solarized-dark",
       "solarized-light",
+      "terminal",
       "tokyo-night-dark",
       "tokyo-night-light",
       "tokyo-night-storm"
     ],
-    "totalThemes": 24
+    "totalThemes": 27
   },
   "shared": {
     "spacing": {
@@ -1896,6 +1899,174 @@
         }
       }
     },
+    "one-dark": {
+      "id": "one-dark",
+      "label": "One Dark",
+      "vendor": "one-dark",
+      "appearance": "dark",
+      "tokens": {
+        "background": {
+          "base": "#282c34",
+          "surface": "#2c313a",
+          "overlay": "#3e4451"
+        },
+        "text": {
+          "primary": "#abb2bf",
+          "secondary": "#828997",
+          "inverse": "#282c34"
+        },
+        "brand": {
+          "primary": "#61afef"
+        },
+        "state": {
+          "info": "#56b6c2",
+          "success": "#98c379",
+          "warning": "#e5c07b",
+          "danger": "#e06c75"
+        },
+        "border": {
+          "default": "#3e4451"
+        },
+        "accent": {
+          "link": "#61afef"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+            "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#61afef",
+            "h2": "#c678dd",
+            "h3": "#98c379",
+            "h4": "#e5c07b",
+            "h5": "#d19a66",
+            "h6": "#56b6c2"
+          },
+          "body": {
+            "primary": "#abb2bf",
+            "secondary": "#828997"
+          },
+          "link": {
+            "default": "#61afef"
+          },
+          "selection": {
+            "fg": "#abb2bf",
+            "bg": "#3e4451"
+          },
+          "blockquote": {
+            "border": "#3e4451",
+            "fg": "#828997",
+            "bg": "#2c313a"
+          },
+          "codeInline": {
+            "fg": "#c678dd",
+            "bg": "#2c313a"
+          },
+          "codeBlock": {
+            "fg": "#abb2bf",
+            "bg": "#21252b"
+          },
+          "table": {
+            "border": "#3e4451",
+            "stripe": "#2c313a",
+            "theadBg": "#3e4451"
+          }
+        }
+      }
+    },
+    "one-light": {
+      "id": "one-light",
+      "label": "One Light",
+      "vendor": "one-dark",
+      "appearance": "light",
+      "tokens": {
+        "background": {
+          "base": "#fafafa",
+          "surface": "#f0f0f0",
+          "overlay": "#e5e5e6"
+        },
+        "text": {
+          "primary": "#383a42",
+          "secondary": "#696c77",
+          "inverse": "#fafafa"
+        },
+        "brand": {
+          "primary": "#4078f2"
+        },
+        "state": {
+          "info": "#0184bc",
+          "success": "#50a14f",
+          "warning": "#c18401",
+          "danger": "#e45649",
+          "infoText": "#000000",
+          "successText": "#000000",
+          "warningText": "#000000",
+          "dangerText": "#000000"
+        },
+        "border": {
+          "default": "#d0d0d1"
+        },
+        "accent": {
+          "link": "#4078f2"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+            "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#4078f2",
+            "h2": "#a626a4",
+            "h3": "#50a14f",
+            "h4": "#c18401",
+            "h5": "#986801",
+            "h6": "#0184bc"
+          },
+          "body": {
+            "primary": "#383a42",
+            "secondary": "#696c77"
+          },
+          "link": {
+            "default": "#4078f2"
+          },
+          "selection": {
+            "fg": "#383a42",
+            "bg": "#dfe1e5"
+          },
+          "blockquote": {
+            "border": "#d0d0d1",
+            "fg": "#696c77",
+            "bg": "#f0f0f0"
+          },
+          "codeInline": {
+            "fg": "#a626a4",
+            "bg": "#e5e5e6"
+          },
+          "codeBlock": {
+            "fg": "#383a42",
+            "bg": "#e5e5e6"
+          },
+          "table": {
+            "border": "#d0d0d1",
+            "stripe": "#f0f0f0",
+            "theadBg": "#e5e5e6"
+          }
+        }
+      }
+    },
     "rose-pine-dawn": {
       "id": "rose-pine-dawn",
       "label": "Rosé Pine Dawn",
@@ -2406,6 +2577,88 @@
         }
       }
     },
+    "terminal": {
+      "id": "terminal",
+      "label": "Terminal",
+      "vendor": "turbo",
+      "appearance": "dark",
+      "tokens": {
+        "background": {
+          "base": "#0d0d0d",
+          "surface": "#080808",
+          "overlay": "#111111"
+        },
+        "text": {
+          "primary": "#c8ffc8",
+          "secondary": "#8fbc8f",
+          "inverse": "#0d0d0d"
+        },
+        "brand": {
+          "primary": "#39ff14"
+        },
+        "state": {
+          "info": "#7dd3fc",
+          "success": "#39ff14",
+          "warning": "#ffb000",
+          "danger": "#ff4444"
+        },
+        "border": {
+          "default": "#1f3d1f"
+        },
+        "accent": {
+          "link": "#7dd3fc"
+        },
+        "typography": {
+          "fonts": {
+            "sans": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
+            "mono": "\"IBM Plex Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+          },
+          "webFonts": [
+            "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+          ]
+        },
+        "content": {
+          "heading": {
+            "h1": "#39ff14",
+            "h2": "#7dd3fc",
+            "h3": "#ffb000",
+            "h4": "#39ff14",
+            "h5": "#8fbc8f",
+            "h6": "#c8ffc8"
+          },
+          "body": {
+            "primary": "#c8ffc8",
+            "secondary": "#8fbc8f"
+          },
+          "link": {
+            "default": "#7dd3fc"
+          },
+          "selection": {
+            "fg": "#0d0d0d",
+            "bg": "#39ff14"
+          },
+          "blockquote": {
+            "border": "#39ff14",
+            "fg": "#8fbc8f",
+            "bg": "#111111"
+          },
+          "codeInline": {
+            "fg": "#ffb000",
+            "bg": "#111111"
+          },
+          "codeBlock": {
+            "fg": "#c8ffc8",
+            "bg": "#080808"
+          },
+          "table": {
+            "border": "#1f3d1f",
+            "stripe": "#111111",
+            "theadBg": "#080808",
+            "headerFg": "#c8ffc8"
+          }
+        }
+      }
+    },
     "tokyo-night-dark": {
       "id": "tokyo-night-dark",
       "label": "Tokyo Night Dark",
@@ -2706,6 +2959,14 @@
         "nord"
       ]
     },
+    "one-dark": {
+      "name": "One",
+      "homepage": "https://github.com/Binaryify/OneDark-Pro",
+      "themes": [
+        "one-dark",
+        "one-light"
+      ]
+    },
     "rose-pine": {
       "name": "Rosé Pine (synced)",
       "homepage": "https://rosepinetheme.com/",
@@ -2721,6 +2982,13 @@
       "themes": [
         "solarized-dark",
         "solarized-light"
+      ]
+    },
+    "turbo": {
+      "name": "Terminal",
+      "homepage": "https://github.com/lgtm-hq/turbo-themes",
+      "themes": [
+        "terminal"
       ]
     },
     "tokyo-night": {


### PR DESCRIPTION
## Summary

Regenerates the three committed cross-platform token artifacts from a clean full build. Main's copies had silently regressed to the 24-theme catalog (dropping `one-dark`, `one-light`, `terminal` from shipped payloads) during #569's conflict-resolution rebase, which ran `build:tokens` against a stale local dist. Hashes verify under the new full-file semantics; `$description` now correctly reads 27 themes.

CI could not catch this because it regenerates from schema before testing — the systemic drift check is tracked in #622 and lands right after this.

Fixes #623

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores three themes (`one-dark`, `one-light`, `terminal`) that were silently dropped from the committed `tokens.json` artifacts during the #569 rebase, bringing all three platform copies (core, Python, Swift) back to parity with the 27-theme catalog.

- All three files are byte-for-byte identical after the change (same blob hash), confirming the cross-platform sync is consistent.
- `one-dark` and `one-light` are both missing `table.headerFg` and `table.cellBg` that every one of the 24 pre-existing themes supplies — consumers reading those keys will get `undefined` and table rendering will fall back to unspecced defaults.
- `terminal` includes `headerFg` but also omits `cellBg`, and its `background.surface` (`#080808`) is slightly darker than `background.base` (`#0d0d0d`), inverting the raised-layer convention used by all other dark themes.
</details>

<h3>Confidence Score: 3/5</h3>

The core goal — restoring three missing themes to all three platform artifacts — is achieved, but the new theme definitions ship with incomplete table token schemas that will produce broken table rendering for one-dark and one-light users immediately after merge.

Two distinct defects are present in the changed data: one-dark and one-light are missing both table.headerFg and table.cellBg (keys universally present in all 24 pre-existing themes), and terminal is missing table.cellBg. These gaps will surface as undefined token reads in every consumer across the JS, Python, and Swift SDKs when rendering tables with the new themes. The three files are otherwise consistent with each other and the metadata counts are correct.

All three tokens.json copies share the same issues — the core package at packages/core/src/themes/tokens.json is the canonical source to fix; the Python and Swift copies should then be re-synced from it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/themes/tokens.json | Adds one-dark, one-light, and terminal theme tokens; one-dark and one-light are missing table.headerFg and table.cellBg that every other theme provides, and terminal is missing table.cellBg |
| python/src/turbo_themes/tokens.json | Byte-for-byte identical to packages/core copy — carries the same table token omissions for one-dark, one-light, and terminal |
| swift/Sources/TurboThemes/Resources/tokens.json | Byte-for-byte identical to packages/core copy — carries the same table token omissions for one-dark, one-light, and terminal |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tokens.json — 27 themes] --> B[24 pre-existing themes]
    A --> C[3 new themes added in this PR]

    B --> D["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✓\nheaderFg ✓"]

    C --> E[one-dark]
    C --> F[one-light]
    C --> G[terminal]

    E --> H["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✗ MISSING\nheaderFg ✗ MISSING"]
    F --> I["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✗ MISSING\nheaderFg ✗ MISSING"]
    G --> J["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✗ MISSING\nheaderFg ✓"]

    style H fill:#ffdddd,stroke:#cc0000
    style I fill:#ffdddd,stroke:#cc0000
    style J fill:#fff3cd,stroke:#e6a817
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tokens.json — 27 themes] --> B[24 pre-existing themes]
    A --> C[3 new themes added in this PR]

    B --> D["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✓\nheaderFg ✓"]

    C --> E[one-dark]
    C --> F[one-light]
    C --> G[terminal]

    E --> H["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✗ MISSING\nheaderFg ✗ MISSING"]
    F --> I["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✗ MISSING\nheaderFg ✗ MISSING"]
    G --> J["content.table\nborder ✓\nstripe ✓\ntheadBg ✓\ncellBg ✗ MISSING\nheaderFg ✓"]

    style H fill:#ffdddd,stroke:#cc0000
    style I fill:#ffdddd,stroke:#cc0000
    style J fill:#fff3cd,stroke:#e6a817
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A1976-1980%0A**Missing%20%60table.headerFg%60%20and%20%60table.cellBg%60%20in%20%60one-dark%60%20and%20%60one-light%60**%0A%0AEvery%20one%20of%20the%2024%20pre-existing%20themes%20includes%20both%20%60headerFg%60%20and%20%60cellBg%60%20inside%20their%20%60content.table%60%20token%20group%20%28e.g.%2C%20%60bulma-dark%60%20at%20line%20141%2C%20%60bulma-light%60%20at%20line%20301%2C%20and%20so%20on%20through%20all%20gruvbox%2Ftokyo%2Fsolarized%20variants%29.%20Both%20%60one-dark%60%20%28here%29%20and%20%60one-light%60%20%28line%202062%29%20omit%20them%20entirely.%20Any%20consumer%20that%20reads%20%60theme.content.table.headerFg%60%20or%20%60theme.content.table.cellBg%60%20for%20these%20themes%20will%20receive%20%60undefined%60%2C%20causing%20table%20headers%20to%20render%20without%20a%20foreground%20color%20and%20table%20cells%20to%20render%20without%20their%20background%20override.%20The%20same%20omission%20is%20present%20in%20the%20parallel%20%60python%2F%60%20and%20%60swift%2F%60%20copies.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A2653-2658%0A**%60terminal%60%20table%20missing%20%60cellBg%60**%0A%0A%60terminal.content.table%60%20includes%20%60headerFg%60%20but%20omits%20%60cellBg%60%2C%20which%20every%20other%20theme%20in%20the%20file%20provides.%20Table%20cells%20rendered%20under%20this%20theme%20will%20have%20no%20%60cellBg%60%20token%2C%20falling%20back%20to%20whatever%20default%20the%20consumer%20applies%20rather%20than%20the%20intended%20%60%23080808%60%20or%20similar%20surface-derived%20value.%20This%20is%20consistent%20with%20the%20%60one-dark%60%2F%60one-light%60%20omissions%20and%20suggests%20the%20three%20new%20source%20configs%20were%20generated%20without%20the%20full%20%60table%60%20token%20set.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A2577-2590%0A**%60terminal%60%20%60background.surface%60%20is%20darker%20than%20%60background.base%60**%0A%0A%60base%60%20is%20%60%230d0d0d%60%20%28brightness%20%E2%89%88%2013%2F255%29%20while%20%60surface%60%20is%20%60%23080808%60%20%28brightness%20%E2%89%88%208%2F255%29%2C%20inverting%20the%20convention%20used%20by%20every%20other%20dark%20theme%20in%20the%20file%20where%20%60surface%60%20is%20a%20slightly%20lighter%20raised%20layer.%20If%20this%20is%20intentional%20for%20a%20%22sunken%20well%22%20terminal%20aesthetic%20it%20should%20be%20noted%20in%20a%20comment%3B%20otherwise%20any%20component%20that%20uses%20%60background.surface%60%20for%20cards%2C%20panels%2C%20or%20sidebars%20will%20appear%20more%20recessed%20than%20the%20page%20background%20rather%20than%20elevated%20above%20it.%0A%0A&pr=624&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A1976-1980%0A**Missing%20%60table.headerFg%60%20and%20%60table.cellBg%60%20in%20%60one-dark%60%20and%20%60one-light%60**%0A%0AEvery%20one%20of%20the%2024%20pre-existing%20themes%20includes%20both%20%60headerFg%60%20and%20%60cellBg%60%20inside%20their%20%60content.table%60%20token%20group%20%28e.g.%2C%20%60bulma-dark%60%20at%20line%20141%2C%20%60bulma-light%60%20at%20line%20301%2C%20and%20so%20on%20through%20all%20gruvbox%2Ftokyo%2Fsolarized%20variants%29.%20Both%20%60one-dark%60%20%28here%29%20and%20%60one-light%60%20%28line%202062%29%20omit%20them%20entirely.%20Any%20consumer%20that%20reads%20%60theme.content.table.headerFg%60%20or%20%60theme.content.table.cellBg%60%20for%20these%20themes%20will%20receive%20%60undefined%60%2C%20causing%20table%20headers%20to%20render%20without%20a%20foreground%20color%20and%20table%20cells%20to%20render%20without%20their%20background%20override.%20The%20same%20omission%20is%20present%20in%20the%20parallel%20%60python%2F%60%20and%20%60swift%2F%60%20copies.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A2653-2658%0A**%60terminal%60%20table%20missing%20%60cellBg%60**%0A%0A%60terminal.content.table%60%20includes%20%60headerFg%60%20but%20omits%20%60cellBg%60%2C%20which%20every%20other%20theme%20in%20the%20file%20provides.%20Table%20cells%20rendered%20under%20this%20theme%20will%20have%20no%20%60cellBg%60%20token%2C%20falling%20back%20to%20whatever%20default%20the%20consumer%20applies%20rather%20than%20the%20intended%20%60%23080808%60%20or%20similar%20surface-derived%20value.%20This%20is%20consistent%20with%20the%20%60one-dark%60%2F%60one-light%60%20omissions%20and%20suggests%20the%20three%20new%20source%20configs%20were%20generated%20without%20the%20full%20%60table%60%20token%20set.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A2577-2590%0A**%60terminal%60%20%60background.surface%60%20is%20darker%20than%20%60background.base%60**%0A%0A%60base%60%20is%20%60%230d0d0d%60%20%28brightness%20%E2%89%88%2013%2F255%29%20while%20%60surface%60%20is%20%60%23080808%60%20%28brightness%20%E2%89%88%208%2F255%29%2C%20inverting%20the%20convention%20used%20by%20every%20other%20dark%20theme%20in%20the%20file%20where%20%60surface%60%20is%20a%20slightly%20lighter%20raised%20layer.%20If%20this%20is%20intentional%20for%20a%20%22sunken%20well%22%20terminal%20aesthetic%20it%20should%20be%20noted%20in%20a%20comment%3B%20otherwise%20any%20component%20that%20uses%20%60background.surface%60%20for%20cards%2C%20panels%2C%20or%20sidebars%20will%20appear%20more%20recessed%20than%20the%20page%20background%20rather%20than%20elevated%20above%20it.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=624&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22fix%2Ftokens-artifact-regression%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftokens-artifact-regression%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A1976-1980%0A**Missing%20%60table.headerFg%60%20and%20%60table.cellBg%60%20in%20%60one-dark%60%20and%20%60one-light%60**%0A%0AEvery%20one%20of%20the%2024%20pre-existing%20themes%20includes%20both%20%60headerFg%60%20and%20%60cellBg%60%20inside%20their%20%60content.table%60%20token%20group%20%28e.g.%2C%20%60bulma-dark%60%20at%20line%20141%2C%20%60bulma-light%60%20at%20line%20301%2C%20and%20so%20on%20through%20all%20gruvbox%2Ftokyo%2Fsolarized%20variants%29.%20Both%20%60one-dark%60%20%28here%29%20and%20%60one-light%60%20%28line%202062%29%20omit%20them%20entirely.%20Any%20consumer%20that%20reads%20%60theme.content.table.headerFg%60%20or%20%60theme.content.table.cellBg%60%20for%20these%20themes%20will%20receive%20%60undefined%60%2C%20causing%20table%20headers%20to%20render%20without%20a%20foreground%20color%20and%20table%20cells%20to%20render%20without%20their%20background%20override.%20The%20same%20omission%20is%20present%20in%20the%20parallel%20%60python%2F%60%20and%20%60swift%2F%60%20copies.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A2653-2658%0A**%60terminal%60%20table%20missing%20%60cellBg%60**%0A%0A%60terminal.content.table%60%20includes%20%60headerFg%60%20but%20omits%20%60cellBg%60%2C%20which%20every%20other%20theme%20in%20the%20file%20provides.%20Table%20cells%20rendered%20under%20this%20theme%20will%20have%20no%20%60cellBg%60%20token%2C%20falling%20back%20to%20whatever%20default%20the%20consumer%20applies%20rather%20than%20the%20intended%20%60%23080808%60%20or%20similar%20surface-derived%20value.%20This%20is%20consistent%20with%20the%20%60one-dark%60%2F%60one-light%60%20omissions%20and%20suggests%20the%20three%20new%20source%20configs%20were%20generated%20without%20the%20full%20%60table%60%20token%20set.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Fthemes%2Ftokens.json%3A2577-2590%0A**%60terminal%60%20%60background.surface%60%20is%20darker%20than%20%60background.base%60**%0A%0A%60base%60%20is%20%60%230d0d0d%60%20%28brightness%20%E2%89%88%2013%2F255%29%20while%20%60surface%60%20is%20%60%23080808%60%20%28brightness%20%E2%89%88%208%2F255%29%2C%20inverting%20the%20convention%20used%20by%20every%20other%20dark%20theme%20in%20the%20file%20where%20%60surface%60%20is%20a%20slightly%20lighter%20raised%20layer.%20If%20this%20is%20intentional%20for%20a%20%22sunken%20well%22%20terminal%20aesthetic%20it%20should%20be%20noted%20in%20a%20comment%3B%20otherwise%20any%20component%20that%20uses%20%60background.surface%60%20for%20cards%2C%20panels%2C%20or%20sidebars%20will%20appear%20more%20recessed%20than%20the%20page%20background%20rather%20than%20elevated%20above%20it.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=624&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(release): regenerate committed token..."](https://github.com/lgtm-hq/turbo-themes/commit/e097a3860b8f231d56877a8c79a31b7f715d9516) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45342548)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->