### PR TITLE
fix(ci): drop unresolvable playwright bundle from Pages manifest

### DIFF
--- a/.github/pages-bundle-manifest.json
+++ b/.github/pages-bundle-manifest.json
@@ -9,13 +9,6 @@
       "require_success": true
     },
     {
-      "id": "playwright",
-      "workflow": "Quality Check - E2E Tests",
-      "artifact": "playwright-report",
-      "dest": "playwright",
-      "require_success": false
-    },
-    {
       "id": "lighthouse",
       "workflow": "Reporting - Lighthouse CI",
       "artifact": "lighthouse-reports",


### PR DESCRIPTION
## Summary

Second and final unblock for the Pages deploy (#673): remove the `playwright` bundle from `.github/pages-bundle-manifest.json`. #674's `require_success: false` was insufficient — under manifest-level `strict: true`, a missing artifact is fatal regardless of that flag (verified by dispatch run 29732010686 failing identically post-#674; bundler lib `workflow_artifacts.sh` lines 425-433). The bundle can never resolve because the lgtm-ci e2e reusable uploads `playwright-report-<run_id>` and only on failure.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- Remove the `playwright` bundle entry; `strict: true` protection stays for the five bundles whose artifacts do exist on green main runs

## Closes

- Closes #673

## Testing

- [x] Manual testing performed (remaining bundle artifacts verified present on latest main runs: coverage-html, lighthouse-reports, examples-playwright-report)

## Quality Checks

- [x] Linting passes
- [x] No new warnings or errors

## Deployment Notes

After merge I will dispatch Deploy - GitHub Pages and verify the live site shows the Noir redesign + new theme packs. Restore the playwright bundle once lgtm-ci uploads a stable-named report on success (tracked in #673's follow-up note).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the `playwright` bundle entry from `.github/pages-bundle-manifest.json` to fix a fatal artifact-resolution error that was blocking the Pages deploy workflow. The root cause is that the lgtm-ci E2E reusable uploads `playwright-report-<run_id>` only on failure, so neither the exact artifact name (`playwright-report`) nor any fallback on `main` could ever resolve under `strict: true`.

- Removes the `playwright` bundle (id, workflow, artifact, dest fields) from the manifest, leaving six remaining entries — three with `require_success: true` (vitest-coverage, lighthouse, playwright-examples) and three with `require_success: false` (coverage-python, coverage-ruby, coverage-swift).
- The three path-triggered coverage bundles retain `require_success: false` and are protected by the existing `fallback-ref: main` in `deploy-pages.yml`, which the workflow comment explicitly acknowledges as the intended safety valve for workflows that do not run on every main commit.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a single manifest entry that was never resolvable and was the direct cause of the blocked deploy.

The change is a one-entry JSON deletion with a clear, verified root cause: the E2E reusable uploads its report under a run-id-suffixed name only on failure, so the static artifact name in the manifest could never be found on a successful main run. The remaining six bundles are unaffected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/pages-bundle-manifest.json | Removes the `playwright` bundle entry that could never resolve (`playwright-report` artifact is uploaded only on failure with a run_id suffix). The remaining six bundles are either unconditionally uploaded or covered by `fallback-ref: main` in the deploy workflow. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/pages-bundle-manifest.json`, line 29-45 ([link](https://github.com/lgtm-hq/turbo-themes/blob/cd4eba20fefb5fdff39fa97ed7c082dc98f69d37/.github/pages-bundle-manifest.json#L29-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`strict: true` + `require_success: false` interaction unverified for multi-language coverage bundles**

   The PR description correctly identifies that `strict: true` makes a missing artifact fatal regardless of a bundle's own `require_success` flag (citing `workflow_artifacts.sh` lines 425-433). The three multi-language coverage bundles (`coverage-python`, `coverage-ruby`, `coverage-swift`) all carry `require_success: false` — if those artifacts aren't uploaded on every green main run, they could trigger the same fatal-missing-artifact path under `strict: true` that this PR is fixing for `playwright`. The PR description also mentions only "five bundles whose artifacts do exist" but six now remain in the file, which is a small mismatch worth double-checking. If the bundler only skips presence enforcement when `require_success: false` at the individual bundle level (i.e., `strict: true` only prevents schema errors, not missing artifacts), these entries are fine as-is — but confirming that before the next deploy dispatch would be worthwhile.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fpages-bundle-manifest.json%0ALine%3A%2029-45%0A%0AComment%3A%0A**%60strict%3A%20true%60%20%2B%20%60require_success%3A%20false%60%20interaction%20unverified%20for%20multi-language%20coverage%20bundles**%0A%0AThe%20PR%20description%20correctly%20identifies%20that%20%60strict%3A%20true%60%20makes%20a%20missing%20artifact%20fatal%20regardless%20of%20a%20bundle's%20own%20%60require_success%60%20flag%20%28citing%20%60workflow_artifacts.sh%60%20lines%20425-433%29.%20The%20three%20multi-language%20coverage%20bundles%20%28%60coverage-python%60%2C%20%60coverage-ruby%60%2C%20%60coverage-swift%60%29%20all%20carry%20%60require_success%3A%20false%60%20%E2%80%94%20if%20those%20artifacts%20aren't%20uploaded%20on%20every%20green%20main%20run%2C%20they%20could%20trigger%20the%20same%20fatal-missing-artifact%20path%20under%20%60strict%3A%20true%60%20that%20this%20PR%20is%20fixing%20for%20%60playwright%60.%20The%20PR%20description%20also%20mentions%20only%20%22five%20bundles%20whose%20artifacts%20do%20exist%22%20but%20six%20now%20remain%20in%20the%20file%2C%20which%20is%20a%20small%20mismatch%20worth%20double-checking.%20If%20the%20bundler%20only%20skips%20presence%20enforcement%20when%20%60require_success%3A%20false%60%20at%20the%20individual%20bundle%20level%20%28i.e.%2C%20%60strict%3A%20true%60%20only%20prevents%20schema%20errors%2C%20not%20missing%20artifacts%29%2C%20these%20entries%20are%20fine%20as-is%20%E2%80%94%20but%20confirming%20that%20before%20the%20next%20deploy%20dispatch%20would%20be%20worthwhile.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fpages-bundle-manifest.json%0ALine%3A%2029-45%0A%0AComment%3A%0A**%60strict%3A%20true%60%20%2B%20%60require_success%3A%20false%60%20interaction%20unverified%20for%20multi-language%20coverage%20bundles**%0A%0AThe%20PR%20description%20correctly%20identifies%20that%20%60strict%3A%20true%60%20makes%20a%20missing%20artifact%20fatal%20regardless%20of%20a%20bundle's%20own%20%60require_success%60%20flag%20%28citing%20%60workflow_artifacts.sh%60%20lines%20425-433%29.%20The%20three%20multi-language%20coverage%20bundles%20%28%60coverage-python%60%2C%20%60coverage-ruby%60%2C%20%60coverage-swift%60%29%20all%20carry%20%60require_success%3A%20false%60%20%E2%80%94%20if%20those%20artifacts%20aren't%20uploaded%20on%20every%20green%20main%20run%2C%20they%20could%20trigger%20the%20same%20fatal-missing-artifact%20path%20under%20%60strict%3A%20true%60%20that%20this%20PR%20is%20fixing%20for%20%60playwright%60.%20The%20PR%20description%20also%20mentions%20only%20%22five%20bundles%20whose%20artifacts%20do%20exist%22%20but%20six%20now%20remain%20in%20the%20file%2C%20which%20is%20a%20small%20mismatch%20worth%20double-checking.%20If%20the%20bundler%20only%20skips%20presence%20enforcement%20when%20%60require_success%3A%20false%60%20at%20the%20individual%20bundle%20level%20%28i.e.%2C%20%60strict%3A%20true%60%20only%20prevents%20schema%20errors%2C%20not%20missing%20artifacts%29%2C%20these%20entries%20are%20fine%20as-is%20%E2%80%94%20but%20confirming%20that%20before%20the%20next%20deploy%20dispatch%20would%20be%20worthwhile.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22fix%2F673-drop-playwright-bundle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F673-drop-playwright-bundle%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fpages-bundle-manifest.json%0ALine%3A%2029-45%0A%0AComment%3A%0A**%60strict%3A%20true%60%20%2B%20%60require_success%3A%20false%60%20interaction%20unverified%20for%20multi-language%20coverage%20bundles**%0A%0AThe%20PR%20description%20correctly%20identifies%20that%20%60strict%3A%20true%60%20makes%20a%20missing%20artifact%20fatal%20regardless%20of%20a%20bundle's%20own%20%60require_success%60%20flag%20%28citing%20%60workflow_artifacts.sh%60%20lines%20425-433%29.%20The%20three%20multi-language%20coverage%20bundles%20%28%60coverage-python%60%2C%20%60coverage-ruby%60%2C%20%60coverage-swift%60%29%20all%20carry%20%60require_success%3A%20false%60%20%E2%80%94%20if%20those%20artifacts%20aren't%20uploaded%20on%20every%20green%20main%20run%2C%20they%20could%20trigger%20the%20same%20fatal-missing-artifact%20path%20under%20%60strict%3A%20true%60%20that%20this%20PR%20is%20fixing%20for%20%60playwright%60.%20The%20PR%20description%20also%20mentions%20only%20%22five%20bundles%20whose%20artifacts%20do%20exist%22%20but%20six%20now%20remain%20in%20the%20file%2C%20which%20is%20a%20small%20mismatch%20worth%20double-checking.%20If%20the%20bundler%20only%20skips%20presence%20enforcement%20when%20%60require_success%3A%20false%60%20at%20the%20individual%20bundle%20level%20%28i.e.%2C%20%60strict%3A%20true%60%20only%20prevents%20schema%20errors%2C%20not%20missing%20artifacts%29%2C%20these%20entries%20are%20fine%20as-is%20%E2%80%94%20but%20confirming%20that%20before%20the%20next%20deploy%20dispatch%20would%20be%20worthwhile.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fturbo-themes&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(ci): drop unresolvable playwright bu..."](https://github.com/lgtm-hq/turbo-themes/commit/6f2d23cc5c5f06c8fc85706e55aa2c9eeff96be8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45589799)</sub>

<!-- /greptile_comment -->