### PR TITLE
ci: pass dispatched tag to action-gh-release

### DIFF
--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -56,7 +56,7 @@ jobs:
           # target the dispatched tag instead (#725).
           tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           body: |
-            ## 📦 @turbocoder13/turbo-themes ${{ github.ref_name }}
+            ## 📦 @turbocoder13/turbo-themes ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
             Published to npm: https://www.npmjs.com/package/@turbocoder13/turbo-themes
 
@@ -85,7 +85,7 @@ jobs:
         run: |
           {
             echo "## GitHub Release Summary"
-            echo "✅ Release ${{ github.ref_name }} published and released"
+            echo "✅ Release ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }} published and released"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Generate multi-format SBOMs at the release tag, cosign-sign them, and

--- a/.github/workflows/release-publish-pr.yml
+++ b/.github/workflows/release-publish-pr.yml
@@ -52,6 +52,9 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # On workflow_dispatch github.ref is a branch; the release must
+          # target the dispatched tag instead (#725).
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           body: |
             ## 📦 @turbocoder13/turbo-themes ${{ github.ref_name }}
 


### PR DESCRIPTION
Fixes #725: `workflow_dispatch` runs of `release-publish-pr.yml` failed at the release step (`GitHub Releases requires a tag`) because `github.ref` is a branch on dispatch and the `tag` input was only wired into the sbom job. Adds `tag_name` with the same event-conditional mapping. Tag-push behavior unchanged. Unblocks validating #721's fix via dispatch and backfilling GitHub releases v0.25.0–v0.38.0.

Closes #725

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes manually dispatched GitHub release publishing. The main changes are:

- Pass the dispatched tag to `action-gh-release`.
- Show the resolved tag in the release body.
- Show the resolved tag in the workflow summary.
- Preserve tag-push behavior through `github.ref_name`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The dispatched tag now reaches the release action, body, and workflow summary.
- Tag-push runs continue to use the pushed tag name.
- No blocking issues remain in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-pr.yml | Uses the dispatched tag consistently for release creation and user-visible release details. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: show resolved tag in dispatched rele..."](https://github.com/lgtm-hq/turbo-themes/commit/73286b1f7973e89db98fb8eaee13d73a9d8e4d54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45896053)</sub>

<!-- /greptile_comment -->