### PR TITLE
docs(site): scope remaining npm package refs to @lgtm-hq/turbo-themes

### DIFF
--- a/apps/site/src/content/docs/api-reference/index.md
+++ b/apps/site/src/content/docs/api-reference/index.md
@@ -96,7 +96,7 @@ turbo-themes/
 ### JavaScript/TypeScript
 
 ```typescript
-import { themeIds, type ThemeId } from 'turbo-themes';
+import { themeIds, type ThemeId } from '@lgtm-hq/turbo-themes';
 
 // Array of all theme IDs
 themeIds: string[]

--- a/apps/site/src/content/docs/api-reference/tokens.md
+++ b/apps/site/src/content/docs/api-reference/tokens.md
@@ -172,7 +172,7 @@ Each theme includes metadata:
 ### JavaScript/TypeScript
 
 ```typescript
-import tokens from 'turbo-themes/tokens.json';
+import tokens from '@lgtm-hq/turbo-themes/tokens.json';
 
 // Access theme data
 const mocha = tokens.themes['catppuccin-mocha'];

--- a/apps/site/src/content/docs/contributing/release-process.md
+++ b/apps/site/src/content/docs/contributing/release-process.md
@@ -115,7 +115,7 @@ For critical bug fixes:
 npm publish
 ```
 
-Published to: https://www.npmjs.com/package/turbo-themes
+Published to: https://www.npmjs.com/package/@lgtm-hq/turbo-themes
 
 ### RubyGems (Jekyll)
 
@@ -212,7 +212,7 @@ If a release has critical issues:
 1. **Unpublish** (within 72 hours on npm):
 
    ```bash
-   npm unpublish turbo-themes@1.2.3
+   npm unpublish @lgtm-hq/turbo-themes@1.2.3
    ```
 
 2. **Or publish a fixed patch**:
@@ -225,7 +225,7 @@ If a release has critical issues:
 3. **Deprecate** (if can't unpublish):
 
    ```bash
-   npm deprecate turbo-themes@1.2.3 "Critical bug, please upgrade to 1.2.4"
+   npm deprecate @lgtm-hq/turbo-themes@1.2.3 "Critical bug, please upgrade to 1.2.4"
    ```
 
 ## Release Checklist

--- a/apps/site/src/content/docs/getting-started/index.md
+++ b/apps/site/src/content/docs/getting-started/index.md
@@ -58,11 +58,11 @@ Here's how simple it is to use Turbo Themes:
 
 ```html
 <!-- Include the core CSS and a theme -->
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-base.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
 <link
   rel="stylesheet"
-  href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 ```
 

--- a/apps/site/src/content/docs/getting-started/index.md
+++ b/apps/site/src/content/docs/getting-started/index.md
@@ -58,8 +58,14 @@ Here's how simple it is to use Turbo Themes:
 
 ```html
 <!-- Include the core CSS and a theme -->
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
+/>
 <link
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"

--- a/apps/site/src/content/docs/getting-started/quick-start.md
+++ b/apps/site/src/content/docs/getting-started/quick-start.md
@@ -39,11 +39,11 @@ bun add @lgtm-hq/turbo-themes
 No installation needed - just add the links to your HTML:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-base.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
 <link
   rel="stylesheet"
-  href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 ```
 
@@ -53,17 +53,17 @@ If you installed via npm, import the CSS files in your project:
 
 ```html
 <!-- Core tokens and base styles -->
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-core.css" />
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-base.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
 
 <!-- Choose a theme -->
 <link
   rel="stylesheet"
