### PR TITLE
fix(ci): align snapshot generation env with quality-e2e

### DIFF
--- a/.github/workflows/maintenance-generate-snapshots.yml
+++ b/.github/workflows/maintenance-generate-snapshots.yml
@@ -1,4 +1,8 @@
 ---
+# Generate Linux @visual baselines in an environment aligned with quality-e2e.yml
+# (harden-runner block + same allowlist, playwright install --with-deps, apt Ruby
+# via bootstrap-e2e-snapshots.sh). Audit-mode / setup-env / install-without-deps
+# previously produced byte-stable baselines that still failed e2e (#708).
 name: Maintenance - Generate E2E Snapshots
 
 on:
@@ -15,7 +19,7 @@ permissions:
   actions: read
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: '22'
   PLAYWRIGHT_SNAPSHOT_DIR: snapshots
 
 jobs:
@@ -25,31 +29,65 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0dc4708d7b5920 # v2.20.0
         with:
-          egress-policy: audit
+          # Match quality-e2e.yml full-suite egress (block + allowlist), not audit.
+          egress-policy: block
+          allowed-endpoints: >-
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            bun.sh:443
+            cdn.playwright.dev:443
+            playwright.azureedge.net:443
+            playwright-akamai.azureedge.net:443
+            playwright-verizon.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
+            storage.googleapis.com:443
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            packages.microsoft.com:443
+            rubygems.org:443
+            api.rubygems.org:443
+            index.rubygems.org:443
+            bundler.rubygems.org:443
+            rubygems.global.ssl.fastly.net:443
+            rubygems-downloads.global.ssl.fastly.net:443
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
+      # Mirror the lgtm-ci Playwright reusable setup used by quality-e2e.yml
+      # (Node + Bun + frozen install + playwright --with-deps), not setup-env
+      # (which pulls Ruby via setup-ruby / Python / uv and different packages).
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '${{ env.NODE_VERSION }}'
-          skip-ruby: 'false'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: bun run e2e:install
-
-      - name: Build site
-        run: bun run e2e:prep
+        # --with-deps pulls the same system font/library packages as quality-e2e.
+        run: npx playwright install --with-deps chromium
 
       - name: Generate snapshots
-        run: bun run e2e --update-snapshots --grep @visual
-        env:
-          UPDATE_SNAPSHOTS: '1'
+        run: ./scripts/ci/bootstrap-e2e-snapshots.sh
 
       - name: Upload Linux snapshots
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/maintenance-generate-snapshots.yml
+++ b/.github/workflows/maintenance-generate-snapshots.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0dc4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           # Match quality-e2e.yml full-suite egress (block + allowlist), not audit.
           egress-policy: block

--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -31,6 +31,9 @@ concurrency:
 # - allowed-endpoints is the complete enforced allowlist (pre-enforcement
 #   replace semantics, lgtm-ci#467): playwright preset + Playwright CDN
 #   fallbacks + Ubuntu apt mirrors (+ RubyGems on the full-suite leg).
+# - Linux @visual baselines must be regenerated via
+#   maintenance-generate-snapshots.yml, which mirrors this job's egress policy,
+#   playwright install --with-deps, and apt-Ruby bootstrap (#708).
 jobs:
   # Org ruleset context: e2e / 🎭 E2E Tests
   e2e:

--- a/docs/E2E-TESTING.md
+++ b/docs/E2E-TESTING.md
@@ -36,3 +36,7 @@ reports locally.
 
 Playwright is integrated into GitHub Actions via `quality-e2e.yml`. It generates PR
 comments and uploads artifacts for reports.
+
+Linux visual baselines for CI should be regenerated with
+`maintenance-generate-snapshots.yml` (aligned with the full e2e job environment) so
+font/system packages match verification.

--- a/docs/PLAYWRIGHT-VISUAL-TESTS.md
+++ b/docs/PLAYWRIGHT-VISUAL-TESTS.md
@@ -97,9 +97,9 @@ bash scripts/local/generate-linux-snapshots.sh
 ```
 
 For CI-matching Linux baselines, dispatch **Maintenance - Generate E2E Snapshots**
-(`maintenance-generate-snapshots.yml`) on the target branch. That workflow uses the
-same harden-runner allowlist, `playwright install --with-deps`, and apt-Ruby bootstrap
-as `quality-e2e.yml`, then uploads `e2e-snapshots-linux` for commit.
+(`maintenance-generate-snapshots.yml`) on the target branch. That workflow uses the same
+harden-runner allowlist, `playwright install --with-deps`, and apt-Ruby bootstrap as
+`quality-e2e.yml`, then uploads `e2e-snapshots-linux` for commit.
 
 **Important**: Always update both macOS and Linux snapshots when making visual changes
 to ensure tests pass in both environments.

--- a/docs/PLAYWRIGHT-VISUAL-TESTS.md
+++ b/docs/PLAYWRIGHT-VISUAL-TESTS.md
@@ -92,9 +92,14 @@ npx playwright test --grep @visual --update-snapshots
 ### Updating Linux Snapshots
 
 ```bash
