### PR TITLE
test(e2e): block remote webfonts in visual specs on linux

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -374,7 +374,7 @@ export async function serveThemeCssWithoutExternalImports(page: Page): Promise<v
  */
 export async function blockRemoteFonts(page: Page): Promise<void> {
   if (process.platform !== 'linux') return;
-  await page.route(/https:\/\/fonts\.(googleapis|gstatic)\.com\/.*/, (route) => route.abort());
+  await page.route(/https:\/\/fonts\.(googleapis|gstatic)\.com/, (route) => route.abort());
 }
 
 /**

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -359,6 +359,25 @@ export async function serveThemeCssWithoutExternalImports(page: Page): Promise<v
 }
 
 /**
+ * Blocks remote webfont requests so visual captures always render with the
+ * fallback font stack.
+ *
+ * Linux CI baselines are captured with Google Fonts unreachable
+ * (harden-runner egress policy), but enforcement can degrade and let the
+ * webfont load, flipping dense-text screenshots between two renderings
+ * (#706). Aborting the font-host requests up front pins Linux rendering to
+ * the fallback stack. macOS baselines are captured locally where the
+ * webfont loads, so the block is scoped to Linux to keep each platform
+ * consistent with its own baselines.
+ *
+ * @param page - The Playwright page object
+ */
+export async function blockRemoteFonts(page: Page): Promise<void> {
+  if (process.platform !== 'linux') return;
+  await page.route(/https:\/\/fonts\.(googleapis|gstatic)\.com\/.*/, (route) => route.abort());
+}
+
+/**
  * Waits for document fonts to finish loading before visual captures.
  *
  * Font-metric differences between the fallback and the webfont cause

--- a/e2e/playground-visual.spec.ts
+++ b/e2e/playground-visual.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { blockRemoteFonts } from './helpers';
 
 /**
  * Visual regression tests for example pages.
@@ -19,6 +20,11 @@ import { expect, test } from '@playwright/test';
 
 // Skip on non-chromium browsers - visual tests run only on Chromium for consistent baselines
 test.skip(({ browserName }) => browserName !== 'chromium', 'Visual tests run only on Chromium');
+
+// Pin text rendering to the fallback font stack (#706).
+test.beforeEach(async ({ page }) => {
+  await blockRemoteFonts(page);
+});
 
 // Representative theme samples (light and dark variants)
 const themes = ['catppuccin-mocha', 'catppuccin-latte', 'dracula', 'github-dark', 'github-light'];

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForFontsReady, waitForThemeApplied } from './helpers';
+import { blockRemoteFonts, waitForFontsReady, waitForThemeApplied } from './helpers';
 
 /**
  * Visual regression tests for main site pages.
@@ -22,6 +22,8 @@ test.skip(({ browserName }) => browserName !== 'chromium', 'Visual tests run onl
 // motion so the page renders deterministically for baselines.
 test.beforeEach(async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
+  // Pin text rendering to the fallback font stack (#706).
+  await blockRemoteFonts(page);
 });
 
 // Themes to test (representative light/dark samples)


### PR DESCRIPTION
## Summary

Pins Linux e2e visual rendering to the fallback font stack by route-aborting `fonts.googleapis.com`/`fonts.gstatic.com` in the two screenshot specs (`visual-regression`, `playground-visual`).

Linux CI baselines are fallback-font renders (harden-runner's egress allowlist excludes the font hosts), but when enforcement degrades the webfont leaks through and dense-text shots fail with byte-identical, deterministic diffs — three consecutive occurrences on PR #704's e2e run today. The block is scoped to Linux because macOS baselines are captured locally where the webfont loads; each platform stays consistent with its own committed baselines.

Verified: full `visual-regression` + `playground-visual` suites pass on macOS (34/34, block is a no-op there).

Closes #706

## Test plan
- [x] macOS visual suites green locally
- [ ] Linux e2e green in CI (this PR)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `blockRemoteFonts` helper to `e2e/helpers.ts` and wires it into `beforeEach` in both visual spec files to deterministically abort Google Fonts requests on Linux CI, where the egress allowlist excluded those hosts and intermittent enforcement failures caused screenshot flakes.

- **`e2e/helpers.ts`**: New `blockRemoteFonts(page)` export — no-ops on non-Linux platforms; on Linux calls `page.route()` with a regex targeting `fonts.googleapis.com` and `fonts.gstatic.com` to immediately abort those requests.
- **`e2e/visual-regression.spec.ts`**: `blockRemoteFonts` added to the existing `beforeEach` alongside `emulateMedia`, and imported from helpers.
- **`e2e/playground-visual.spec.ts`**: A new file-level `beforeEach` added (and the helper imported) to register the font block before each test navigates.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to test infrastructure, has no effect on macOS, and correctly registers the font-abort route before any navigation occurs in both spec files.

The blockRemoteFonts helper is a clean, well-documented addition that targets exactly the flake source described in the PR. The Linux guard is a reliable Node.js primitive, page.route() is registered in beforeEach before any page.goto() in all test paths, and each test's fresh page fixture means route cleanup is handled automatically. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| e2e/helpers.ts | Adds `blockRemoteFonts` — a Linux-only `page.route()` abort for Google Fonts hosts; well-documented, correctly scoped, and cleanly exported. |
| e2e/visual-regression.spec.ts | Imports and calls `blockRemoteFonts` in the existing `beforeEach`; route is registered before any navigation in all test describe blocks, including the nested `Demo Page` `beforeEach`. |
| e2e/playground-visual.spec.ts | Adds a file-level `beforeEach` calling `blockRemoteFonts` before each test navigates; covers both `Example Visual Regression` and `Theme Selector Component` describe blocks. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PW as Playwright Test Runner
    participant BEF as beforeEach hook
    participant HLP as blockRemoteFonts (helpers.ts)
    participant PAGE as Playwright Page
    participant GF as fonts.googleapis.com / fonts.gstatic.com
    participant TEST as Test Body

    PW->>BEF: run beforeEach
    BEF->>HLP: blockRemoteFonts(page)
    HLP->>HLP: "process.platform === 'linux'?"
    alt Linux CI
        HLP->>PAGE: "page.route(/fonts.(googleapis|gstatic).com/, abort)"
        PAGE-->>HLP: route handler registered
    else macOS / other
        HLP-->>BEF: return (no-op)
    end
    BEF-->>PW: beforeEach complete
    PW->>TEST: run test body
    TEST->>PAGE: page.goto(url)
    PAGE->>GF: font request (CSS / WOFF2)
    alt Linux (route active)
        PAGE-->>GF: aborted
        PAGE-->>TEST: fallback fonts rendered
    else macOS
        GF-->>PAGE: webfont loaded
        PAGE-->>TEST: webfont rendered
    end
    TEST->>PAGE: toHaveScreenshot(...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PW as Playwright Test Runner
    participant BEF as beforeEach hook
    participant HLP as blockRemoteFonts (helpers.ts)
    participant PAGE as Playwright Page
    participant GF as fonts.googleapis.com / fonts.gstatic.com
    participant TEST as Test Body

    PW->>BEF: run beforeEach
    BEF->>HLP: blockRemoteFonts(page)
    HLP->>HLP: "process.platform === 'linux'?"
    alt Linux CI
        HLP->>PAGE: "page.route(/fonts.(googleapis|gstatic).com/, abort)"
        PAGE-->>HLP: route handler registered
    else macOS / other
        HLP-->>BEF: return (no-op)
    end
    BEF-->>PW: beforeEach complete
    PW->>TEST: run test body
    TEST->>PAGE: page.goto(url)
    PAGE->>GF: font request (CSS / WOFF2)
    alt Linux (route active)
        PAGE-->>GF: aborted
        PAGE-->>TEST: fallback fonts rendered
    else macOS
        GF-->>PAGE: webfont loaded
        PAGE-->>TEST: webfont rendered
    end
    TEST->>PAGE: toHaveScreenshot(...)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): simplify font-host route patt..."](https://github.com/lgtm-hq/turbo-themes/commit/ed5a14d5c5b53082db61c03b7afede5d488e5f32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45737626)</sub>

<!-- /greptile_comment -->