### PR TITLE
fix(ci): allow PyPI egress in drift job for setup-env Python deps

### DIFF
--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -223,9 +223,13 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             bun.sh:443
+            codeload.github.com:443
+            files.pythonhosted.org:443
             github.com:443
             github-releases.githubusercontent.com:443
             npmjs.org:443
+            objects.githubusercontent.com:443
+            pypi.org:443
             raw.githubusercontent.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443


### PR DESCRIPTION
## Summary

Extends the `drift` job's harden-runner allowlist with `pypi.org`, `files.pythonhosted.org`, `objects.githubusercontent.com`, and `codeload.github.com` — `.github/actions/setup-env` resolves the uv-managed Python environment and was hitting `Connection refused` on PyPI, failing every drift run since #628 merged.

Fixes #632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI network access settings to support additional GitHub, npm, and Python package endpoints.
  * Improved reliability for automated dependency and artifact retrieval during quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds four missing egress endpoints (`pypi.org`, `files.pythonhosted.org`, `objects.githubusercontent.com`, `codeload.github.com`) to the `drift` job's harden-runner allowlist, unblocking the uv-managed Python environment setup that started failing after #628.

- The four new endpoints align exactly with what the `build` and `reporting` jobs already allow for the same `.github/actions/setup-env` composite action — the omission was a straightforward gap when the drift job adopted `setup-env`.
- All additions are scoped to port 443 (HTTPS) and cover legitimate PyPI distribution infrastructure and GitHub's CDN/codeload hosts used by uv to fetch Python runtimes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted allowlist addition that directly unblocks the broken drift job with no side effects on other jobs.

The four added endpoints are present verbatim in the build and reporting jobs that run the same setup-env action, confirming the drift job simply inherited an incomplete allowlist when it adopted setup-env. All entries use HTTPS port 443 and cover well-known PyPI/GitHub infrastructure. No logic, scripts, or permissions are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/quality-ci-main.yml | Adds four PyPI/GitHub CDN endpoints to the drift job's harden-runner allowlist; change is consistent with identical allowlists in the build and reporting jobs that run the same setup-env action. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Runner as GitHub Runner (drift job)
    participant HR as step-security/harden-runner
    participant GH as github.com / objects.githubusercontent.com / codeload.github.com
    participant PyPI as pypi.org / files.pythonhosted.org
    participant NPM as registry.npmjs.org / npmjs.org

    Runner->>HR: egress-policy: block (allowlist enforced)
    Runner->>GH: Checkout repo (actions/checkout)
    Runner->>GH: Download uv binary + python-build-standalone
    Note over Runner,GH: objects.githubusercontent.com & codeload.github.com now allowed ✅
    Runner->>PyPI: Resolve uv-managed Python deps (setup-env)
    Note over Runner,PyPI: pypi.org & files.pythonhosted.org now allowed ✅
    Runner->>NPM: Install Node/Bun packages (setup-env)
    Runner->>Runner: check-generated-drift.sh (verify artifact parity)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Runner as GitHub Runner (drift job)
    participant HR as step-security/harden-runner
    participant GH as github.com / objects.githubusercontent.com / codeload.github.com
    participant PyPI as pypi.org / files.pythonhosted.org
    participant NPM as registry.npmjs.org / npmjs.org

    Runner->>HR: egress-policy: block (allowlist enforced)
    Runner->>GH: Checkout repo (actions/checkout)
    Runner->>GH: Download uv binary + python-build-standalone
    Note over Runner,GH: objects.githubusercontent.com & codeload.github.com now allowed ✅
    Runner->>PyPI: Resolve uv-managed Python deps (setup-env)
    Note over Runner,PyPI: pypi.org & files.pythonhosted.org now allowed ✅
    Runner->>NPM: Install Node/Bun packages (setup-env)
    Runner->>Runner: check-generated-drift.sh (verify artifact parity)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): allow PyPI egress in drift job ..."](https://github.com/lgtm-hq/turbo-themes/commit/7914f82fe32d0c61a770756a3a1e79a779135645) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45348946)</sub>

<!-- /greptile_comment -->