### PR TITLE
fix(ci): tolerate missing playwright report in Pages bundle manifest

### DIFF
--- a/.github/pages-bundle-manifest.json
+++ b/.github/pages-bundle-manifest.json
@@ -13,7 +13,7 @@
       "workflow": "Quality Check - E2E Tests",
       "artifact": "playwright-report",
       "dest": "playwright",
-      "require_success": true
+      "require_success": false
     },
     {
       "id": "lighthouse",


### PR DESCRIPTION
## Summary

Unblocks the GitHub Pages deploy, which has failed on every main push since #600: the strict `playwright` bundle demands a `playwright-report` artifact that the lgtm-ci e2e reusable never produces on successful runs (it uploads `playwright-report-<run_id>`, failure-only). The site is frozen pre-Noir/pre-Radix as a result.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- Set `require_success: false` on the `playwright` bundle in `.github/pages-bundle-manifest.json` so a missing report degrades to a warning and the site content deploys

## Closes

- Closes #673

## Testing

- [x] Manual testing performed (bundler semantics verified against lgtm-ci `workflow_artifacts.sh` v0.59.0: missing artifact is warn-and-continue when `require_success` is false)

## Quality Checks

- [x] Linting passes (`uv run lintro chk` on the manifest)
- [x] No new warnings or errors

## Deployment Notes

After merge, the next main push (or a `workflow_dispatch` of Deploy - GitHub Pages) publishes the accumulated releases (Noir redesign, Radix, Everforest, and Kanagawa once #605 lands). Follow-up in #673: stable-named success upload in lgtm-ci, then restore `require_success: true`; plus failure alerting for the deploy workflow.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes `require_success` from `true` to `false` for the `playwright` bundle in `.github/pages-bundle-manifest.json`, unblocking the GitHub Pages deploy that has been broken since #600. The root cause is that the lgtm-ci E2E reusable workflow never uploads an artifact named `playwright-report` (it uses `playwright-report-<run_id>` on failure only), so the bundler always fails to find the artifact and aborts the deploy under the old strict setting.

- The one-line config change is minimal and correctly targeted — only the broken `playwright` bundle is relaxed; `vitest-coverage`, `lighthouse`, and `playwright-examples` retain `require_success: true`.
- As a side effect of the artifact name mismatch (pre-existing, tracked in #673), E2E failure reports won't appear on Pages until the follow-up lands; the deployed site will simply omit the playwright section.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — it unblocks a broken deploy with a one-line config change and no functional regressions on other bundles.

The change is correct and narrowly scoped. The remaining gap — E2E failure reports won't appear on Pages because the artifact name never matches — is a pre-existing issue acknowledged by the author and tracked for follow-up. Other bundles are unaffected.

No files require special attention; the single changed line in `.github/pages-bundle-manifest.json` is straightforward.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/pages-bundle-manifest.json | Single-field change: `require_success` on the `playwright` bundle flipped from `true` to `false` so a missing `playwright-report` artifact degrades to a warning instead of aborting the Pages deploy. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as lgtm-ci E2E Workflow
    participant GH as GitHub Artifacts
    participant Bundler as pages-bundler (workflow_artifacts.sh)
    participant Pages as GitHub Pages

    CI->>CI: Run Playwright tests (success)
    Note over CI,GH: On success: no artifact uploaded<br/>(failure-only path uploads playwright-report-run_id)

    Bundler->>GH: Fetch artifact "playwright-report"
    GH-->>Bundler: 404 Not Found

    alt require_success: true (before this PR)
        Bundler-->>Pages: ❌ ABORT — missing required artifact
        Note over Pages: Site frozen since #600
    else require_success: false (after this PR)
        Bundler-->>Pages: ⚠️ WARN — skipping missing artifact
        Bundler->>Pages: ✅ Deploy remaining bundles
        Note over Pages: Site deploys (Noir, Radix, Everforest, etc.)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as lgtm-ci E2E Workflow
    participant GH as GitHub Artifacts
    participant Bundler as pages-bundler (workflow_artifacts.sh)
    participant Pages as GitHub Pages

    CI->>CI: Run Playwright tests (success)
    Note over CI,GH: On success: no artifact uploaded<br/>(failure-only path uploads playwright-report-run_id)

    Bundler->>GH: Fetch artifact "playwright-report"
    GH-->>Bundler: 404 Not Found

    alt require_success: true (before this PR)
        Bundler-->>Pages: ❌ ABORT — missing required artifact
        Note over Pages: Site frozen since #600
    else require_success: false (after this PR)
        Bundler-->>Pages: ⚠️ WARN — skipping missing artifact
        Bundler->>Pages: ✅ Deploy remaining bundles
        Note over Pages: Site deploys (Noir, Radix, Everforest, etc.)
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/pages-bundle-manifest.json`, line 12-17 ([link](https://github.com/lgtm-hq/turbo-themes/blob/a8092cf90e9ea979bdacf2c3479dc8d38af17a60/.github/pages-bundle-manifest.json#L12-L17)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Artifact name mismatch means failure reports also won't surface on Pages**

   The manifest looks for an artifact named `playwright-report`, but the lgtm-ci reusable uploads it as `playwright-report-<run_id>` — even on failure. This means a broken E2E run after merge will silently produce no report on GitHub Pages (the lookup misses either way), so a regression in E2E could go unnoticed until someone manually checks Actions. The follow-up in #673 (stable-named artifact + restoring `require_success: true`) will close this gap, but it's worth noting that until then the Pages playwright section will always be empty, not just absent on success.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fpages-bundle-manifest.json%0ALine%3A%2012-17%0A%0AComment%3A%0A**Artifact%20name%20mismatch%20means%20failure%20reports%20also%20won't%20surface%20on%20Pages**%0A%0AThe%20manifest%20looks%20for%20an%20artifact%20named%20%60playwright-report%60%2C%20but%20the%20lgtm-ci%20reusable%20uploads%20it%20as%20%60playwright-report-%3Crun_id%3E%60%20%E2%80%94%20even%20on%20failure.%20This%20means%20a%20broken%20E2E%20run%20after%20merge%20will%20silently%20produce%20no%20report%20on%20GitHub%20Pages%20%28the%20lookup%20misses%20either%20way%29%2C%20so%20a%20regression%20in%20E2E%20could%20go%20unnoticed%20until%20someone%20manually%20checks%20Actions.%20The%20follow-up%20in%20%23673%20%28stable-named%20artifact%20%2B%20restoring%20%60require_success%3A%20true%60%29%20will%20close%20this%20gap%2C%20but%20it's%20worth%20noting%20that%20until%20then%20the%20Pages%20playwright%20section%20will%20always%20be%20empty%2C%20not%20just%20absent%20on%20success.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=674&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fpages-bundle-manifest.json%0ALine%3A%2012-17%0A%0AComment%3A%0A**Artifact%20name%20mismatch%20means%20failure%20reports%20also%20won't%20surface%20on%20Pages**%0A%0AThe%20manifest%20looks%20for%20an%20artifact%20named%20%60playwright-report%60%2C%20but%20the%20lgtm-ci%20reusable%20uploads%20it%20as%20%60playwright-report-%3Crun_id%3E%60%20%E2%80%94%20even%20on%20failure.%20This%20means%20a%20broken%20E2E%20run%20after%20merge%20will%20silently%20produce%20no%20report%20on%20GitHub%20Pages%20%28the%20lookup%20misses%20either%20way%29%2C%20so%20a%20regression%20in%20E2E%20could%20go%20unnoticed%20until%20someone%20manually%20checks%20Actions.%20The%20follow-up%20in%20%23673%20%28stable-named%20artifact%20%2B%20restoring%20%60require_success%3A%20true%60%29%20will%20close%20this%20gap%2C%20but%20it's%20worth%20noting%20that%20until%20then%20the%20Pages%20playwright%20section%20will%20always%20be%20empty%2C%20not%20just%20absent%20on%20success.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=674&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22fix%2F673-pages-playwright-bundle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F673-pages-playwright-bundle%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fpages-bundle-manifest.json%0ALine%3A%2012-17%0A%0AComment%3A%0A**Artifact%20name%20mismatch%20means%20failure%20reports%20also%20won't%20surface%20on%20Pages**%0A%0AThe%20manifest%20looks%20for%20an%20artifact%20named%20%60playwright-report%60%2C%20but%20the%20lgtm-ci%20reusable%20uploads%20it%20as%20%60playwright-report-%3Crun_id%3E%60%20%E2%80%94%20even%20on%20failure.%20This%20means%20a%20broken%20E2E%20run%20after%20merge%20will%20silently%20produce%20no%20report%20on%20GitHub%20Pages%20%28the%20lookup%20misses%20either%20way%29%2C%20so%20a%20regression%20in%20E2E%20could%20go%20unnoticed%20until%20someone%20manually%20checks%20Actions.%20The%20follow-up%20in%20%23673%20%28stable-named%20artifact%20%2B%20restoring%20%60require_success%3A%20true%60%29%20will%20close%20this%20gap%2C%20but%20it's%20worth%20noting%20that%20until%20then%20the%20Pages%20playwright%20section%20will%20always%20be%20empty%2C%20not%20just%20absent%20on%20success.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=674&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fpages-bundle-manifest.json%3A12-17%0A**Artifact%20name%20mismatch%20means%20failure%20reports%20also%20won't%20surface%20on%20Pages**%0A%0AThe%20manifest%20looks%20for%20an%20artifact%20named%20%60playwright-report%60%2C%20but%20the%20lgtm-ci%20reusable%20uploads%20it%20as%20%60playwright-report-%3Crun_id%3E%60%20%E2%80%94%20even%20on%20failure.%20This%20means%20a%20broken%20E2E%20run%20after%20merge%20will%20silently%20produce%20no%20report%20on%20GitHub%20Pages%20%28the%20lookup%20misses%20either%20way%29%2C%20so%20a%20regression%20in%20E2E%20could%20go%20unnoticed%20until%20someone%20manually%20checks%20Actions.%20The%20follow-up%20in%20%23673%20%28stable-named%20artifact%20%2B%20restoring%20%60require_success%3A%20true%60%29%20will%20close%20this%20gap%2C%20but%20it's%20worth%20noting%20that%20until%20then%20the%20Pages%20playwright%20section%20will%20always%20be%20empty%2C%20not%20just%20absent%20on%20success.%0A%0A&pr=674&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fpages-bundle-manifest.json%3A12-17%0A**Artifact%20name%20mismatch%20means%20failure%20reports%20also%20won't%20surface%20on%20Pages**%0A%0AThe%20manifest%20looks%20for%20an%20artifact%20named%20%60playwright-report%60%2C%20but%20the%20lgtm-ci%20reusable%20uploads%20it%20as%20%60playwright-report-%3Crun_id%3E%60%20%E2%80%94%20even%20on%20failure.%20This%20means%20a%20broken%20E2E%20run%20after%20merge%20will%20silently%20produce%20no%20report%20on%20GitHub%20Pages%20%28the%20lookup%20misses%20either%20way%29%2C%20so%20a%20regression%20in%20E2E%20could%20go%20unnoticed%20until%20someone%20manually%20checks%20Actions.%20The%20follow-up%20in%20%23673%20%28stable-named%20artifact%20%2B%20restoring%20%60require_success%3A%20true%60%29%20will%20close%20this%20gap%2C%20but%20it's%20worth%20noting%20that%20until%20then%20the%20Pages%20playwright%20section%20will%20always%20be%20empty%2C%20not%20just%20absent%20on%20success.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=674&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22fix%2F673-pages-playwright-bundle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F673-pages-playwright-bundle%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fpages-bundle-manifest.json%3A12-17%0A**Artifact%20name%20mismatch%20means%20failure%20reports%20also%20won't%20surface%20on%20Pages**%0A%0AThe%20manifest%20looks%20for%20an%20artifact%20named%20%60playwright-report%60%2C%20but%20the%20lgtm-ci%20reusable%20uploads%20it%20as%20%60playwright-report-%3Crun_id%3E%60%20%E2%80%94%20even%20on%20failure.%20This%20means%20a%20broken%20E2E%20run%20after%20merge%20will%20silently%20produce%20no%20report%20on%20GitHub%20Pages%20%28the%20lookup%20misses%20either%20way%29%2C%20so%20a%20regression%20in%20E2E%20could%20go%20unnoticed%20until%20someone%20manually%20checks%20Actions.%20The%20follow-up%20in%20%23673%20%28stable-named%20artifact%20%2B%20restoring%20%60require_success%3A%20true%60%29%20will%20close%20this%20gap%2C%20but%20it's%20worth%20noting%20that%20until%20then%20the%20Pages%20playwright%20section%20will%20always%20be%20empty%2C%20not%20just%20absent%20on%20success.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=674&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): tolerate missing playwright rep..."](https://github.com/lgtm-hq/turbo-themes/commit/a8092cf90e9ea979bdacf2c3479dc8d38af17a60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45576976)</sub>

<!-- /greptile_comment -->