-  href="node_modules/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 
 <!-- Optional: Syntax highlighting for code blocks -->
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-syntax.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css" />
 ```
 
 ## Step 3: Use the Tokens
@@ -101,7 +101,7 @@ To enable theme switching, swap the theme CSS file dynamically:
 ```javascript
 function setTheme(themeName) {
   const themeLink = document.getElementById('theme-css');
-  themeLink.href = `/css/themes/turbo/${themeName}.css`;
+  themeLink.href = `/packages/css/dist/themes/${themeName}.css`;
 
   // Persist the choice
   localStorage.setItem('turbo-theme', themeName);

--- a/apps/site/src/content/docs/getting-started/quick-start.md
+++ b/apps/site/src/content/docs/getting-started/quick-start.md
@@ -39,8 +39,14 @@ bun add @lgtm-hq/turbo-themes
 No installation needed - just add the links to your HTML:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
+/>
 <link
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
@@ -53,8 +59,14 @@ If you installed via npm, import the CSS files in your project:
 
 ```html
 <!-- Core tokens and base styles -->
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
+/>
 
 <!-- Choose a theme -->
 <link
@@ -63,7 +75,10 @@ If you installed via npm, import the CSS files in your project:
 />
 
 <!-- Optional: Syntax highlighting for code blocks -->
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css"
+/>
 ```
 
 ## Step 3: Use the Tokens

--- a/apps/site/src/content/docs/guides/advanced-theming.md
+++ b/apps/site/src/content/docs/guides/advanced-theming.md
@@ -105,7 +105,7 @@ Create theme variants that inherit from a base:
 
 ```javascript
 // themes/custom-theme.js
-import { createTheme } from 'turbo-themes';
+import { createTheme } from '@lgtm-hq/turbo-themes';
 
 const baseTheme = {
   colors: {

--- a/apps/site/src/content/docs/guides/performance.md
+++ b/apps/site/src/content/docs/guides/performance.md
@@ -90,11 +90,11 @@ Import only what you need:
 
 ```javascript
 // Instead of importing everything
-// import { themes, tokens, utils } from 'turbo-themes';
+// import { themes, tokens, utils } from '@lgtm-hq/turbo-themes';
 
 // Import specific modules
-import { getTheme } from 'turbo-themes/themes';
-import { applyTheme } from 'turbo-themes/utils';
+import { getTheme } from '@lgtm-hq/turbo-themes';
+import { applyTheme } from '@lgtm-hq/turbo-themes';
 ```
 
 ### CSS Purging

--- a/apps/site/src/content/docs/installation/cdn.md
+++ b/apps/site/src/content/docs/installation/cdn.md
@@ -17,8 +17,14 @@ Add these links to your HTML `<head>`:
 
 ```html
 <!-- Core tokens and base styles -->
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
+/>
 
 <!-- Choose a theme -->
 <link
@@ -27,7 +33,10 @@ Add these links to your HTML `<head>`:
 />
 
 <!-- Optional: Syntax highlighting -->
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css"
+/>
 ```
 
 ## CDN Providers
@@ -56,7 +65,10 @@ For production, pin to a specific version to avoid unexpected changes:
 
 ```html
 <!-- Pin to specific version -->
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes@1.0.0/packages/css/dist/turbo-core.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes@1.0.0/packages/css/dist/turbo-core.css"
+/>
 ```
 
 ## Available Files
@@ -100,8 +112,14 @@ For production, pin to a specific version to avoid unexpected changes:
     <title>My Turbo Themed Site</title>
 
     <!-- Turbo Themes -->
-    <link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
-    <link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
+    />
     <link
       id="theme-css"
       rel="stylesheet"

--- a/apps/site/src/content/docs/installation/cdn.md
+++ b/apps/site/src/content/docs/installation/cdn.md
@@ -17,17 +17,17 @@ Add these links to your HTML `<head>`:
 
 ```html
 <!-- Core tokens and base styles -->
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-base.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
 
 <!-- Choose a theme -->
 <link
   rel="stylesheet"
-  href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 
 <!-- Optional: Syntax highlighting -->
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-syntax.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css" />
 ```
 
 ## CDN Providers
@@ -37,7 +37,7 @@ Add these links to your HTML `<head>`:
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/turbo-themes@latest/css/turbo-core.css"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes@latest/packages/css/dist/turbo-core.css"
 />
 ```
 
@@ -46,7 +46,7 @@ Add these links to your HTML `<head>`:
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/turbo-themes@latest/css/turbo-core.css"
+  href="https://cdn.jsdelivr.net/npm/@lgtm-hq/turbo-themes@latest/packages/css/dist/turbo-core.css"
 />
 ```
 
@@ -56,38 +56,38 @@ For production, pin to a specific version to avoid unexpected changes:
 
 ```html
 <!-- Pin to specific version -->
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes@1.0.0/css/turbo-core.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes@1.0.0/packages/css/dist/turbo-core.css" />
 ```
 
 ## Available Files
 
 ### Core Files
 
-| File                | URL                     | Size |
-| ------------------- | ----------------------- | ---- |
-| Core tokens         | `/css/turbo-core.css`   | ~2KB |
-| Base styles         | `/css/turbo-base.css`   | ~1KB |
-| Syntax highlighting | `/css/turbo-syntax.css` | ~1KB |
+| File                | URL                                   | Size |
+| ------------------- | ------------------------------------- | ---- |
+| Core tokens         | `/packages/css/dist/turbo-core.css`   | ~2KB |
+| Base styles         | `/packages/css/dist/turbo-base.css`   | ~1KB |
+| Syntax highlighting | `/packages/css/dist/turbo-syntax.css` | ~1KB |
 
 ### Theme Files
 
-| Theme                | URL                                          |
-| -------------------- | -------------------------------------------- |
-| Catppuccin Mocha     | `/css/themes/turbo/catppuccin-mocha.css`     |
-| Catppuccin Macchiato | `/css/themes/turbo/catppuccin-macchiato.css` |
-| Catppuccin Frappé    | `/css/themes/turbo/catppuccin-frappe.css`    |
-| Catppuccin Latte     | `/css/themes/turbo/catppuccin-latte.css`     |
-| Dracula              | `/css/themes/turbo/dracula.css`              |
-| GitHub Dark          | `/css/themes/turbo/github-dark.css`          |
-| GitHub Light         | `/css/themes/turbo/github-light.css`         |
-| Bulma Dark           | `/css/themes/turbo/bulma-dark.css`           |
-| Bulma Light          | `/css/themes/turbo/bulma-light.css`          |
+| Theme                | URL                                                  |
+| -------------------- | ---------------------------------------------------- |
+| Catppuccin Mocha     | `/packages/css/dist/themes/catppuccin-mocha.css`     |
+| Catppuccin Macchiato | `/packages/css/dist/themes/catppuccin-macchiato.css` |
+| Catppuccin Frappé    | `/packages/css/dist/themes/catppuccin-frappe.css`    |
+| Catppuccin Latte     | `/packages/css/dist/themes/catppuccin-latte.css`     |
+| Dracula              | `/packages/css/dist/themes/dracula.css`              |
+| GitHub Dark          | `/packages/css/dist/themes/github-dark.css`          |
+| GitHub Light         | `/packages/css/dist/themes/github-light.css`         |
+| Bulma Dark           | `/packages/css/dist/themes/bulma-dark.css`           |
+| Bulma Light          | `/packages/css/dist/themes/bulma-light.css`          |
 
 ### Adapters
 
-| Adapter | URL                       |
-| ------- | ------------------------- |
-| Bulma   | `/css/adapters/bulma.css` |
+| Adapter | URL                                               |
+| ------- | ------------------------------------------------- |
+| Bulma   | `/packages/adapters/bulma/dist/bulma-adapter.css` |
 
 ## Complete Example
 
@@ -100,12 +100,12 @@ For production, pin to a specific version to avoid unexpected changes:
     <title>My Turbo Themed Site</title>
 
     <!-- Turbo Themes -->
-    <link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
-    <link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-base.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
     <link
       id="theme-css"
       rel="stylesheet"
-      href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+      href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
     />
 
     <style>
@@ -149,7 +149,7 @@ For production, pin to a specific version to avoid unexpected changes:
         currentIndex = (currentIndex + 1) % themes.length;
         const theme = themes[currentIndex];
         document.getElementById('theme-css').href =
-          `https://unpkg.com/turbo-themes/css/themes/turbo/${theme}.css`;
+          `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${theme}.css`;
       }
     </script>
   </body>
