### PR TITLE
fix(ci): route docs commits to the Internal changelog section

### DIFF
--- a/scripts/ci/version-bump.mjs
+++ b/scripts/ci/version-bump.mjs
@@ -25,13 +25,17 @@ const CONFIG = {
   minorTypes: ['feat', 'feature'],
   patchTypes: ['fix', 'bugfix', 'patch', 'docs', 'style', 'refactor', 'perf', 'test', 'chore'],
   // Subset of patchTypes that represent true defect fixes (→ "🐛 Fixed" changelog bucket).
-  // All other patchTypes (docs, style, refactor, perf, test, chore) go to "🔧 Changed".
+  // style/refactor/perf/test/chore (without an internal scope) go to "🔧 Changed".
+  // docs type commits are routed to Internal (see changelogInternalTypes).
   fixTypes: ['fix', 'bugfix', 'patch'],
   ignoreTypes: ['ci', 'build', 'release'],
   // Scopes routed to the non-consumer "Internal" changelog section (not Fixed/Added/Changed).
   // These commits still participate in version bump decisions via their type.
   // Breaking changes always stay in BREAKING CHANGES regardless of scope.
-  changelogInternalScopes: ['ci', 'build', 'test'],
+  changelogInternalScopes: ['ci', 'build', 'test', 'docs'],
+  // Commit types always routed to Internal (Keep a Changelog "Changed" is for
+  // consumer-facing functional changes; docs updates are not).
+  changelogInternalTypes: ['docs'],
   ignorePatterns: ['chore(release):'], // Full prefix patterns to skip entirely
   changelogFile: join(projectRoot, 'CHANGELOG.md'),
   packageFile: join(projectRoot, 'package.json'),
@@ -75,6 +79,15 @@ function parseCommit(commit) {
 function isChangelogInternalScope(scope) {
   if (!scope) return false;
   return CONFIG.changelogInternalScopes.includes(scope.toLowerCase());
+}
+
+/**
+ * Whether a commit's type belongs in the non-consumer Internal changelog section.
+ * Version bump logic is unaffected — only changelog rendering consults this.
+ */
+function isChangelogInternalType(type) {
+  if (!type) return false;
+  return CONFIG.changelogInternalTypes.includes(type.toLowerCase());
 }
 
 /**
@@ -241,9 +254,9 @@ function generateChangelogEntry(commits, version, bumpType) {
       continue;
     }
 
-    // Route non-consumer scopes (e.g. fix(ci): …) to Internal — not Fixed/Added/Changed.
-    // Bump decisions still use these commits via determineBumpType().
-    if (isChangelogInternalScope(parsed.scope)) {
+    // Route non-consumer scopes/types (e.g. fix(ci): …, docs(site): …) to Internal —
+    // not Fixed/Added/Changed. Bump decisions still use these via determineBumpType().
+    if (isChangelogInternalScope(parsed.scope) || isChangelogInternalType(parsed.type)) {
       internal.push(entry);
       continue;
     }
@@ -253,7 +266,7 @@ function generateChangelogEntry(commits, version, bumpType) {
     } else if (CONFIG.fixTypes.includes(parsed.type)) {
       fixes.push(entry);
     } else {
-      // docs, style, refactor, perf, test, chore → "### 🔧 Changed"
+      // style, refactor, perf, test, chore → "### 🔧 Changed"
       others.push(entry);
     }
   }
@@ -391,6 +404,7 @@ export {
   generateChangelogEntry,
   formatChangelogDescription,
   isChangelogInternalScope,
+  isChangelogInternalType,
   isBreakingCommit,
   parseCommit,
 };

--- a/test/version-bump.test.ts
+++ b/test/version-bump.test.ts
@@ -2,9 +2,10 @@
  * Tests for generateChangelogEntry() bucketing logic in scripts/ci/version-bump.mjs.
  *
  * Regression coverage for:
- * - GitHub issue #546: docs/style/refactor/perf/test/chore under Changed (not Fixed)
+ * - GitHub issue #546: style/refactor/perf/test/chore under Changed (not Fixed)
  * - GitHub issue #581: scope-aware Internal section (ci/build) + human-readable descriptions
  * - Greptile P1 on #602: breaking changes with ci/build scopes must not be dropped
+ * - GitHub issue #718: docs type/scope → Internal (not Changed)
  */
 import { describe, expect, it } from 'vitest';
 
@@ -16,6 +17,7 @@ const {
   determineBumpType,
   formatChangelogDescription,
   isChangelogInternalScope,
+  isChangelogInternalType,
   parseCommit,
 } = await import('../scripts/ci/version-bump.mjs');
 
@@ -49,7 +51,7 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
   });
 
   describe('non-fix patch types → ### 🔧 Changed (not ### 🐛 Fixed)', () => {
-    it.each(['docs', 'style', 'refactor', 'perf', 'test', 'chore'] as const)(
+    it.each(['style', 'refactor', 'perf', 'test', 'chore'] as const)(
       '"%s" commit appears under Changed, not Fixed',
       (type) => {
         const commits = [fakeCommit(type, `update ${type} thing`)];
@@ -61,15 +63,16 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
     );
   });
 
-  describe('issue #546 regression: docs-only release', () => {
-    it('docs commit is NOT listed under Fixed (reproduces 0.22.1 misclassification)', () => {
+  describe('issue #718: docs type → ### 🤖 Internal (not Changed/Fixed)', () => {
+    it('docs commit appears under Internal, not Fixed or Changed', () => {
       const commits = [
         fakeCommit('docs', 'add AGENTS.md with Cursor Cloud dev environment instructions (#542)'),
       ];
       const entry = generateChangelogEntry(commits, '0.22.1', 'patch');
 
       expect(entry).not.toContain('### 🐛 Fixed');
-      expect(entry).toContain('### 🔧 Changed');
+      expect(entry).not.toContain('### 🔧 Changed');
+      expect(entry).toContain('### 🤖 Internal');
       expect(entry).toContain(
         '- Add AGENTS.md with Cursor Cloud dev environment instructions (#542)',
       );
@@ -102,8 +105,8 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
     );
   });
 
-  describe('issue #581/#648: ci/build/test scopes → ### 🤖 Internal (not consumer sections)', () => {
-    it.each(['ci', 'build', 'test'] as const)(
+  describe('issue #581/#648/#718: ci/build/test/docs scopes → ### 🤖 Internal (not consumer sections)', () => {
+    it.each(['ci', 'build', 'test', 'docs'] as const)(
       'fix(%s) appears under Internal, not Fixed',
       (scope) => {
         const commits = [
@@ -122,7 +125,7 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
       },
     );
 
-    it.each(['ci', 'build', 'test'] as const)(
+    it.each(['ci', 'build', 'test', 'docs'] as const)(
       'feat(%s) appears under Internal, not Added',
       (scope) => {
         const commits = [
@@ -140,17 +143,17 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
       },
     );
 
-    it.each(['ci', 'build', 'test'] as const)(
+    it.each(['ci', 'build', 'test', 'docs'] as const)(
       'chore(%s) appears under Internal, not Changed',
       (scope) => {
         const commits = [
           fakeCommit('chore', 'tweak pipeline cache', scope),
-          fakeCommit('docs', 'update README'),
+          fakeCommit('style', 'format README'),
         ];
         const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
 
         expect(entry).toContain('### 🔧 Changed');
-        expect(entry).toContain('- Update README');
+        expect(entry).toContain('- Format README');
         expect(entry).toContain('### 🤖 Internal');
         expect(entry).toContain('- Tweak pipeline cache');
         const changedSection = entry.split('### 🤖 Internal')[0];
@@ -255,21 +258,25 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
       expect(entry).toContain('- Fix token import');
 
       expect(entry).toContain('### 🔧 Changed');
-      expect(entry).toContain('- Update README');
       expect(entry).toContain('- Bump deps');
       expect(entry).toContain('- Simplify renderer');
 
       expect(entry).not.toContain('add lint job');
       expect(entry).toContain('### 🤖 Internal');
+      expect(entry).toContain('- Update README');
       expect(entry).toContain('- Address greptile P2 findings');
+      const changedSection = entry.split('### 🤖 Internal')[0];
+      expect(changedSection).not.toContain('Update README');
     });
   });
 
   describe('scoped commits', () => {
-    it('docs(site) commit goes to Changed, not Fixed', () => {
+    it('docs(site) commit goes to Internal, not Changed/Fixed (#718)', () => {
       const commits = [fakeCommit('docs', 'add API reference', 'site')];
       const entry = generateChangelogEntry(commits, '1.0.1', 'patch');
-      expect(entry).toContain('### 🔧 Changed');
+      expect(entry).toContain('### 🤖 Internal');
+      expect(entry).toContain('- Add API reference');
+      expect(entry).not.toContain('### 🔧 Changed');
       expect(entry).not.toContain('### 🐛 Fixed');
     });
 
@@ -283,9 +290,12 @@ describe('generateChangelogEntry – changelog section bucketing', () => {
 });
 
 describe('isChangelogInternalScope', () => {
-  it.each(['ci', 'build', 'CI', 'Build'] as const)('"%s" is internal', (scope) => {
-    expect(isChangelogInternalScope(scope)).toBe(true);
-  });
+  it.each(['ci', 'build', 'test', 'docs', 'CI', 'Build', 'Test', 'Docs'] as const)(
+    '"%s" is internal',
+    (scope) => {
+      expect(isChangelogInternalScope(scope)).toBe(true);
+    },
+  );
 
   it.each(['core', 'site', 'deps'] as const)('"%s" is not internal', (scope) => {
     expect(isChangelogInternalScope(scope)).toBe(false);
@@ -294,6 +304,21 @@ describe('isChangelogInternalScope', () => {
   it('null/undefined scopes are not internal', () => {
     expect(isChangelogInternalScope(null)).toBe(false);
     expect(isChangelogInternalScope(undefined)).toBe(false);
+  });
+});
+
+describe('isChangelogInternalType', () => {
+  it.each(['docs', 'Docs'] as const)('"%s" is internal', (type) => {
+    expect(isChangelogInternalType(type)).toBe(true);
+  });
+
+  it.each(['fix', 'feat', 'chore', 'test', 'style'] as const)('"%s" is not internal', (type) => {
+    expect(isChangelogInternalType(type)).toBe(false);
+  });
+
+  it('null/undefined types are not internal', () => {
+    expect(isChangelogInternalType(null)).toBe(false);
+    expect(isChangelogInternalType(undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs commits were landing under “🔧 Changed” in generated release notes (e.g. `docs(site)` for ADR-0007). Keep a Changelog reserves Changed for consumer-facing functional updates; docs belong with other non-consumer work.

## Changes

- Add `docs` to `changelogInternalScopes` (matches the `#649` treatment for `test`)
- Route commit **type** `docs` to `### 🤖 Internal` as well, so `docs(site): …` / unscoped `docs:` entries leave Changed
- Version bump behavior unchanged (docs still participate as patch)
- Update `test/version-bump.test.ts` coverage for type + scope routing

## Test plan

- [x] `bun run test` (including `test/version-bump.test.ts`)
- [x] `uv run lintro chk` (0 issues)
- [ ] Next release PR should list docs commits under Internal, not Changed

Closes #718
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves documentation commits into the Internal changelog section. The main changes are:

- Routes `docs` commit types to Internal.
- Treats `docs` scopes as internal work.
- Keeps documentation commits eligible for patch version bumps.
- Updates tests for type, scope, breaking-change, and mixed-release routing.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Documentation commits are routed to Internal without changing version calculation.
- Breaking changes are handled before internal routing.
- No blocking issues were found in the updated code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/version-bump.mjs | Adds documentation type and scope routing while preserving breaking-change precedence and version bump behavior. |
| test/version-bump.test.ts | Updates changelog expectations and covers documentation routing by type and scope. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: retrigger ci after ready-for-revi..."](https://github.com/lgtm-hq/turbo-themes/commit/4dbe71df7653adaebba62afeb78798b0a82a4c18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45895626)</sub>

<!-- /greptile_comment -->