### PR TITLE
chore(ci): enforce drift checks for generated artifacts

### DIFF
--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -208,6 +208,51 @@ jobs:
           path: sbom.cyclonedx.json
           overwrite: true
 
+  drift:
+    name: 🧬 Verify Generated Artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        if: ${{ !env.ACT }}
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            bun.sh:443
+            github.com:443
+            github-releases.githubusercontent.com:443
+            npmjs.org:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          node-version: '22'
+          skip-ruby: 'true'
+
+      - name: Regenerate all generated artifacts
+        run: |
+          bun run build
+          bun run generate:types
+          bun run build:js:dev
+          bun run build:js:prod
+
+      - name: Verify committed artifacts match regeneration
+        run: |
+          chmod +x scripts/ci/verify-generated-tokens.sh
+          scripts/ci/verify-generated-tokens.sh
+
   examples:
     name: 📦 Validate Examples
     runs-on: ubuntu-24.04

--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -241,17 +241,8 @@ jobs:
           node-version: '22'
           skip-ruby: 'true'
 
-      - name: Regenerate all generated artifacts
-        run: |
-          bun run build
-          bun run generate:types
-          bun run build:js:dev
-          bun run build:js:prod
-
       - name: Verify committed artifacts match regeneration
-        run: |
-          chmod +x scripts/ci/verify-generated-tokens.sh
-          scripts/ci/verify-generated-tokens.sh
+        run: ./scripts/ci/check-generated-drift.sh
 
   examples:
     name: 📦 Validate Examples

--- a/scripts/ci/check-generated-drift.sh
+++ b/scripts/ci/check-generated-drift.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Regenerate all committed generated artifacts through the
+# lockfile-pinned toolchain, then fail if any differ from the committed
+# versions (single code path for local writer flow and the CI gate).
+#
+# Usage: ./scripts/ci/check-generated-drift.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bun run build
+bun run generate:types
+bun run build:js:dev
+bun run build:js:prod
+
+exec "${SCRIPT_DIR}/verify-generated-tokens.sh"

