### PR TITLE
fix(examples): repair terminal theme entries in example markup

### DIFF
--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -59,6 +59,7 @@
             'rose-pine',
             'solarized-dark',
             'solarized-light',
+            'terminal',
             'tokyo-night-dark',
             'tokyo-night-light',
             'tokyo-night-storm',
@@ -75,7 +76,6 @@
             'solarized-light',
             'tokyo-night-light',
           ];
-          'terminal',
 
           var saved = localStorage.getItem('turbo-theme');
           var theme =
@@ -114,7 +114,6 @@
               style="width: auto"
               aria-label="Select theme"
             ></select>
-            <option value="terminal">Terminal</option>
           </label>
         </div>
       </div>

--- a/examples/html-vanilla-css-only/index.html
+++ b/examples/html-vanilla-css-only/index.html
@@ -1,8 +1,7 @@
 <!doctype html>
 <html
   lang="en"
-  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light one-dark one-light"
-  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light terminal"
+  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light one-dark one-light terminal"
 >
   <head>
     <meta charset="UTF-8" />

--- a/examples/html-vanilla/index.html
+++ b/examples/html-vanilla/index.html
@@ -166,7 +166,9 @@
             <option value="tokyo-night-storm">Tokyo Night Storm</option>
             <option value="tokyo-night-light">Tokyo Night Light</option>
           </optgroup>
-          <option value="terminal">Terminal</option>
+          <optgroup label="Terminal">
+            <option value="terminal">Terminal</option>
+          </optgroup>
         </select>
       </label>
     </header>


### PR DESCRIPTION
## Summary

Repairs the Terminal theme integration defects in example markup that landed with #567's conflict resolution, per the sweep requested in #620.

## Problem

- **bootstrap**: `'terminal',` sat *after* `lightThemes`'s closing `];` as a dead expression, so the FOUC script's `VALID_THEMES` never contained it (saved `terminal` theme fell back to default on reload); a stray `<option>` after `</select>` was ignored by browsers and redundant with dynamic population.
- **html-vanilla-css-only**: two `data-theme-whitelist` attributes on `<html>` — the first (without `terminal`) wins, the second is silently dropped.
- **html-vanilla**: terminal `<option>` floated outside any optgroup.

Swept all other examples (jekyll, react, vue, tailwind, stackblitz suite): their terminal entries are correctly placed.

Fixes #620

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three distinct `terminal` theme integration defects across three example pages that were introduced by a bad merge in #567. Each fix is surgical and correct.

- **bootstrap**: `'terminal'` is moved inside `VALID_THEMES` (was a dead statement after the array close), and the orphaned `<option>` element placed after `</select>` is removed.
- **html-vanilla-css-only**: Two conflicting `data-theme-whitelist` attributes are merged into one that includes `one-dark`, `one-light`, and `terminal` — both sets that each duplicate attribute was missing.
- **html-vanilla**: The floating `<option value="terminal">` is wrapped in an `<optgroup label="Terminal">`, matching the pattern used by every other vendor group in the same select.
</details>

<h3>Confidence Score: 5/5</h3>

All three changes are safe to merge — each is a targeted correction of a broken markup condition with no logic regressions.

Every change is a well-scoped fix to a concrete, pre-existing breakage: a dead JS statement that silently excluded `terminal` from theme validation, a duplicate HTML attribute that caused the browser to silently discard the second value, and a floating `<option>` outside any `<optgroup>`. The resolutions are all correct — `'terminal'` is placed in the right array, the whitelist attributes are properly merged (retaining `one-dark`, `one-light`, and `terminal`), and the option is now inside an `<optgroup>` consistent with the file's existing pattern. No logic changes, no new dependencies, no risk of cross-file side effects.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/bootstrap/index.html | Moves `'terminal'` into the VALID_THEMES array at the correct alphabetical position, removes the dead standalone expression after lightThemes, and removes the orphaned `<option>` after `</select>` — all three cleanups fix the original FOUC regression. |
| examples/html-vanilla-css-only/index.html | Collapses two conflicting `data-theme-whitelist` attributes into one, correctly merging `one-dark one-light` (from the first/winning attribute) with `terminal` (from the second/silently-dropped attribute) so the FOUC script sees all valid themes. |
| examples/html-vanilla/index.html | Wraps the floating `<option value="terminal">` in a proper `<optgroup label="Terminal">`, consistent with every other single-theme vendor group (Dracula, Nord) already in the select. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page Load] --> B{FOUC Script}
    B -->|bootstrap| C["VALID_THEMES array\n(now includes 'terminal')"]
    B -->|html-vanilla-css-only| D["data-theme-whitelist\n(now single merged attr\nwith one-dark, one-light, terminal)"]
    C --> E{saved theme in VALID_THEMES?}
    D --> F{saved theme in whitelist?}
    E -->|yes - FIXED| G[Apply saved theme]
    E -->|no| H[Fall back to default]
    F -->|yes - FIXED| G
    F -->|no| H
    G --> I[No FOUC]
    H --> J[Default theme shown]
    K[User opens select] -->|bootstrap| L["Dynamically populated\nfrom CATALOG\n(stray option removed)"]
    K -->|html-vanilla| M["optgroup label=Terminal\nwrapping option value=terminal\n(FIXED: was floating)"]
    K -->|html-vanilla-css-only| N["option value=terminal\nin flat list\n(unchanged, already correct)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Page Load] --> B{FOUC Script}
    B -->|bootstrap| C["VALID_THEMES array\n(now includes 'terminal')"]
    B -->|html-vanilla-css-only| D["data-theme-whitelist\n(now single merged attr\nwith one-dark, one-light, terminal)"]
    C --> E{saved theme in VALID_THEMES?}
    D --> F{saved theme in whitelist?}
    E -->|yes - FIXED| G[Apply saved theme]
    E -->|no| H[Fall back to default]
    F -->|yes - FIXED| G
    F -->|no| H
    G --> I[No FOUC]
    H --> J[Default theme shown]
    K[User opens select] -->|bootstrap| L["Dynamically populated\nfrom CATALOG\n(stray option removed)"]
    K -->|html-vanilla| M["optgroup label=Terminal\nwrapping option value=terminal\n(FIXED: was floating)"]
    K -->|html-vanilla-css-only| N["option value=terminal\nin flat list\n(unchanged, already correct)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(examples): repair terminal theme ent..."](https://github.com/lgtm-hq/turbo-themes/commit/5b700608c7650504870aa28ea1ac38c94e79bb73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45343071)</sub>

<!-- /greptile_comment -->