### PR TITLE
fix(release): assign CODEOWNER on release version PRs

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           reviewer=$(grep -m1 '^[*][[:space:]]' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
           if [ -n "$reviewer" ]; then
-            gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer"
+            gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer" --add-assignee "$reviewer"
           fi
 
       - name: Enable auto-merge

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -115,11 +115,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
-        run: |
-          reviewer=$(grep -m1 '^[*][[:space:]]' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
-          if [ -n "$reviewer" ]; then
-            gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer" --add-assignee "$reviewer"
-          fi
+        run: ./scripts/ci/request-codeowner-review.sh
 
       - name: Enable auto-merge
         if: steps.create_pr.outputs.pull-request-number

--- a/scripts/ci/request-codeowner-review.sh
+++ b/scripts/ci/request-codeowner-review.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Request review from and assign the repository CODEOWNER on a PR.
+#
+# Usage: PR_NUMBER=<n> GH_TOKEN=<token> ./scripts/ci/request-codeowner-review.sh
+#
+# Reads the first catch-all owner from .github/CODEOWNERS. No-op when the
+# file has no owner entry.
+
+set -euo pipefail
+
+if [ -z "${PR_NUMBER:-}" ]; then
+  echo "❌ PR_NUMBER is required" >&2
+  exit 1
+fi
+
+reviewer=$(grep -m1 '^[*][[:space:]]' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
+if [ -n "$reviewer" ]; then
+  gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer" --add-assignee "$reviewer"
+fi

--- a/scripts/ci/request-codeowner-review.sh
+++ b/scripts/ci/request-codeowner-review.sh
@@ -14,7 +14,7 @@ if [ -z "${PR_NUMBER:-}" ]; then
   exit 1
 fi
 
-reviewer=$(grep -m1 '^[*][[:space:]]' .github/CODEOWNERS | awk '{print $2}' | tr -d '@')
+reviewer=$(grep -m1 '^[*][[:space:]]' .github/CODEOWNERS 2>/dev/null | awk '{print $2}' | tr -d '@' || true)
 if [ -n "$reviewer" ]; then
   gh pr edit "$PR_NUMBER" --add-reviewer "$reviewer" --add-assignee "$reviewer"
 fi


### PR DESCRIPTION
## Summary

Extends the release workflow's "Request CODEOWNER review" step with `--add-assignee`, restoring assignees on release version PRs.

## Problem

#577 skipped `pr-auto-assign` for `release-bump` PRs assuming the release workflow covers it, but that step only requests a review — #611–#618 all shipped unassigned. Assigning from the release workflow (rather than reverting the skip) avoids the label-timing race on `pull_request_target`.

Fixes #621

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores assignee assignment on release version PRs by adding `--add-assignee` to the existing `gh pr edit` call, and extracts that logic from the inline workflow step into a dedicated script at `scripts/ci/request-codeowner-review.sh`.

- The wildcard CODEOWNERS entry is parsed the same way as before; the only new side-effect is `--add-assignee "$reviewer"` running alongside `--add-reviewer` in a single `gh pr edit` invocation.
- The previously reported `set -euo pipefail` / `grep` exit-code issue has been resolved: `|| true` is appended to the pipeline so a missing file or absent wildcard entry yields an empty `reviewer` and a clean no-op instead of a non-zero exit.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, additive, and correctly handles the empty-reviewer edge case.

The diff touches only two files: the workflow drops four inline lines in favour of the new script, and the script itself is straightforward. The || true guard correctly handles the no-CODEOWNERS-entry path, the gh pr edit flags are valid for the individual-user entry in CODEOWNERS, and the step condition (pull-request-number != '') is unchanged from the working state before this PR.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-version-pr.yml | Inline review-request shell logic replaced by a single call to the extracted script; the only functional change is that the step now also assigns the CODEOWNER (via --add-assignee) in addition to requesting their review. |
| scripts/ci/request-codeowner-review.sh | New script that parses the wildcard CODEOWNERS entry, guards on an empty match (|| true absorbs grep exit-1), and runs a single gh pr edit with both --add-reviewer and --add-assignee; logic is correct for the individual-user entry present in CODEOWNERS. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WF as release-version-pr.yml
    participant Script as request-codeowner-review.sh
    participant CO as .github/CODEOWNERS
    participant GH as GitHub API

    WF->>Script: ./scripts/ci/request-codeowner-review.sh
    Script->>CO: grep -m1 wildcard entry
    alt entry found
        CO-->>Script: "* @TurboCoder13"
        Script->>Script: awk / tr → TurboCoder13
        Script->>GH: gh pr edit PR_NUMBER --add-reviewer TurboCoder13 --add-assignee TurboCoder13
        GH-->>Script: 200 OK
    else no wildcard entry / file absent
        CO-->>Script: "empty, exit 1 absorbed by || true"
        Script->>Script: reviewer empty → no-op
    end
    Script-->>WF: exit 0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WF as release-version-pr.yml
    participant Script as request-codeowner-review.sh
    participant CO as .github/CODEOWNERS
    participant GH as GitHub API

    WF->>Script: ./scripts/ci/request-codeowner-review.sh
    Script->>CO: grep -m1 wildcard entry
    alt entry found
        CO-->>Script: "* @TurboCoder13"
        Script->>Script: awk / tr → TurboCoder13
        Script->>GH: gh pr edit PR_NUMBER --add-reviewer TurboCoder13 --add-assignee TurboCoder13
        GH-->>Script: 200 OK
    else no wildcard entry / file absent
        CO-->>Script: "empty, exit 1 absorbed by || true"
        Script->>Script: reviewer empty → no-op
    end
    Script-->>WF: exit 0
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): make missing CODEOWNERS entry a..."](https://github.com/lgtm-hq/turbo-themes/commit/c7d5d08dcc9f07c66d08cafa9bec9e085a2656d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45343243)</sub>

<!-- /greptile_comment -->