@@ -170,7 +170,7 @@ For production, pin to a specific version to avoid unexpected changes:
    <link
      rel="preload"
      as="style"
-     href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+     href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
    />
    ```
 

--- a/apps/site/src/content/docs/installation/npm.md
+++ b/apps/site/src/content/docs/installation/npm.md
@@ -35,8 +35,14 @@ Add the CSS files to your HTML or import them in your bundler:
 
 ```html
 <!-- In your HTML -->
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
+/>
 <link
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
@@ -69,7 +75,10 @@ Now use the CSS custom properties in your styles:
 For code blocks with theme-aware syntax highlighting:
 
 ```html
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css"
+/>
 ```
 
 ## Theme Switching

--- a/apps/site/src/content/docs/installation/npm.md
+++ b/apps/site/src/content/docs/installation/npm.md
@@ -35,11 +35,11 @@ Add the CSS files to your HTML or import them in your bundler:
 
 ```html
 <!-- In your HTML -->
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-core.css" />
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-base.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css" />
 <link
   rel="stylesheet"
-  href="node_modules/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 ```
 
@@ -47,9 +47,9 @@ Or with a bundler like Vite or webpack:
 
 ```javascript
 // In your JavaScript entry point
-import 'turbo-themes/css/turbo-core.css';
-import 'turbo-themes/css/turbo-base.css';
-import 'turbo-themes/css/themes/turbo/catppuccin-mocha.css';
+import '@lgtm-hq/turbo-themes/css/core';
+import '@lgtm-hq/turbo-themes/css/base';
+import '@lgtm-hq/turbo-themes/css/themes/catppuccin-mocha.css';
 ```
 
 ### 2. Use the Tokens
