### PR TITLE
chore(ci): document lgtm-ci reusable release-version-pr adoption audit

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -1,4 +1,59 @@
 ---
+# =============================================================================
+# lgtm-ci reusable adoption audit — issue #647 (supersedes stale PR #489)
+# =============================================================================
+# Decision: DEFER. Keep this local workflow; do NOT swap it for a thin
+# `workflow_call` caller of lgtm-hq/lgtm-ci `reusable-release-version-pr.yml`.
+#
+# Audited against: lgtm-hq/lgtm-ci reusable-release-version-pr.yml
+#   version v0.59.0 — SHA 443a687caa93b3afa306a066aae8d8a2b4e60c3c
+#
+# Behaviors that ARE expressible via the current reusable (no blocker):
+#   - sign-commits: true (hardcoded upstream; required-signatures ruleset #544)
+#   - release-commit guard loop prevention (skip-patterns default
+#     `^chore\(release\):` matches guard-release-commit.sh)
+#   - CODEOWNER review AND assignee (#621): upstream assign-codeowner.sh does
+#     `--add-assignee` and requests review for Bot-authored PRs when
+#     REQUEST_CODEOWNER_REVIEW=true (parity with request-codeowner-review.sh)
+#   - Auto-merge for minor+patch bumps (current practice, e.g. 0.29.0): set
+#     `auto-merge: true` + `auto-merge-patch-only: false`. Patch-only remains a
+#     deliberate future product decision, NOT adopted here.
+#   - Failure reporting (#568): upstream report-release-failure job opens/updates
+#     a deduplicated issue (different mechanism, comparable coverage).
+#
+# BLOCKING gaps that would REGRESS load-bearing behavior if adopted today:
+#   1. Version-stamped artifact regeneration (#635) — BLOCKER. The reusable job
+#      has no Bun/Node toolchain setup and no `bun install`; its only
+#      repo-specific hook, `version-update-script`, runs bare with just
+#      NEXT_VERSION in env. turbo-themes must run
+#      `scripts/ci/regenerate-release-artifacts.sh`
+#      (bun run build && build:js:dev && build:js:prod), which requires the
+#      installed workspace toolchain, to refresh committed version-stamped
+#      artifacts: the tokens.json `$version` + recomputed `$generated` sha256
+#      hashes (packages/core, python, swift) and the `assets/js/theme-selector*`
+#      IIFE bundles that embed the tokens payload. A caller cannot inject
+#      setup/install steps into a reusable job, so adoption would ship
+#      stale/hash-mismatched artifacts in the release PR.
+#   2. Transient push-retry in-run recovery (#568) — upstream drops
+#      retry-release-branch-push.sh; it fails then reports via issue rather than
+#      recovering the push within the same run.
+#   3. Cross-platform version sync semantics (scripts/sync-version.mjs) —
+#      tokens `$generated` hash recompute is turbo-themes-specific and is not
+#      covered by the generic per-ecosystem updaters; it too needs the toolchain
+#      hook from gap #1.
+#
+# Upstream (lgtm-ci) needs before this can be adopted without regression:
+#   - A pre-PR toolchain/build hook that runs with repo dependencies installed
+#     (e.g. caller-provided setup-commands / node+bun setup + install before the
+#     version-update-script step), so repo-specific artifact regeneration can
+#     run inside the reusable job.
+#   - Optionally, an in-run transient push-retry option (or accept dedup-issue
+#     reporting as the replacement for recovery).
+#
+# Revisit when: lgtm-ci ships the pre-PR toolchain/build hook above. Re-run this
+# diff against the then-current reusable SHA before adopting; never regress
+# sign-commits or artifact regeneration.
+# =============================================================================
 name: Release - Version PR
 
 on:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the #647 re-evaluation of adopting `lgtm-ci` `reusable-release-version-pr` for turbo-themes. Diffed the local `release-version-pr.yml` against the org reusable at v0.59.0 (`443a687caa93b3afa306a066aae8d8a2b4e60c3c`) and recorded a durable in-workflow audit: adoption is deferred because version-stamped artifact regeneration (#635 / `regenerate-release-artifacts.sh`) is not expressible without a Bun/Node install + build hook inside the reusable job.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [x] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [x] 🔨 Chore (`chore:`)

## Changes Made

- Add a durable audit comment to `.github/workflows/release-version-pr.yml` covering what the reusable can/cannot express
- Document preserved local behaviors (signed commits, artifact regen, CODEOWNER assign/review, guard loop, auto-merge policy for minor+patch)
- Document upstream need: pre-PR toolchain/build hook before adoption can proceed without regressing #635

## Closes

- Closes #647
- Relates to #489

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`npm test`)

### Test Coverage

- [x] Coverage maintained or improved
- [x] No decrease in code coverage
- [ ] Coverage report reviewed

## Quality Checks

- [x] Linting passes (`uv run lintro chk`)
- [x] Formatting passes (`uv run lintro fmt`)
- [ ] TypeScript build successful (`npm run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

## Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [x] Comments added to complex code
- [ ] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided below

## Screenshots / Demos

<!-- N/A — comment-only workflow documentation -->

## Deployment Notes

No runtime behavior change; local `release-version-pr.yml` remains the active implementation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

## Additional Context

Expressible today via reusable inputs: `sign-commits`, skip/guard patterns, CODEOWNER assign+review, failure reporting, minor+patch auto-merge. Blocking gap: no Bun/Node setup path for `regenerate-release-artifacts.sh` before the bump commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e446e938-d14f-4a61-93af-b1be41e56ebc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e446e938-d14f-4a61-93af-b1be41e56ebc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR records why the local release-version workflow cannot yet move to the reusable `lgtm-ci` workflow. The main changes are:

- Documents behavior supported by the reusable workflow.
- Records artifact regeneration and version synchronization as migration blockers.
- Notes retry differences and the upstream hooks needed before adoption.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The update changes comments only and does not alter workflow execution.
- No new blocking issue remains after excluding the already-reported policy wording.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-version-pr.yml | Adds a comment-only adoption audit while leaving the executable release workflow unchanged. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(ci): document lgtm-ci reusable rel..."](https://github.com/lgtm-hq/turbo-themes/commit/08629f715d4b49c132f1b210712252355e28c283) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46043476)</sub>

<!-- /greptile_comment -->