-# Update Linux snapshots (matches CI environment)
+# Update Linux snapshots locally via Docker
 bash scripts/local/generate-linux-snapshots.sh
 ```
+
+For CI-matching Linux baselines, dispatch **Maintenance - Generate E2E Snapshots**
+(`maintenance-generate-snapshots.yml`) on the target branch. That workflow uses the
+same harden-runner allowlist, `playwright install --with-deps`, and apt-Ruby bootstrap
+as `quality-e2e.yml`, then uploads `e2e-snapshots-linux` for commit.
 
 **Important**: Always update both macOS and Linux snapshots when making visual changes
 to ensure tests pass in both environments.

--- a/scripts/ci/bootstrap-e2e-full.sh
+++ b/scripts/ci/bootstrap-e2e-full.sh
@@ -12,23 +12,10 @@
 
 set -euo pipefail
 
-if ! command -v ruby >/dev/null 2>&1; then
-  echo "Installing Ruby via apt..."
-  sudo apt-get update -y
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ruby-full
-fi
-echo "ruby: $(ruby --version)"
-
-if ! command -v bundle >/dev/null 2>&1; then
-  echo "Installing bundler..."
-  sudo gem install bundler --no-document
-fi
-echo "bundler: $(bundle --version)"
-
-# Vendor the bundle locally so `bundle exec jekyll build` (prepare-examples.mjs)
-# resolves gems without writing to system paths.
-bundle config set --local path vendor/bundle
-bundle install
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ci/ensure-e2e-ruby.sh
+source "${SCRIPT_DIR}/ensure-e2e-ruby.sh"
+ensure_e2e_ruby
 
 # Heavy prep build up front: the playwright.config webServer timeout (120s) is
 # too short for a cold e2e:prep, so the webServer then only serves the dist.

--- a/scripts/ci/bootstrap-e2e-snapshots.sh
+++ b/scripts/ci/bootstrap-e2e-snapshots.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Linux visual-snapshot regeneration for maintenance-generate-snapshots.yml.
+#
+# Mirrors bootstrap-e2e-full.sh (same Ruby/apt path and e2e:prep) so generated
+# baselines match what quality-e2e.yml's verification job renders. Runs only the
+# @visual suite with --update-snapshots.
+#
+# Usage: bootstrap-e2e-snapshots.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ci/ensure-e2e-ruby.sh
+source "${SCRIPT_DIR}/ensure-e2e-ruby.sh"
+ensure_e2e_ruby
+
+bun run e2e:prep
+
+export UPDATE_SNAPSHOTS=1
+exec bun run e2e --update-snapshots --grep @visual

--- a/scripts/ci/ensure-e2e-ruby.sh
+++ b/scripts/ci/ensure-e2e-ruby.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Shared Ruby + Bundler provisioning for full-suite Playwright E2E paths.
+#
+# quality-e2e.yml's bootstrap-e2e-full.sh and maintenance-generate-snapshots.yml
+# must install Ruby the same way so @visual Jekyll builds (and the surrounding
+# apt packages) match between baseline generation and verification.
+#
+# Usage: source this file, then call ensure_e2e_ruby
+
+set -euo pipefail
+
+ensure_e2e_ruby() {
+  if ! command -v ruby >/dev/null 2>&1; then
+    echo "Installing Ruby via apt..."
+    sudo apt-get update -y
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ruby-full
+  fi
+  echo "ruby: $(ruby --version)"
+
+  if ! command -v bundle >/dev/null 2>&1; then
+    echo "Installing bundler..."
+    sudo gem install bundler --no-document
+  fi
+  echo "bundler: $(bundle --version)"
+
+  # Vendor the bundle locally so `bundle exec jekyll build` (prepare-examples.mjs)
+  # resolves gems without writing to system paths.
+  bundle config set --local path vendor/bundle
+  bundle install
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`maintenance-generate-snapshots.yml` produced Linux baselines that were byte-stable but disagreed with `quality-e2e.yml` rendering (text-metric / font stack drift). This aligns the baseline-generation environment with the verification job.

## Root cause

- Maintenance used harden-runner `audit` and `playwright install chromium` (no `--with-deps`)
- E2E uses harden-runner `block` + allowlist and `playwright install --with-deps` (system font/library packages)
- Maintenance also went through `setup-env` (setup-ruby / Python / uv) instead of the e2e apt-Ruby bootstrap

## Changes

- Rewrite `maintenance-generate-snapshots.yml` to mirror the full e2e job: block egress + same allowlist, Node/Bun + frozen install, `playwright install --with-deps chromium`
- Extract shared `scripts/ci/ensure-e2e-ruby.sh`; use it from `bootstrap-e2e-full.sh` and new `bootstrap-e2e-snapshots.sh`
- Document the aligned rebaseline path in Playwright/E2E docs

## Test plan

- [x] `uv run lintro chk` (0 issues)
- [x] `bun run test`
- [ ] Dispatch Maintenance - Generate E2E Snapshots on a branch with intentional visual churn; confirm artifact matches what quality-e2e accepts

Closes #708
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns Linux visual-snapshot generation with the E2E verification environment. The main changes are:

- Enforces the same outbound network allowlist in both workflows.
- Installs Playwright with its required system and font packages.
- Shares the apt-based Ruby and Bundler setup between generation and verification.
- Adds a dedicated snapshot bootstrap script and updates the E2E documentation.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The shared Ruby helper preserves the existing full-suite setup.
- Snapshot generation uses the same preparation and rendering dependencies as verification.
- Snapshot output matches the uploaded Linux artifact directory.
- No blocking issues were found in the updated code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/maintenance-generate-snapshots.yml | Aligns snapshot generation with the E2E job's network policy, runtime setup, and Playwright system dependencies. |
| scripts/ci/bootstrap-e2e-full.sh | Replaces inline Ruby provisioning with the shared helper while preserving the existing build and test flow. |
| scripts/ci/bootstrap-e2e-snapshots.sh | Prepares the full E2E site and regenerates all tagged Linux visual snapshots. |
| scripts/ci/ensure-e2e-ruby.sh | Centralizes apt-based Ruby, Bundler, and vendored gem installation for both CI paths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style(docs): prettier-format playwright ..."](https://github.com/lgtm-hq/turbo-themes/commit/0338c441974f2887ca506fc3450b5a34477361fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45895628)</sub>

<!-- /greptile_comment -->