@@ -69,7 +69,7 @@ Now use the CSS custom properties in your styles:
 For code blocks with theme-aware syntax highlighting:
 
 ```html
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-syntax.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css" />
 ```
 
 ## Theme Switching
@@ -80,7 +80,7 @@ To enable runtime theme switching:
 function setTheme(themeName) {
   // Update the theme CSS
   const themeLink = document.getElementById('theme-css');
-  themeLink.href = `node_modules/turbo-themes/css/themes/turbo/${themeName}.css`;
+  themeLink.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
 
   // Persist the choice
   localStorage.setItem('turbo-theme', themeName);
@@ -99,7 +99,7 @@ Make sure your theme link has an ID:
 <link
   id="theme-css"
   rel="stylesheet"
-  href="node_modules/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 ```
 
@@ -108,7 +108,7 @@ Make sure your theme link has an ID:
 Turbo Themes includes TypeScript definitions for the theme registry:
 
 ```typescript
-import { themeIds, type ThemeId } from 'turbo-themes';
+import { themeIds, type ThemeId } from '@lgtm-hq/turbo-themes';
 
 // All available theme IDs
 console.log(themeIds);

--- a/apps/site/src/content/docs/integrations/bootstrap.md
+++ b/apps/site/src/content/docs/integrations/bootstrap.md
@@ -17,10 +17,10 @@ Use Turbo Themes with Bootstrap by mapping tokens to Bootstrap's CSS variables.
 
 ```html
 <!-- Turbo Themes -->
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
 <link
   rel="stylesheet"
-  href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 
 <!-- Bootstrap -->
@@ -197,7 +197,7 @@ Use standard Bootstrap classes:
 ```javascript
 function setTheme(themeName) {
   const link = document.getElementById('theme-css');
-  link.href = `/css/themes/turbo/${themeName}.css`;
+  link.href = `/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }
 ```

--- a/apps/site/src/content/docs/integrations/bootstrap.md
+++ b/apps/site/src/content/docs/integrations/bootstrap.md
@@ -17,7 +17,10 @@ Use Turbo Themes with Bootstrap by mapping tokens to Bootstrap's CSS variables.
 
 ```html
 <!-- Turbo Themes -->
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
 <link
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"

--- a/apps/site/src/content/docs/integrations/bulma.md
+++ b/apps/site/src/content/docs/integrations/bulma.md
@@ -27,14 +27,14 @@ Add the CSS files in this order:
 
 ```html
 <!-- 1. Turbo Themes core and your chosen theme -->
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-core.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
 <link
   rel="stylesheet"
-  href="node_modules/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 
 <!-- 2. Bulma adapter (maps Turbo tokens to Bulma variables) -->
-<link rel="stylesheet" href="node_modules/turbo-themes/css/adapters/bulma.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/adapters/bulma/dist/bulma-adapter.css" />
 
 <!-- 3. Bulma CSS -->
 <link rel="stylesheet" href="node_modules/bulma/css/bulma.min.css" />
@@ -46,12 +46,12 @@ Add the CSS files in this order:
 
 ```html
 <!-- Turbo Themes -->
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/turbo-core.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
 <link
   rel="stylesheet"
-  href="https://unpkg.com/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
-<link rel="stylesheet" href="https://unpkg.com/turbo-themes/css/adapters/bulma.css" />
+<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/adapters/bulma/dist/bulma-adapter.css" />
 
 <!-- Bulma -->
 <link
@@ -180,7 +180,7 @@ Switching themes updates all Bulma components automatically:
 ```javascript
 function setTheme(themeName) {
   const link = document.getElementById('theme-css');
-  link.href = `/css/themes/turbo/${themeName}.css`;
+  link.href = `/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }
 

--- a/apps/site/src/content/docs/integrations/bulma.md
+++ b/apps/site/src/content/docs/integrations/bulma.md
@@ -27,14 +27,20 @@ Add the CSS files in this order:
 
 ```html
 <!-- 1. Turbo Themes core and your chosen theme -->
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
 <link
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 
 <!-- 2. Bulma adapter (maps Turbo tokens to Bulma variables) -->
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/adapters/bulma/dist/bulma-adapter.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/adapters/bulma/dist/bulma-adapter.css"
+/>
 
 <!-- 3. Bulma CSS -->
 <link rel="stylesheet" href="node_modules/bulma/css/bulma.min.css" />
@@ -46,12 +52,18 @@ Add the CSS files in this order:
 
 ```html
 <!-- Turbo Themes -->
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
 <link
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
-<link rel="stylesheet" href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/adapters/bulma/dist/bulma-adapter.css" />
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/adapters/bulma/dist/bulma-adapter.css"
+/>
 
 <!-- Bulma -->
 <link

