### PR TITLE
fix(swift): derive ThemeLoader.themeIds from bundled tokens at runtime

### DIFF
--- a/swift/Sources/TurboThemes/ThemeLoader.swift
+++ b/swift/Sources/TurboThemes/ThemeLoader.swift
@@ -4,16 +4,22 @@ import Foundation
 
 /// Loads and provides access to theme definitions from bundled JSON.
 public enum ThemeLoader {
-    /// All available theme IDs, derived from the bundled tokens.json
+    /// All available theme IDs, derived once from the bundled tokens.json
     /// (`meta.themeIds`, falling back to the theme dictionary keys).
-    /// Returns an empty array only if the bundled resource cannot be loaded.
-    public static var themeIds: [String] {
+    ///
+    /// This convenience accessor is deliberately non-throwing for source
+    /// compatibility and returns an empty array only in the exceptional case
+    /// that the bundled resource cannot be loaded; call `loadThemes()` for a
+    /// throwing API with a diagnosable error. Evaluated lazily exactly once
+    /// (`static let` initialization is thread-safe), so repeated access takes
+    /// no lock.
+    public static let themeIds: [String] = {
         guard let themes = try? loadThemes() else { return [] }
         if let ids = themes.meta?.themeIds, !ids.isEmpty {
             return ids
         }
         return themes.themes.keys.sorted()
-    }
+    }()
 
     /// Thread synchronization lock for cache access.
     private static let lock = NSLock()

--- a/swift/Sources/TurboThemes/ThemeLoader.swift
+++ b/swift/Sources/TurboThemes/ThemeLoader.swift
@@ -1,23 +1,19 @@
 // SPDX-License-Identifier: MIT
-// Auto-generated from dist/tokens.json
-// Do not edit manually - regenerate with: bun run generate:swift
 
 import Foundation
 
 /// Loads and provides access to theme definitions from bundled JSON.
 public enum ThemeLoader {
-    /// All available theme IDs.
-    public static let themeIds: [String] = [
-        "bulma-dark",
-        "bulma-light",
-        "catppuccin-frappe",
-        "catppuccin-latte",
-        "catppuccin-macchiato",
-        "catppuccin-mocha",
-        "dracula",
-        "github-dark",
-        "github-light"
-    ]
+    /// All available theme IDs, derived from the bundled tokens.json
+    /// (`meta.themeIds`, falling back to the theme dictionary keys).
+    /// Returns an empty array only if the bundled resource cannot be loaded.
+    public static var themeIds: [String] {
+        guard let themes = try? loadThemes() else { return [] }
+        if let ids = themes.meta?.themeIds, !ids.isEmpty {
+            return ids
+        }
+        return themes.themes.keys.sorted()
+    }
 
     /// Thread synchronization lock for cache access.
     private static let lock = NSLock()

--- a/swift/Tests/TurboThemesTests/ThemeLoaderTests.swift
+++ b/swift/Tests/TurboThemesTests/ThemeLoaderTests.swift
@@ -20,6 +20,11 @@ final class ThemeLoaderTests: XCTestCase {
 
     func testThemeIdsMatchesBundledCatalog() throws {
         let themes = try ThemeLoader.loadThemes()
+        // Pin the primary source so the set-equality below cannot silently
+        // degrade into comparing the fallback against itself.
+        let metaIds = try XCTUnwrap(themes.meta?.themeIds)
+        XCTAssertFalse(metaIds.isEmpty)
+        XCTAssertEqual(Set(ThemeLoader.themeIds), Set(metaIds))
         XCTAssertEqual(Set(ThemeLoader.themeIds), Set(themes.themes.keys))
     }
 

--- a/swift/Tests/TurboThemesTests/ThemeLoaderTests.swift
+++ b/swift/Tests/TurboThemesTests/ThemeLoaderTests.swift
@@ -14,6 +14,13 @@ final class ThemeLoaderTests: XCTestCase {
         XCTAssertTrue(ThemeLoader.themeIds.contains("catppuccin-mocha"))
         XCTAssertTrue(ThemeLoader.themeIds.contains("dracula"))
         XCTAssertTrue(ThemeLoader.themeIds.contains("github-dark"))
+        XCTAssertTrue(ThemeLoader.themeIds.contains("one-dark"))
+        XCTAssertTrue(ThemeLoader.themeIds.contains("terminal"))
+    }
+
+    func testThemeIdsMatchesBundledCatalog() throws {
+        let themes = try ThemeLoader.loadThemes()
+        XCTAssertEqual(Set(ThemeLoader.themeIds), Set(themes.themes.keys))
     }
 
     // MARK: - Load Themes


### PR DESCRIPTION
## Summary

`ThemeLoader.themeIds` was a hand-maintained list frozen at nine themes (missing 18, including every pack since Gruvbox) under a misleading auto-generated header nothing regenerated. Per the no-hand-maintained-mirrors rule it is now derived at runtime from the bundled `tokens.json` (`meta.themeIds`, falling back to sorted theme keys), so the documented "All available theme IDs" API always matches the shipped catalog.

Tests: added contains-checks for `one-dark`/`terminal` and a set-equality assertion between `themeIds` and the bundled theme dictionary; full Swift suite passes locally (71 tests).

Fixes #638

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces a stale, hand-maintained `static let themeIds` list (frozen at 9 themes) with a closure-initialized `static let` that derives the list at runtime from `tokens.json` — using `meta.themeIds` when present and falling back to the sorted theme dictionary keys.

- `ThemeLoader.swift`: `themeIds` is now a `static let` with a self-executing closure; Swift's `dispatch_once` semantics guarantee exactly one lock-free initialization, addressing the previously noted per-call lock overhead.
- `ThemeLoaderTests.swift`: adds `contains` checks for two previously missing themes (`one-dark`, `terminal`) and a new `testThemeIdsMatchesBundledCatalog` test that `XCTUnwrap`s `meta.themeIds` and asserts set equality against both the meta list and the theme dictionary keys, preventing the fallback-tautology failure mode flagged in earlier review rounds.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a direct replacement of a stale constant with a runtime-derived value using a well-understood Swift initialization pattern.

The new static let closure calls loadThemes() exactly once (Swift dispatch_once), eliminating repeated lock acquisition while keeping the non-throwing public API intact. The meta.themeIds / sorted-keys fallback logic is straightforward and the test suite pins both code paths with XCTUnwrap and cross-checks against the theme dictionary, so regressions would be caught immediately.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| swift/Sources/TurboThemes/ThemeLoader.swift | Replaces hardcoded theme ID list with a closure-initialized static let that derives IDs from bundled tokens.json at first access; thread-safe via Swift dispatch_once, with a well-documented non-throwing contract. |
| swift/Tests/TurboThemesTests/ThemeLoaderTests.swift | Adds two previously-missing contains checks and a set-equality catalog test that pins meta.themeIds via XCTUnwrap, preventing the test from silently exercising only the fallback path. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant themeIds as ThemeLoader.themeIds (static let)
    participant loadThemes as ThemeLoader.loadThemes()
    participant lock as NSLock
    participant cache as _themes cache
    participant bundle as Bundle (tokens.json)

    Note over themeIds: First access — Swift dispatch_once runs closure
    Caller->>themeIds: ThemeLoader.themeIds
    themeIds->>loadThemes: try? loadThemes()
    loadThemes->>lock: lock()
    loadThemes->>cache: check _themes
    cache-->>loadThemes: nil (cold)
    loadThemes->>bundle: Bundle.module.url("tokens")
    bundle-->>loadThemes: URL
    loadThemes->>bundle: Data(contentsOf:)
    bundle-->>loadThemes: JSON data
    loadThemes->>cache: store TurboThemes
    loadThemes->>lock: unlock()
    loadThemes-->>themeIds: TurboThemes
    themeIds->>themeIds: meta.themeIds present and non-empty?
    alt meta.themeIds available
        themeIds-->>Caller: meta.themeIds (ordered)
    else fallback
        themeIds-->>Caller: themes.keys.sorted()
    end
    Note over themeIds: Subsequent accesses — no closure, no lock
    Caller->>themeIds: ThemeLoader.themeIds
    themeIds-->>Caller: cached [String] (dispatch_once)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant themeIds as ThemeLoader.themeIds (static let)
    participant loadThemes as ThemeLoader.loadThemes()
    participant lock as NSLock
    participant cache as _themes cache
    participant bundle as Bundle (tokens.json)

    Note over themeIds: First access — Swift dispatch_once runs closure
    Caller->>themeIds: ThemeLoader.themeIds
    themeIds->>loadThemes: try? loadThemes()
    loadThemes->>lock: lock()
    loadThemes->>cache: check _themes
    cache-->>loadThemes: nil (cold)
    loadThemes->>bundle: Bundle.module.url("tokens")
    bundle-->>loadThemes: URL
    loadThemes->>bundle: Data(contentsOf:)
    bundle-->>loadThemes: JSON data
    loadThemes->>cache: store TurboThemes
    loadThemes->>lock: unlock()
    loadThemes-->>themeIds: TurboThemes
    themeIds->>themeIds: meta.themeIds present and non-empty?
    alt meta.themeIds available
        themeIds-->>Caller: meta.themeIds (ordered)
    else fallback
        themeIds-->>Caller: themes.keys.sorted()
    end
    Note over themeIds: Subsequent accesses — no closure, no lock
    Caller->>themeIds: ThemeLoader.themeIds
    themeIds-->>Caller: cached [String] (dispatch_once)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(swift): cache themeIds via static le..."](https://github.com/lgtm-hq/turbo-themes/commit/f36985f468f99450dab14a678942e87b2923280f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45366135)</sub>

<!-- /greptile_comment -->