--- a/scripts/ci/verify-generated-tokens.sh
+++ b/scripts/ci/verify-generated-tokens.sh
@@ -28,6 +28,13 @@ TOKEN_PATHS=(
   # These are checked to ensure consistency when tokens.json changes
   'python/src/turbo_themes/themes.py'
   'swift/Sources/TurboThemes/ThemeLoader.swift'
+  # Generated TypeScript sources (bun run generate:types:ts)
+  'packages/core/src/themes/theme-ids.ts'
+  'packages/core/src/themes/generated-types.ts'
+  # Committed IIFE selector bundles (bun run build:js:dev / build:js:prod)
+  'assets/js/theme-selector.js'
+  'assets/js/theme-selector.js.map'
+  'assets/js/theme-selector.min.js'
 )
 
 main() {


### PR DESCRIPTION
## Summary

Implements #622:

- **Revives `scripts/ci/verify-generated-tokens.sh`** (dead code — nothing invoked it) and extends its path list with `packages/core/src/themes/theme-ids.ts`, `generated-types.ts`, and the committed `assets/js/theme-selector{.js,.js.map,.min.js}` IIFE bundles.
- **Wires a `drift` job** into `quality-ci-main.yml` (pull_request + merge_group + push like its siblings): regenerates everything (`bun run build`, `generate:types`, `build:js:dev`, `build:js:prod`) through the lockfile-pinned toolchain, then fails on `git diff` over the covered paths.
- **Determinism**: all regeneration runs through repo-local pinned binaries (vite/esbuild via the lockfile); sourcemaps already use relative paths. Committed-bundle model retained (decided against build-at-publish for now — the bundles are consumed directly from the repo by the gem and Pages).

This is exactly the guard that would have caught #623 (tokens artifacts silently regressed to 24 themes on main).

**Sequencing note:** must merge after #624 — the drift check correctly fails on main's current stale tokens artifacts.

Fixes #622

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires up a new `drift` CI job that regenerates all committed artifacts through the lockfile-pinned toolchain (`bun run build`, `generate:types`, `build:js:dev`, `build:js:prod`) and fails if any of the 13 covered paths differ from the committed versions — closing the gap that allowed the 24-theme regression on main (#623).

- **New `drift` job** in `quality-ci-main.yml`: follows the same harden-runner / egress-block / setup-env pattern as sibling jobs; no `needs:` dependency so it runs in parallel.
- **`check-generated-drift.sh`**: thin orchestrator that runs all four regeneration commands then `exec`s into the verification script, cleanly propagating the exit code.
- **`verify-generated-tokens.sh`**: five new paths added to `TOKEN_PATHS` (two TS sources, three IIFE bundles). A pre-existing P1 noted in the prior review — the error message on line 69 still only instructs `bun run build:tokens`, which does not cover the three newly added non-token paths — remains unaddressed in this diff.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with one known outstanding issue: the error message in verify-generated-tokens.sh still only points developers to `bun run build:tokens`, which won't regenerate the TypeScript sources or IIFE bundles added by this PR.

The drift gate itself is correctly implemented and will catch regressions as intended. The unresolved issue from the prior review — the misleading fix-it instructions on line 69 of verify-generated-tokens.sh — means a developer whose CI fails on theme-ids.ts, generated-types.ts, or the IIFE bundles will follow the printed instructions, get no change, and be left debugging a failing job with no clear path forward.

scripts/ci/verify-generated-tokens.sh — the error message (line 69) needs to be updated to list all regeneration commands covering the full set of checked paths.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/quality-ci-main.yml | Adds a new `drift` job that checks out, runs setup-env, and executes the drift-check script. Follows the same pattern as sibling jobs (harden-runner, egress block, local composite action). No issues found. |
| scripts/ci/check-generated-drift.sh | New orchestration script that runs all four regeneration commands then execs into verify-generated-tokens.sh. Clean `set -euo pipefail` guard, correct use of `exec` for exit-code passthrough. |
| scripts/ci/verify-generated-tokens.sh | Extends TOKEN_PATHS with five new entries for TS sources and IIFE bundles. The inline comment on the new TypeScript block misnames the regeneration script (`generate:types:ts` vs the actual `generate:types`). The existing error message on line 69 still only instructs `bun run build:tokens`, which doesn't cover three of the new paths — a P1 flagged in the previous review that remains unaddressed here. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions (drift job)
    participant CDS as check-generated-drift.sh
    participant Bun as bun (lockfile-pinned toolchain)
    participant VGT as verify-generated-tokens.sh
    participant Git as git diff HEAD

    GH->>CDS: execute
    CDS->>Bun: bun run build
    Bun-->>CDS: Style Dictionary + token copies
    CDS->>Bun: bun run generate:types
    Bun-->>CDS: theme-ids.ts / generated-types.ts
    CDS->>Bun: bun run build:js:dev
    Bun-->>CDS: theme-selector.js + .js.map
    CDS->>Bun: bun run build:js:prod
    Bun-->>CDS: theme-selector.min.js
    CDS->>VGT: exec (replaces process)
    loop Each path in TOKEN_PATHS (13 paths)
        VGT->>Git: git diff --quiet --exit-code HEAD -- path
        Git-->>VGT: clean / dirty
    end
    alt All paths clean
        VGT-->>GH: exit 0
    else Any path dirty
        VGT-->>GH: print diff + error message, exit 1
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions (drift job)
    participant CDS as check-generated-drift.sh
    participant Bun as bun (lockfile-pinned toolchain)
    participant VGT as verify-generated-tokens.sh
    participant Git as git diff HEAD

    GH->>CDS: execute
    CDS->>Bun: bun run build
    Bun-->>CDS: Style Dictionary + token copies
    CDS->>Bun: bun run generate:types
    Bun-->>CDS: theme-ids.ts / generated-types.ts
    CDS->>Bun: bun run build:js:dev
    Bun-->>CDS: theme-selector.js + .js.map
    CDS->>Bun: bun run build:js:prod
    Bun-->>CDS: theme-selector.min.js
    CDS->>VGT: exec (replaces process)
    loop Each path in TOKEN_PATHS (13 paths)
        VGT->>Git: git diff --quiet --exit-code HEAD -- path
        Git-->>VGT: clean / dirty
    end
    alt All paths clean
        VGT-->>GH: exit 0
    else Any path dirty
        VGT-->>GH: print diff + error message, exit 1
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/ci/verify-generated-tokens.sh`, line 69 ([link](https://github.com/lgtm-hq/turbo-themes/blob/6db5bd59a167011d061610d97f978159eec63fc2/scripts/ci/verify-generated-tokens.sh#L69)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Misleading fix-it message for newly added paths**

   The hardcoded error message only instructs developers to run `bun run build:tokens`, but three of the seven new paths are regenerated by completely different commands: `theme-ids.ts` and `generated-types.ts` require `bun run generate:types`, while the IIFE bundles require `bun run build:js:dev` / `bun run build:js:prod`. A developer whose PR drifts one of those three files will follow the printed instructions, find no change, and spend time debugging why the CI still fails.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fverify-generated-tokens.sh%0ALine%3A%2069%0A%0AComment%3A%0A**Misleading%20fix-it%20message%20for%20newly%20added%20paths**%0A%0AThe%20hardcoded%20error%20message%20only%20instructs%20developers%20to%20run%20%60bun%20run%20build%3Atokens%60%2C%20but%20three%20of%20the%20seven%20new%20paths%20are%20regenerated%20by%20completely%20different%20commands%3A%20%60theme-ids.ts%60%20and%20%60generated-types.ts%60%20require%20%60bun%20run%20generate%3Atypes%60%2C%20while%20the%20IIFE%20bundles%20require%20%60bun%20run%20build%3Ajs%3Adev%60%20%2F%20%60bun%20run%20build%3Ajs%3Aprod%60.%20A%20developer%20whose%20PR%20drifts%20one%20of%20those%20three%20files%20will%20follow%20the%20printed%20instructions%2C%20find%20no%20change%2C%20and%20spend%20time%20debugging%20why%20the%20CI%20still%20fails.%0A%0A%60%60%60suggestion%0A%20%20%20%20log_error%20%22Please%20regenerate%20and%20commit%20the%20changes%3A%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Atokens%20%20%20%20%20%20%20%20%20%20%23%20Style%20Dictionary%20outputs%20%2B%20token%20copies%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20generate%3Atypes%20%20%20%20%20%20%20%20%23%20theme-ids.ts%20%2F%20generated-types.ts%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Adev%20%20%20%20%20%20%20%20%20%20%23%20theme-selector.js%20%2B%20.js.map%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Aprod%20%20%20%20%20%20%20%20%20%23%20theme-selector.min.js%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fverify-generated-tokens.sh%0ALine%3A%2069%0A%0AComment%3A%0A**Misleading%20fix-it%20message%20for%20newly%20added%20paths**%0A%0AThe%20hardcoded%20error%20message%20only%20instructs%20developers%20to%20run%20%60bun%20run%20build%3Atokens%60%2C%20but%20three%20of%20the%20seven%20new%20paths%20are%20regenerated%20by%20completely%20different%20commands%3A%20%60theme-ids.ts%60%20and%20%60generated-types.ts%60%20require%20%60bun%20run%20generate%3Atypes%60%2C%20while%20the%20IIFE%20bundles%20require%20%60bun%20run%20build%3Ajs%3Adev%60%20%2F%20%60bun%20run%20build%3Ajs%3Aprod%60.%20A%20developer%20whose%20PR%20drifts%20one%20of%20those%20three%20files%20will%20follow%20the%20printed%20instructions%2C%20find%20no%20change%2C%20and%20spend%20time%20debugging%20why%20the%20CI%20still%20fails.%0A%0A%60%60%60suggestion%0A%20%20%20%20log_error%20%22Please%20regenerate%20and%20commit%20the%20changes%3A%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Atokens%20%20%20%20%20%20%20%20%20%20%23%20Style%20Dictionary%20outputs%20%2B%20token%20copies%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20generate%3Atypes%20%20%20%20%20%20%20%20%23%20theme-ids.ts%20%2F%20generated-types.ts%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Adev%20%20%20%20%20%20%20%20%20%20%23%20theme-selector.js%20%2B%20.js.map%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Aprod%20%20%20%20%20%20%20%20%20%23%20theme-selector.min.js%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22feat%2F622-drift-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F622-drift-check%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fverify-generated-tokens.sh%0ALine%3A%2069%0A%0AComment%3A%0A**Misleading%20fix-it%20message%20for%20newly%20added%20paths**%0A%0AThe%20hardcoded%20error%20message%20only%20instructs%20developers%20to%20run%20%60bun%20run%20build%3Atokens%60%2C%20but%20three%20of%20the%20seven%20new%20paths%20are%20regenerated%20by%20completely%20different%20commands%3A%20%60theme-ids.ts%60%20and%20%60generated-types.ts%60%20require%20%60bun%20run%20generate%3Atypes%60%2C%20while%20the%20IIFE%20bundles%20require%20%60bun%20run%20build%3Ajs%3Adev%60%20%2F%20%60bun%20run%20build%3Ajs%3Aprod%60.%20A%20developer%20whose%20PR%20drifts%20one%20of%20those%20three%20files%20will%20follow%20the%20printed%20instructions%2C%20find%20no%20change%2C%20and%20spend%20time%20debugging%20why%20the%20CI%20still%20fails.%0A%0A%60%60%60suggestion%0A%20%20%20%20log_error%20%22Please%20regenerate%20and%20commit%20the%20changes%3A%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Atokens%20%20%20%20%20%20%20%20%20%20%23%20Style%20Dictionary%20outputs%20%2B%20token%20copies%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20generate%3Atypes%20%20%20%20%20%20%20%20%23%20theme-ids.ts%20%2F%20generated-types.ts%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Adev%20%20%20%20%20%20%20%20%20%20%23%20theme-selector.js%20%2B%20.js.map%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Aprod%20%20%20%20%20%20%20%20%20%23%20theme-selector.min.js%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `scripts/ci/verify-generated-tokens.sh`, line 69 ([link](https://github.com/lgtm-hq/turbo-themes/blob/99178067845328e7858b99a8940fd30b31a4bfdc/scripts/ci/verify-generated-tokens.sh#L69)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Misleading fix-it message for newly added paths**

   The error message still only tells developers to run `bun run build:tokens`, but three of the seven checked paths are regenerated by different commands: `theme-ids.ts` and `generated-types.ts` require `bun run generate:types`, and the IIFE bundles require `bun run build:js:dev` / `build:js:prod`. A developer whose PR drifts one of those files will follow these instructions, see no change, and be stuck debugging a failing CI job with no clear path forward.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fverify-generated-tokens.sh%0ALine%3A%2069%0A%0AComment%3A%0A**Misleading%20fix-it%20message%20for%20newly%20added%20paths**%0A%0AThe%20error%20message%20still%20only%20tells%20developers%20to%20run%20%60bun%20run%20build%3Atokens%60%2C%20but%20three%20of%20the%20seven%20checked%20paths%20are%20regenerated%20by%20different%20commands%3A%20%60theme-ids.ts%60%20and%20%60generated-types.ts%60%20require%20%60bun%20run%20generate%3Atypes%60%2C%20and%20the%20IIFE%20bundles%20require%20%60bun%20run%20build%3Ajs%3Adev%60%20%2F%20%60build%3Ajs%3Aprod%60.%20A%20developer%20whose%20PR%20drifts%20one%20of%20those%20files%20will%20follow%20these%20instructions%2C%20see%20no%20change%2C%20and%20be%20stuck%20debugging%20a%20failing%20CI%20job%20with%20no%20clear%20path%20forward.%0A%0A%60%60%60suggestion%0A%20%20%20%20log_error%20%22Please%20regenerate%20and%20commit%20the%20changes%3A%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Style%20Dictionary%20outputs%20%2B%20token%20copies%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20generate%3Atypes%20%20%20%20%23%20theme-ids.ts%20%2F%20generated-types.ts%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Adev%20%20%20%20%20%20%23%20theme-selector.js%20%2B%20.js.map%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Aprod%20%20%20%20%20%23%20theme-selector.min.js%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fverify-generated-tokens.sh%0ALine%3A%2069%0A%0AComment%3A%0A**Misleading%20fix-it%20message%20for%20newly%20added%20paths**%0A%0AThe%20error%20message%20still%20only%20tells%20developers%20to%20run%20%60bun%20run%20build%3Atokens%60%2C%20but%20three%20of%20the%20seven%20checked%20paths%20are%20regenerated%20by%20different%20commands%3A%20%60theme-ids.ts%60%20and%20%60generated-types.ts%60%20require%20%60bun%20run%20generate%3Atypes%60%2C%20and%20the%20IIFE%20bundles%20require%20%60bun%20run%20build%3Ajs%3Adev%60%20%2F%20%60build%3Ajs%3Aprod%60.%20A%20developer%20whose%20PR%20drifts%20one%20of%20those%20files%20will%20follow%20these%20instructions%2C%20see%20no%20change%2C%20and%20be%20stuck%20debugging%20a%20failing%20CI%20job%20with%20no%20clear%20path%20forward.%0A%0A%60%60%60suggestion%0A%20%20%20%20log_error%20%22Please%20regenerate%20and%20commit%20the%20changes%3A%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Style%20Dictionary%20outputs%20%2B%20token%20copies%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20generate%3Atypes%20%20%20%20%23%20theme-ids.ts%20%2F%20generated-types.ts%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Adev%20%20%20%20%20%20%23%20theme-selector.js%20%2B%20.js.map%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Aprod%20%20%20%20%20%23%20theme-selector.min.js%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22feat%2F622-drift-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F622-drift-check%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fverify-generated-tokens.sh%0ALine%3A%2069%0A%0AComment%3A%0A**Misleading%20fix-it%20message%20for%20newly%20added%20paths**%0A%0AThe%20error%20message%20still%20only%20tells%20developers%20to%20run%20%60bun%20run%20build%3Atokens%60%2C%20but%20three%20of%20the%20seven%20checked%20paths%20are%20regenerated%20by%20different%20commands%3A%20%60theme-ids.ts%60%20and%20%60generated-types.ts%60%20require%20%60bun%20run%20generate%3Atypes%60%2C%20and%20the%20IIFE%20bundles%20require%20%60bun%20run%20build%3Ajs%3Adev%60%20%2F%20%60build%3Ajs%3Aprod%60.%20A%20developer%20whose%20PR%20drifts%20one%20of%20those%20files%20will%20follow%20these%20instructions%2C%20see%20no%20change%2C%20and%20be%20stuck%20debugging%20a%20failing%20CI%20job%20with%20no%20clear%20path%20forward.%0A%0A%60%60%60suggestion%0A%20%20%20%20log_error%20%22Please%20regenerate%20and%20commit%20the%20changes%3A%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Style%20Dictionary%20outputs%20%2B%20token%20copies%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20generate%3Atypes%20%20%20%20%23%20theme-ids.ts%20%2F%20generated-types.ts%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Adev%20%20%20%20%20%20%23%20theme-selector.js%20%2B%20.js.map%22%0A%20%20%20%20log_error%20%22%20%20bun%20run%20build%3Ajs%3Aprod%20%20%20%20%20%23%20theme-selector.min.js%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["chore(ci): extract drift regeneration in..."](https://github.com/lgtm-hq/turbo-themes/commit/5257966ab7b112b422758c9f0b851ba4a1633116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45343475)</sub>

<!-- /greptile_comment -->