--- a/apps/site/src/content/docs/integrations/index.md
+++ b/apps/site/src/content/docs/integrations/index.md
@@ -71,7 +71,7 @@ The Tailwind preset extends your color palette:
 ```javascript
 // tailwind.config.js
 module.exports = {
-  presets: [require('turbo-themes/adapters/tailwind/preset')],
+  presets: [require('@lgtm-hq/turbo-themes/adapters/tailwind/preset')],
 };
 ```
 

--- a/apps/site/src/content/docs/integrations/tailwind.md
+++ b/apps/site/src/content/docs/integrations/tailwind.md
@@ -29,7 +29,7 @@ Use the Turbo Themes preset in your `tailwind.config.js`:
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
-  presets: [require('turbo-themes/adapters/tailwind/preset')],
+  presets: [require('@lgtm-hq/turbo-themes/adapters/tailwind/preset')],
 };
 ```
 
@@ -38,10 +38,10 @@ module.exports = {
 Add the theme CSS to your HTML:
 
 ```html
-<link rel="stylesheet" href="node_modules/turbo-themes/css/turbo-core.css" />
+<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
 <link
   rel="stylesheet"
-  href="node_modules/turbo-themes/css/themes/turbo/catppuccin-mocha.css"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
 ```
 
@@ -116,7 +116,7 @@ utilities update because they reference CSS variables:
 ```javascript
 function setTheme(themeName) {
   const link = document.getElementById('theme-css');
-  link.href = `/css/themes/turbo/${themeName}.css`;
+  link.href = `/packages/css/dist/themes/${themeName}.css`;
 }
 ```
 
@@ -130,7 +130,7 @@ No rebuild required - changes are instant.
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
-  presets: [require('turbo-themes/adapters/tailwind/preset')],
+  presets: [require('@lgtm-hq/turbo-themes/adapters/tailwind/preset')],
   theme: {
     extend: {
       // Add your own extensions

--- a/apps/site/src/content/docs/integrations/tailwind.md
+++ b/apps/site/src/content/docs/integrations/tailwind.md
@@ -38,7 +38,10 @@ module.exports = {
 Add the theme CSS to your HTML:
 
 ```html
-<link rel="stylesheet" href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
+/>
 <link
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Words-only docs sweep so npm package references use `@lgtm-hq/turbo-themes` (the published scoped name). Follow-up from PR #704, which already fixed install commands.

## Changes

- Update ES imports, `require()`, `node_modules/` paths, and unpkg/jsDelivr URLs under `apps/site/src/content/docs/`
- Point CSS file examples at `packages/css/dist/...` (and the Bulma adapter dist path)
- Prefer package export paths for bundler CSS imports (`css/core`, `css/base`, `css/themes/...`)
- Fix npm publish/unpublish/deprecate examples in the release-process docs
- Leave Ruby gem / PyPI / repo-local names unscoped

## Test plan

- [x] `uv run lintro chk` (0 issues)
- [x] `bun run test`
- [ ] Confirm gem/pip docs still use unscoped names

Closes #715
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the documentation to use the published scoped npm package. The main changes are:

- Scope JavaScript imports and package references to `@lgtm-hq/turbo-themes`.
- Update CDN, `node_modules`, CSS, theme, and adapter paths.
- Correct npm publish, unpublish, and deprecate examples.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No new blocking issues found in the updated documentation paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/content/docs/installation/npm.md | Updates npm, direct asset, bundler CSS, and TypeScript examples to use the scoped package. |
| apps/site/src/content/docs/installation/cdn.md | Updates unpkg and jsDelivr examples to use the scoped package and published asset layout. |
| apps/site/src/content/docs/contributing/release-process.md | Scopes npm package links and package-management commands while leaving other distribution names unchanged. |
| apps/site/src/content/docs/integrations/bulma.md | Updates the documented CSS, theme, and Bulma adapter paths. |
| apps/site/src/content/docs/integrations/tailwind.md | Updates the Tailwind preset and CSS examples to use scoped package paths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style(docs): wrap long link tags after p..."](https://github.com/lgtm-hq/turbo-themes/commit/452c8de6cc011a46ea1b713d9b3f2675ecfe2c9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45895623)</sub>

<!-- /greptile_comment -->