### PR TITLE
ci: grant sbom job the permissions its reusable workflow requests

### DIFF
--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -106,3 +106,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      # Static validation requires granting everything ANY callee job requests,
+      # even jobs skipped in release-assets mode (scan/attest); missing these
+      # startup-failed every tag run since v0.25.0 (#720).
+      security-events: write
+      attestations: write


### PR DESCRIPTION
## Summary

Fixes #720. The run-page banner (thanks for the screenshots) pins the startup failure to static validation of the `sbom` reusable call at line 91: `Error calling workflow 'lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@…'`.

Root cause: the callee's report-mode `sbom` job requests `security-events: write` and `attestations: write`; GitHub statically requires the caller job to grant every permission any callee job requests — even jobs that are `if`-skipped in `release-assets` mode. The working caller `security-sbom.yml` grants all four; `release-publish-pr.yml` granted only `contents`/`id-token`, so every tag run since v0.25.0 startup-failed and GitHub releases are stuck at v0.24.5.

## After merge
- `workflow_dispatch` this workflow with `tag: v0.38.0` to validate the fix and create the v0.38.0 GitHub release + signed SBOMs.
- Optionally backfill v0.25.0–v0.37.0 releases by dispatching per tag.

## Test plan
- [x] lintro/actionlint clean
- [ ] Post-merge dispatch with `tag: v0.38.0` succeeds

Closes #720

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes static validation of the release SBOM workflow call. The main changes are:

- Grants `security-events: write` to the SBOM job.
- Grants `attestations: write` to the SBOM job.
- Documents why skipped jobs in the reusable workflow still require these permissions.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The permission set matches the existing caller of the same pinned reusable workflow.
- The grants are scoped to the SBOM job.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-pr.yml | Adds the missing permissions required to validate the pinned reusable SBOM workflow call. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: grant sbom job the permissions its r..."](https://github.com/lgtm-hq/turbo-themes/commit/3ad653f9b0cb98437fa9dd71bec78c51ac366608) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45892396)</sub>

<!-- /greptile_comment -->