### PR TITLE
feat(ci): route test-scoped commits to the Internal changelog section

### DIFF
--- a/scripts/ci/version-bump.mjs
+++ b/scripts/ci/version-bump.mjs
@@ -31,7 +31,7 @@ const CONFIG = {
   // Scopes routed to the non-consumer "Internal" changelog section (not Fixed/Added/Changed).
   // These commits still participate in version bump decisions via their type.
   // Breaking changes always stay in BREAKING CHANGES regardless of scope.
-  changelogInternalScopes: ['ci', 'build'],
+  changelogInternalScopes: ['ci', 'build', 'test'],
   ignorePatterns: ['chore(release):'], // Full prefix patterns to skip entirely
   changelogFile: join(projectRoot, 'CHANGELOG.md'),
   packageFile: join(projectRoot, 'package.json'),

--- a/test/version-bump.test.ts
+++ b/test/version-bump.test.ts
@@ -102,8 +102,8 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
     );
   });
 
-  describe('issue #581: ci/build scopes → ### 🤖 Internal (not consumer sections)', () => {
-    it.each(['ci', 'build'] as const)(
+  describe('issue #581/#648: ci/build/test scopes → ### 🤖 Internal (not consumer sections)', () => {
+    it.each(['ci', 'build', 'test'] as const)(
       'fix(%s) appears under Internal, not Fixed',
       (scope) => {
         const commits = [
@@ -122,7 +122,7 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
       },
     );
 
-    it.each(['ci', 'build'] as const)(
+    it.each(['ci', 'build', 'test'] as const)(
       'feat(%s) appears under Internal, not Added',
       (scope) => {
         const commits = [
@@ -140,7 +140,7 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
       },
     );
 
-    it.each(['ci', 'build'] as const)(
+    it.each(['ci', 'build', 'test'] as const)(
       'chore(%s) appears under Internal, not Changed',
       (scope) => {
         const commits = [


### PR DESCRIPTION
## Summary

Extends #602's Internal-section routing to `test`-scoped commits (`refactor(test): …` etc.), which have no observable consumer effect but were still surfacing in consumer-facing changelog sections (flagged on release #646). Bump behavior unchanged per policy. Test matrix extended to cover the new scope.

Fixes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog generation so test-related changes are grouped under the Internal section, alongside CI and build updates.
  * Expanded coverage to verify the new changelog categorization across fixes, features, and chores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the Internal-section scope routing (introduced in #602) to the `test` scope, so commits like `fix(test): …` or `refactor(test): …` no longer surface in consumer-facing changelog sections. Version bump behavior is unchanged: the commit TYPE still governs whether a bump fires.

- `scripts/ci/version-bump.mjs`: One-line addition of `'test'` to `changelogInternalScopes`; breaking-change bypass and bump logic are untouched.
- `test/version-bump.test.ts`: Three `it.each` matrices extended from `['ci', 'build']` to `['ci', 'build', 'test']`; however, the standalone `isChangelogInternalScope` unit-test block at the bottom of the file was not updated to include `'test'`/`'Test'`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the production change is a single-element array addition with no impact on bump logic or breaking-change handling.

The core change is correct and the new bucketing tests cover the three main commit type × test scope combinations. The only gap is that the dedicated `isChangelogInternalScope` unit test block was not updated to assert `'test'`/`'Test'` are considered internal, so that function's direct tests are now slightly stale relative to the implementation.

test/version-bump.test.ts — the `isChangelogInternalScope` describe block near the bottom needs `'test'` and `'Test'` added to its `.each` array.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/version-bump.mjs | Adds `'test'` to `changelogInternalScopes`; one-line change is correct and consistent with existing `ci`/`build` scope routing. Bump decision logic is untouched. |
| test/version-bump.test.ts | Bucketing `it.each` matrices correctly extended to cover `test` scope. The standalone `isChangelogInternalScope` unit test block at the bottom was not updated to include `'test'`/`'Test'`, leaving a gap in direct coverage for that function. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Commit Message] --> B{parseCommit}
    B -->|null| SKIP[Skip]
    B -->|parsed| C{Type in ignoreTypes?\nci / build / release}
    C -->|yes| SKIP
    C -->|no| D{Matches ignorePatterns?\ne.g. chore release}
    D -->|yes| SKIP
    D -->|no| E{isBreakingCommit?}
    E -->|yes| BREAK[⚠️ BREAKING CHANGES]
    E -->|no| F{isChangelogInternalScope?\nscope in ci / build / test}
    F -->|yes - NEW: test added| INTERNAL[🤖 Internal]
    F -->|no| G{minorTypes?\nfeat / feature}
    G -->|yes| ADDED[✨ Added]
    G -->|no| H{fixTypes?\nfix / bugfix / patch}
    H -->|yes| FIXED[🐛 Fixed]
    H -->|no| CHANGED[🔧 Changed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Commit Message] --> B{parseCommit}
    B -->|null| SKIP[Skip]
    B -->|parsed| C{Type in ignoreTypes?\nci / build / release}
    C -->|yes| SKIP
    C -->|no| D{Matches ignorePatterns?\ne.g. chore release}
    D -->|yes| SKIP
    D -->|no| E{isBreakingCommit?}
    E -->|yes| BREAK[⚠️ BREAKING CHANGES]
    E -->|no| F{isChangelogInternalScope?\nscope in ci / build / test}
    F -->|yes - NEW: test added| INTERNAL[🤖 Internal]
    F -->|no| G{minorTypes?\nfeat / feature}
    G -->|yes| ADDED[✨ Added]
    G -->|no| H{fixTypes?\nfix / bugfix / patch}
    H -->|yes| FIXED[🐛 Fixed]
    H -->|no| CHANGED[🔧 Changed]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/version-bump.test.ts`, line 286-288 ([link](https://github.com/lgtm-hq/turbo-themes/blob/0110500858d195bb22bd53ea012e45fa73b253a0/test/version-bump.test.ts#L286-L288)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `.each` array should be updated to include `'test'` and `'Test'` so the direct unit tests for `isChangelogInternalScope` stay in sync with `changelogInternalScopes`. The new scope gets indirect exercise through the bucketing `it.each` blocks above, but if someone later changes `isChangelogInternalScope` in isolation, the dedicated unit test will not catch a regression for `'test'`.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fversion-bump.test.ts%0ALine%3A%20286-288%0A%0AComment%3A%0AThe%20%60.each%60%20array%20should%20be%20updated%20to%20include%20%60'test'%60%20and%20%60'Test'%60%20so%20the%20direct%20unit%20tests%20for%20%60isChangelogInternalScope%60%20stay%20in%20sync%20with%20%60changelogInternalScopes%60.%20The%20new%20scope%20gets%20indirect%20exercise%20through%20the%20bucketing%20%60it.each%60%20blocks%20above%2C%20but%20if%20someone%20later%20changes%20%60isChangelogInternalScope%60%20in%20isolation%2C%20the%20dedicated%20unit%20test%20will%20not%20catch%20a%20regression%20for%20%60'test'%60.%0A%0A%60%60%60suggestion%0A%20%20it.each%28%5B'ci'%2C%20'build'%2C%20'test'%2C%20'CI'%2C%20'Build'%2C%20'Test'%5D%20as%20const%29%28'%22%25s%22%20is%20internal'%2C%20%28scope%29%20%3D%3E%20%7B%0A%20%20%20%20expect%28isChangelogInternalScope%28scope%29%29.toBe%28true%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fversion-bump.test.ts%0ALine%3A%20286-288%0A%0AComment%3A%0AThe%20%60.each%60%20array%20should%20be%20updated%20to%20include%20%60'test'%60%20and%20%60'Test'%60%20so%20the%20direct%20unit%20tests%20for%20%60isChangelogInternalScope%60%20stay%20in%20sync%20with%20%60changelogInternalScopes%60.%20The%20new%20scope%20gets%20indirect%20exercise%20through%20the%20bucketing%20%60it.each%60%20blocks%20above%2C%20but%20if%20someone%20later%20changes%20%60isChangelogInternalScope%60%20in%20isolation%2C%20the%20dedicated%20unit%20test%20will%20not%20catch%20a%20regression%20for%20%60'test'%60.%0A%0A%60%60%60suggestion%0A%20%20it.each%28%5B'ci'%2C%20'build'%2C%20'test'%2C%20'CI'%2C%20'Build'%2C%20'Test'%5D%20as%20const%29%28'%22%25s%22%20is%20internal'%2C%20%28scope%29%20%3D%3E%20%7B%0A%20%20%20%20expect%28isChangelogInternalScope%28scope%29%29.toBe%28true%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22feat%2F648-test-scope-internal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F648-test-scope-internal%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fversion-bump.test.ts%0ALine%3A%20286-288%0A%0AComment%3A%0AThe%20%60.each%60%20array%20should%20be%20updated%20to%20include%20%60'test'%60%20and%20%60'Test'%60%20so%20the%20direct%20unit%20tests%20for%20%60isChangelogInternalScope%60%20stay%20in%20sync%20with%20%60changelogInternalScopes%60.%20The%20new%20scope%20gets%20indirect%20exercise%20through%20the%20bucketing%20%60it.each%60%20blocks%20above%2C%20but%20if%20someone%20later%20changes%20%60isChangelogInternalScope%60%20in%20isolation%2C%20the%20dedicated%20unit%20test%20will%20not%20catch%20a%20regression%20for%20%60'test'%60.%0A%0A%60%60%60suggestion%0A%20%20it.each%28%5B'ci'%2C%20'build'%2C%20'test'%2C%20'CI'%2C%20'Build'%2C%20'Test'%5D%20as%20const%29%28'%22%25s%22%20is%20internal'%2C%20%28scope%29%20%3D%3E%20%7B%0A%20%20%20%20expect%28isChangelogInternalScope%28scope%29%29.toBe%28true%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fversion-bump.test.ts%3A286-288%0AThe%20%60.each%60%20array%20should%20be%20updated%20to%20include%20%60'test'%60%20and%20%60'Test'%60%20so%20the%20direct%20unit%20tests%20for%20%60isChangelogInternalScope%60%20stay%20in%20sync%20with%20%60changelogInternalScopes%60.%20The%20new%20scope%20gets%20indirect%20exercise%20through%20the%20bucketing%20%60it.each%60%20blocks%20above%2C%20but%20if%20someone%20later%20changes%20%60isChangelogInternalScope%60%20in%20isolation%2C%20the%20dedicated%20unit%20test%20will%20not%20catch%20a%20regression%20for%20%60'test'%60.%0A%0A%60%60%60suggestion%0A%20%20it.each%28%5B'ci'%2C%20'build'%2C%20'test'%2C%20'CI'%2C%20'Build'%2C%20'Test'%5D%20as%20const%29%28'%22%25s%22%20is%20internal'%2C%20%28scope%29%20%3D%3E%20%7B%0A%20%20%20%20expect%28isChangelogInternalScope%28scope%29%29.toBe%28true%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fversion-bump.test.ts%3A286-288%0AThe%20%60.each%60%20array%20should%20be%20updated%20to%20include%20%60'test'%60%20and%20%60'Test'%60%20so%20the%20direct%20unit%20tests%20for%20%60isChangelogInternalScope%60%20stay%20in%20sync%20with%20%60changelogInternalScopes%60.%20The%20new%20scope%20gets%20indirect%20exercise%20through%20the%20bucketing%20%60it.each%60%20blocks%20above%2C%20but%20if%20someone%20later%20changes%20%60isChangelogInternalScope%60%20in%20isolation%2C%20the%20dedicated%20unit%20test%20will%20not%20catch%20a%20regression%20for%20%60'test'%60.%0A%0A%60%60%60suggestion%0A%20%20it.each%28%5B'ci'%2C%20'build'%2C%20'test'%2C%20'CI'%2C%20'Build'%2C%20'Test'%5D%20as%20const%29%28'%22%25s%22%20is%20internal'%2C%20%28scope%29%20%3D%3E%20%7B%0A%20%20%20%20expect%28isChangelogInternalScope%28scope%29%29.toBe%28true%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22feat%2F648-test-scope-internal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F648-test-scope-internal%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fversion-bump.test.ts%3A286-288%0AThe%20%60.each%60%20array%20should%20be%20updated%20to%20include%20%60'test'%60%20and%20%60'Test'%60%20so%20the%20direct%20unit%20tests%20for%20%60isChangelogInternalScope%60%20stay%20in%20sync%20with%20%60changelogInternalScopes%60.%20The%20new%20scope%20gets%20indirect%20exercise%20through%20the%20bucketing%20%60it.each%60%20blocks%20above%2C%20but%20if%20someone%20later%20changes%20%60isChangelogInternalScope%60%20in%20isolation%2C%20the%20dedicated%20unit%20test%20will%20not%20catch%20a%20regression%20for%20%60'test'%60.%0A%0A%60%60%60suggestion%0A%20%20it.each%28%5B'ci'%2C%20'build'%2C%20'test'%2C%20'CI'%2C%20'Build'%2C%20'Test'%5D%20as%20const%29%28'%22%25s%22%20is%20internal'%2C%20%28scope%29%20%3D%3E%20%7B%0A%20%20%20%20expect%28isChangelogInternalScope%28scope%29%29.toBe%28true%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): route test-scoped commits to t..."](https://github.com/lgtm-hq/turbo-themes/commit/0110500858d195bb22bd53ea012e45fa73b253a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45408972)</sub>

<!-- /greptile_comment -->