### PR TITLE
fix(core): guard process before reading NODE_ENV in catalog dev warning

### DIFF
--- a/packages/core/src/catalog/index.ts
+++ b/packages/core/src/catalog/index.ts
@@ -55,13 +55,14 @@ export interface ThemeCatalog {
 const KNOWN_THEME_IDS: ReadonlySet<string> = new Set(allThemeIds);
 
 /**
- * Emit a dev-time warning for unknown IDs. Bundlers replace
- * `process.env.NODE_ENV` with the literal `"production"` and eliminate this
- * branch via dead-code removal, so production builds never log.
+ * Emit a dev-time warning for unknown IDs. The `typeof` guard is safe even
+ * when `process` is an undeclared identifier (browsers/workers without a
+ * shim), and keeps the contiguous `process.env.NODE_ENV` token sequence so
+ * bundler define-replacement and dead-code elimination still apply.
  */
 function warnInvalidIds(source: 'include' | 'exclude', ids: readonly string[]): void {
   if (ids.length === 0) return;
-  if (process?.env.NODE_ENV === 'production') return;
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') return;
   console.warn(
     `[catalog] createThemeCatalog: ignoring unknown ${source} theme ID(s): ${ids.join(', ')}. ` +
       'Valid IDs come from the exported `themeIds`.',


### PR DESCRIPTION
## Summary

Replaces `process?.env.NODE_ENV` with `typeof process !== 'undefined' && process.env.NODE_ENV` in `warnInvalidIds()`.

## Problem

Optional chaining does not guard an *undeclared* identifier — browser/worker consumers without a `process` shim got `ReferenceError: process is not defined` when calling `createThemeCatalog()` with an unknown ID, instead of the intended dev warning. The optional-chained form also breaks bundler define-replacement, which matches the contiguous `process.env.NODE_ENV` token sequence.

Fixes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three themes: One Dark, One Light, and Terminal.
  * Expanded the available theme catalog from 24 to 27 themes.
  * Added vendor listings for the new themes.

* **Bug Fixes**
  * Improved production-environment detection while preserving warnings for invalid theme IDs during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a one-line guard in `warnInvalidIds()` so that the function no longer throws `ReferenceError: process is not defined` in browser and worker environments that have no `process` shim.

- The optional-chaining form `process?.env.NODE_ENV` only guards against `null`/`undefined` — it cannot protect against an *undeclared* identifier, which is the true state of `process` in a browser runtime without a shim. The replacement `typeof process !== 'undefined' && process.env.NODE_ENV === 'production'` is the correct idiom for this guard.
- The old form also broke bundler define-replacement (esbuild, Vite, webpack all match the exact token sequence `process.env.NODE_ENV`; inserting `?.` breaks the match), preventing dead-code elimination of the warning block in production bundles. The new form restores that sequence and is paired with an updated JSDoc comment explaining both points.
- The existing `declare const process: { readonly env: { readonly NODE_ENV?: string } } | undefined` module-level declaration already types `process` as `| undefined`, so TypeScript narrows the type correctly after the `typeof` guard with no further changes needed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-reasoned fix to a guard expression, and the rest of the function is untouched.

The only modified line is the environment check inside `warnInvalidIds`, which is a non-throwing, console-only helper. The fix correctly substitutes an idiom that protects against an undeclared identifier and restores the uninterrupted `process.env.NODE_ENV` token for bundler replacement. The TypeScript declaration at line 24 already anticipates `process` being absent (`| undefined`), so the type model is consistent. No logic paths, public API, or data flow are affected beyond the one buggy ReferenceError case that motivated the PR.

No files require special attention — only one line changed in a single file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/catalog/index.ts | Single-line guard fix in warnInvalidIds(): replaces optional-chaining process?.env with a typeof guard, preventing ReferenceError in browser/worker runtimes and restoring the contiguous process.env.NODE_ENV token for bundler dead-code elimination. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[warnInvalidIds called] --> B{ids.length === 0?}
    B -- yes --> C[return early, no warn]
    B -- no --> D{typeof process !== 'undefined'?}
    D -- no\n browser/worker, undeclared --> E[condition false → warn emitted]
    D -- yes\n Node / shimmed env --> F{process.env.NODE_ENV === 'production'?}
    F -- yes --> G[return early, no warn\nbundler DCE eliminates block]
    F -- no\n dev / test / undefined --> E

    style E fill:#f9c74f,stroke:#f3722c
    style G fill:#90be6d,stroke:#43aa8b
    style C fill:#90be6d,stroke:#43aa8b
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[warnInvalidIds called] --> B{ids.length === 0?}
    B -- yes --> C[return early, no warn]
    B -- no --> D{typeof process !== 'undefined'?}
    D -- no\n browser/worker, undeclared --> E[condition false → warn emitted]
    D -- yes\n Node / shimmed env --> F{process.env.NODE_ENV === 'production'?}
    F -- yes --> G[return early, no warn\nbundler DCE eliminates block]
    F -- no\n dev / test / undefined --> E

    style E fill:#f9c74f,stroke:#f3722c
    style G fill:#90be6d,stroke:#43aa8b
    style C fill:#90be6d,stroke:#43aa8b
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): guard process before reading ..."](https://github.com/lgtm-hq/turbo-themes/commit/dd68ae225a449624cdd3baaab5a2b1d111986973) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45342689)</sub>

<!-- /greptile_comment -->