### PR TITLE
docs(site): fix broken export and theme-switcher examples

### DIFF
--- a/apps/site/src/content/docs/api-reference/javascript-api.md
+++ b/apps/site/src/content/docs/api-reference/javascript-api.md
@@ -240,7 +240,7 @@ For static pages, write the script directly. Keep `VALID_THEMES` in sync with yo
       var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
 
       document.documentElement.setAttribute('data-theme', theme);
-      var link = document.getElementById('theme-css');
+      var link = document.getElementById('turbo-theme-css');
       if (link) link.href = '/css/themes/turbo/' + theme + '.css';
     } catch (e) {
       console.warn('Unable to load saved theme:', e);
@@ -269,7 +269,7 @@ function getStoredTheme(): string {
 function setTheme(themeId: string): void {
   if (!CATALOG.includes(themeId)) return;
 
-  const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+  const link = document.getElementById('turbo-theme-css') as HTMLLinkElement | null;
   if (link) link.href = `/css/themes/turbo/${themeId}.css`;
 
   document.documentElement.setAttribute('data-theme', themeId);
@@ -301,14 +301,14 @@ export function useTheme() {
     if (!CATALOG.includes(newTheme)) return;
     setThemeState(newTheme);
     localStorage.setItem(STORAGE_KEY, newTheme);
-    const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+    const link = document.getElementById('turbo-theme-css') as HTMLLinkElement | null;
     if (link) link.href = `/css/themes/turbo/${newTheme}.css`;
     document.documentElement.setAttribute('data-theme', newTheme);
   };
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-    const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+    const link = document.getElementById('turbo-theme-css') as HTMLLinkElement | null;
     if (link) link.href = `/css/themes/turbo/${theme}.css`;
   }, [theme]);
 
@@ -340,7 +340,7 @@ function setTheme(newTheme: string) {
 
 watch(theme, (id) => {
   document.documentElement.setAttribute('data-theme', id);
-  const link = document.getElementById('theme-css') as HTMLLinkElement | null;
+  const link = document.getElementById('turbo-theme-css') as HTMLLinkElement | null;
   if (link) link.href = `/css/themes/turbo/${id}.css`;
   localStorage.setItem(STORAGE_KEY, id);
 });
@@ -373,7 +373,7 @@ onMounted(() => {
     currentTheme = theme;
     localStorage.setItem('turbo-theme', theme);
 
-    const link = document.getElementById('theme-css') as HTMLLinkElement;
+    const link = document.getElementById('turbo-theme-css') as HTMLLinkElement;
     if (link) {
       link.href = `/css/themes/turbo/${theme}.css`;
     }

--- a/apps/site/src/content/docs/api-reference/themes.md
+++ b/apps/site/src/content/docs/api-reference/themes.md
@@ -457,7 +457,7 @@ const lightThemes = getThemesByAppearance('light').map((f) => f.id); // 9 themes
 
 ```javascript
 function setTheme(themeId) {
-  const link = document.getElementById('theme-css');
+  const link = document.getElementById('turbo-theme-css');
   link.href = `/css/themes/turbo/${themeId}.css`;
   document.documentElement.setAttribute('data-theme', themeId);
   localStorage.setItem('turbo-theme', themeId);

--- a/apps/site/src/content/docs/getting-started/quick-start.md
+++ b/apps/site/src/content/docs/getting-started/quick-start.md
@@ -68,8 +68,9 @@ If you installed via npm, import the CSS files in your project:
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
 />
 
-<!-- Choose a theme -->
+<!-- Choose a theme (id required for the switcher below) -->
 <link
+  id="theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -79,6 +80,14 @@ If you installed via npm, import the CSS files in your project:
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-syntax.css"
 />
+```
+
+With a bundler, prefer the public CSS export paths:
+
+```javascript
+import '@lgtm-hq/turbo-themes/css/core';
+import '@lgtm-hq/turbo-themes/css/base';
+import '@lgtm-hq/turbo-themes/css/themes/catppuccin-mocha.css';
 ```
 
 ## Step 3: Use the Tokens
@@ -111,12 +120,16 @@ Now you can use Turbo Themes tokens in your CSS:
 
 ## Step 4: Switch Themes (Optional)
 
-To enable theme switching, swap the theme CSS file dynamically:
+To enable theme switching, swap the theme CSS file dynamically. Keep the href in the
+same form as your initial `<link>` (npm `node_modules/…` path, or a CDN URL — not a
+site-root `/packages/…` path, which will 404):
+
+#### npm / local install
 
 ```javascript
 function setTheme(themeName) {
   const themeLink = document.getElementById('theme-css');
-  themeLink.href = `/packages/css/dist/themes/${themeName}.css`;
+  themeLink.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
 
   // Persist the choice
   localStorage.setItem('turbo-theme', themeName);
@@ -125,6 +138,16 @@ function setTheme(themeName) {
 // Usage
 setTheme('dracula');
 setTheme('catppuccin-latte');
+```
+
+#### CDN
+
+```javascript
+function setTheme(themeName) {
+  const themeLink = document.getElementById('theme-css');
+  themeLink.href = `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
+  localStorage.setItem('turbo-theme', themeName);
+}
 ```
 
 ## All Done

--- a/apps/site/src/content/docs/getting-started/quick-start.md
+++ b/apps/site/src/content/docs/getting-started/quick-start.md
@@ -48,6 +48,7 @@ No installation needed - just add the links to your HTML:
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
 />
 <link
+  id="theme-css"
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -122,7 +123,10 @@ Now you can use Turbo Themes tokens in your CSS:
 
 To enable theme switching, swap the theme CSS file dynamically. Keep the href in the
 same form as your initial `<link>` (npm `node_modules/…` path, or a CDN URL — not a
-site-root `/packages/…` path, which will 404):
+site-root `/packages/…` path, which will 404). The `node_modules/…` form suits
+plain-HTML pages served from the project root during development; production apps
+should bundle the CSS, copy the themes directory into their public assets, or use
+the CDN URLs:
 
 #### npm / local install
 

--- a/apps/site/src/content/docs/getting-started/quick-start.md
+++ b/apps/site/src/content/docs/getting-started/quick-start.md
@@ -124,9 +124,8 @@ Now you can use Turbo Themes tokens in your CSS:
 To enable theme switching, swap the theme CSS file dynamically. Keep the href in the
 same form as your initial `<link>` (npm `node_modules/…` path, or a CDN URL — not a
 site-root `/packages/…` path, which will 404). The `node_modules/…` form suits
-plain-HTML pages served from the project root during development; production apps
-should bundle the CSS, copy the themes directory into their public assets, or use
-the CDN URLs:
+plain-HTML pages served from the project root during development; production apps should
+bundle the CSS, copy the themes directory into their public assets, or use the CDN URLs:
 
 #### npm / local install
 

--- a/apps/site/src/content/docs/getting-started/quick-start.md
+++ b/apps/site/src/content/docs/getting-started/quick-start.md
@@ -48,7 +48,7 @@ No installation needed - just add the links to your HTML:
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
 />
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -71,7 +71,7 @@ If you installed via npm, import the CSS files in your project:
 
 <!-- Choose a theme (id required for the switcher below) -->
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -131,7 +131,7 @@ bundle the CSS, copy the themes directory into their public assets, or use the C
 
 ```javascript
 function setTheme(themeName) {
-  const themeLink = document.getElementById('theme-css');
+  const themeLink = document.getElementById('turbo-theme-css');
   themeLink.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
 
   // Persist the choice
@@ -147,7 +147,7 @@ setTheme('catppuccin-latte');
 
 ```javascript
 function setTheme(themeName) {
-  const themeLink = document.getElementById('theme-css');
+  const themeLink = document.getElementById('turbo-theme-css');
   themeLink.href = `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }

--- a/apps/site/src/content/docs/guides/advanced-theming.md
+++ b/apps/site/src/content/docs/guides/advanced-theming.md
@@ -99,46 +99,28 @@ Combine multiple theme layers for complex designs:
 }
 ```
 
-### Theme Inheritance
+### Theme Catalog Variants
 
-Create theme variants that inherit from a base:
+Curate light/dark (or vendor-scoped) subsets with `createThemeCatalog` — there is no
+`createTheme` factory on the package root. For brand-new palettes, author CSS token
+files instead (see [Custom Themes](/docs/guides/custom-themes/)).
 
 ```javascript
-// themes/custom-theme.js
-import { createTheme } from '@lgtm-hq/turbo-themes';
+import { createThemeCatalog } from '@lgtm-hq/turbo-themes';
 
-const baseTheme = {
-  colors: {
-    brand: {
-      primary: '#7c3aed',
-      secondary: '#a78bfa',
-    },
-  },
-};
+// Light-only catalog for a settings panel
+export const lightCatalog = createThemeCatalog({ appearances: ['light'] });
 
-export const lightVariant = createTheme({
-  ...baseTheme,
-  mode: 'light',
-  colors: {
-    ...baseTheme.colors,
-    background: {
-      base: '#ffffff',
-      surface: '#f8fafc',
-    },
-  },
+// Dark-only catalog
+export const darkCatalog = createThemeCatalog({ appearances: ['dark'] });
+
+// Vendor-scoped catalog (e.g. Catppuccin + Dracula)
+export const accentCatalog = createThemeCatalog({
+  vendors: ['catppuccin', 'dracula'],
 });
 
-export const darkVariant = createTheme({
-  ...baseTheme,
-  mode: 'dark',
-  colors: {
-    ...baseTheme.colors,
-    background: {
-      base: '#0f172a',
-      surface: '#1e293b',
-    },
-  },
-});
+// Use catalog.themeIds / catalog.flavors / catalog.vendorGroups in your UI
+console.log(lightCatalog.themeIds);
 ```
 
 ## Dynamic Theming

--- a/apps/site/src/content/docs/guides/custom-themes.md
+++ b/apps/site/src/content/docs/guides/custom-themes.md
@@ -203,7 +203,7 @@ function setTheme(themeId) {
   const basePath = isCustom ? '/css/' : '/css/themes/turbo/';
   const fileName = isCustom ? 'my-custom-theme.css' : `${themeId}.css`;
 
-  document.getElementById('theme-css').href = basePath + fileName;
+  document.getElementById('turbo-theme-css').href = basePath + fileName;
   localStorage.setItem('turbo-theme', themeId);
 }
 ```

--- a/apps/site/src/content/docs/guides/performance.md
+++ b/apps/site/src/content/docs/guides/performance.md
@@ -92,9 +92,9 @@ Import only what you need:
 // Instead of importing everything
 // import { themes, tokens, utils } from '@lgtm-hq/turbo-themes';
 
-// Import specific modules
+// Import specific modules from their public entry points
 import { getTheme } from '@lgtm-hq/turbo-themes';
-import { applyTheme } from '@lgtm-hq/turbo-themes';
+import { applyTheme } from '@lgtm-hq/turbo-themes/selector';
 ```
 
 ### CSS Purging

--- a/apps/site/src/content/docs/guides/theme-switching.md
+++ b/apps/site/src/content/docs/guides/theme-switching.md
@@ -76,7 +76,7 @@ Give your theme CSS link an ID so JavaScript can swap it:
   <link rel="stylesheet" href="/css/turbo-base.css" />
 
   <!-- Theme (with ID for JavaScript access) -->
-  <link id="theme-css" rel="stylesheet" href="/css/themes/turbo/catppuccin-mocha.css" />
+  <link id="turbo-theme-css" rel="stylesheet" href="/css/themes/turbo/catppuccin-mocha.css" />
 </head>
 ```
 
@@ -94,7 +94,7 @@ const CATALOG = [
 function setTheme(themeName) {
   if (!CATALOG.includes(themeName)) return;
 
-  document.getElementById('theme-css').href = `/css/themes/turbo/${themeName}.css`;
+  document.getElementById('turbo-theme-css').href = `/css/themes/turbo/${themeName}.css`;
   document.documentElement.setAttribute('data-theme', themeName);
   localStorage.setItem('turbo-theme', themeName);
 }
@@ -195,7 +195,7 @@ For plain HTML files, write the script directly using your hardcoded catalog:
       var theme = saved && VALID_THEMES.indexOf(saved) !== -1 ? saved : DEFAULT_THEME;
 
       document.documentElement.setAttribute('data-theme', theme);
-      var link = document.getElementById('theme-css');
+      var link = document.getElementById('turbo-theme-css');
       if (link) link.href = '/css/themes/turbo/' + theme + '.css';
     } catch (e) {
       console.warn('Unable to load saved theme:', e);

--- a/apps/site/src/content/docs/guides/theme-switching.md
+++ b/apps/site/src/content/docs/guides/theme-switching.md
@@ -76,7 +76,11 @@ Give your theme CSS link an ID so JavaScript can swap it:
   <link rel="stylesheet" href="/css/turbo-base.css" />
 
   <!-- Theme (with ID for JavaScript access) -->
-  <link id="turbo-theme-css" rel="stylesheet" href="/css/themes/turbo/catppuccin-mocha.css" />
+  <link
+    id="turbo-theme-css"
+    rel="stylesheet"
+    href="/css/themes/turbo/catppuccin-mocha.css"
+  />
 </head>
 ```
 
@@ -94,7 +98,8 @@ const CATALOG = [
 function setTheme(themeName) {
   if (!CATALOG.includes(themeName)) return;
 
-  document.getElementById('turbo-theme-css').href = `/css/themes/turbo/${themeName}.css`;
+  document.getElementById('turbo-theme-css').href =
+    `/css/themes/turbo/${themeName}.css`;
   document.documentElement.setAttribute('data-theme', themeName);
   localStorage.setItem('turbo-theme', themeName);
 }

--- a/apps/site/src/content/docs/installation/cdn.md
+++ b/apps/site/src/content/docs/installation/cdn.md
@@ -121,7 +121,7 @@ For production, pin to a specific version to avoid unexpected changes:
       href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-base.css"
     />
     <link
-      id="theme-css"
+      id="turbo-theme-css"
       rel="stylesheet"
       href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
     />
@@ -166,7 +166,7 @@ For production, pin to a specific version to avoid unexpected changes:
       function toggleTheme() {
         currentIndex = (currentIndex + 1) % themes.length;
         const theme = themes[currentIndex];
-        document.getElementById('theme-css').href =
+        document.getElementById('turbo-theme-css').href =
           `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${theme}.css`;
       }
     </script>

--- a/apps/site/src/content/docs/installation/jekyll.md
+++ b/apps/site/src/content/docs/installation/jekyll.md
@@ -70,7 +70,7 @@ In your `_layouts/default.html`:
     <link rel="stylesheet" href="{{ '/assets/css/turbo-core.css' | relative_url }}" />
     <link rel="stylesheet" href="{{ '/assets/css/turbo-base.css' | relative_url }}" />
     <link
-      id="theme-css"
+      id="turbo-theme-css"
       rel="stylesheet"
       href="{{ '/assets/css/themes/turbo/catppuccin-mocha.css' | relative_url }}"
     />
@@ -100,7 +100,7 @@ Create a theme switcher component:
 
 <script>
   function setTheme(theme) {
-    document.getElementById('theme-css').href =
+    document.getElementById('turbo-theme-css').href =
       '{{ "/assets/css/themes/turbo/" | relative_url }}' + theme + '.css';
     localStorage.setItem('turbo-theme', theme);
   }
@@ -147,7 +147,7 @@ Add a blocking script in your `<head>` to apply the saved theme before render:
 <script>
   (function () {
     var theme = localStorage.getItem('turbo-theme') || 'catppuccin-mocha';
-    var link = document.getElementById('theme-css');
+    var link = document.getElementById('turbo-theme-css');
     if (link) {
       link.href = '{{ "/assets/css/themes/turbo/" | relative_url }}' + theme + '.css';
     }

--- a/apps/site/src/content/docs/installation/npm.md
+++ b/apps/site/src/content/docs/installation/npm.md
@@ -88,7 +88,7 @@ To enable runtime theme switching:
 ```javascript
 function setTheme(themeName) {
   // Update the theme CSS
-  const themeLink = document.getElementById('theme-css');
+  const themeLink = document.getElementById('turbo-theme-css');
   themeLink.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
 
   // Persist the choice
@@ -106,7 +106,7 @@ Make sure your theme link has an ID:
 
 ```html
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />

--- a/apps/site/src/content/docs/integrations/bootstrap.md
+++ b/apps/site/src/content/docs/integrations/bootstrap.md
@@ -22,6 +22,7 @@ Use Turbo Themes with Bootstrap by mapping tokens to Bootstrap's CSS variables.
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
+  id="theme-css"
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -197,10 +198,12 @@ Use standard Bootstrap classes:
 
 ## Theme Switching
 
+Keep the switcher on the same CDN origin as the initial `#theme-css` `<link>`:
+
 ```javascript
 function setTheme(themeName) {
   const link = document.getElementById('theme-css');
-  link.href = `/packages/css/dist/themes/${themeName}.css`;
+  link.href = `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }
 ```

--- a/apps/site/src/content/docs/integrations/bootstrap.md
+++ b/apps/site/src/content/docs/integrations/bootstrap.md
@@ -22,7 +22,7 @@ Use Turbo Themes with Bootstrap by mapping tokens to Bootstrap's CSS variables.
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -198,11 +198,11 @@ Use standard Bootstrap classes:
 
 ## Theme Switching
 
-Keep the switcher on the same CDN origin as the initial `#theme-css` `<link>`:
+Keep the switcher on the same CDN origin as the initial `#turbo-theme-css` `<link>`:
 
 ```javascript
 function setTheme(themeName) {
-  const link = document.getElementById('theme-css');
+  const link = document.getElementById('turbo-theme-css');
   link.href = `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }

--- a/apps/site/src/content/docs/integrations/bulma.md
+++ b/apps/site/src/content/docs/integrations/bulma.md
@@ -32,6 +32,7 @@ Add the CSS files in this order:
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
+  id="theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -57,6 +58,7 @@ Add the CSS files in this order:
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
+  id="theme-css"
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -187,18 +189,31 @@ Use standard Bulma classes - they'll automatically use your theme colors.
 
 ## Theme Switching
 
-Switching themes updates all Bulma components automatically:
+Switching themes updates all Bulma components automatically. Match the href form to
+how you loaded the initial theme:
+
+#### npm / local install
 
 ```javascript
 function setTheme(themeName) {
   const link = document.getElementById('theme-css');
-  link.href = `/packages/css/dist/themes/${themeName}.css`;
+  link.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }
 
 // Example usage
 setTheme('dracula');
 setTheme('catppuccin-latte');
+```
+
+#### CDN
+
+```javascript
+function setTheme(themeName) {
+  const link = document.getElementById('theme-css');
+  link.href = `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
+  localStorage.setItem('turbo-theme', themeName);
+}
 ```
 
 ## Customizing the Adapter

--- a/apps/site/src/content/docs/integrations/bulma.md
+++ b/apps/site/src/content/docs/integrations/bulma.md
@@ -190,7 +190,9 @@ Use standard Bulma classes - they'll automatically use your theme colors.
 ## Theme Switching
 
 Switching themes updates all Bulma components automatically. Match the href form to
-how you loaded the initial theme:
+how you loaded the initial theme. The `node_modules/…` form suits plain-HTML pages
+served from the project root during development; in production, copy the themes
+directory into your public assets or use the CDN URLs:
 
 #### npm / local install
 

--- a/apps/site/src/content/docs/integrations/bulma.md
+++ b/apps/site/src/content/docs/integrations/bulma.md
@@ -189,10 +189,10 @@ Use standard Bulma classes - they'll automatically use your theme colors.
 
 ## Theme Switching
 
-Switching themes updates all Bulma components automatically. Match the href form to
-how you loaded the initial theme. The `node_modules/…` form suits plain-HTML pages
-served from the project root during development; in production, copy the themes
-directory into your public assets or use the CDN URLs:
+Switching themes updates all Bulma components automatically. Match the href form to how
+you loaded the initial theme. The `node_modules/…` form suits plain-HTML pages served
+from the project root during development; in production, copy the themes directory into
+your public assets or use the CDN URLs:
 
 #### npm / local install
 

--- a/apps/site/src/content/docs/integrations/bulma.md
+++ b/apps/site/src/content/docs/integrations/bulma.md
@@ -32,7 +32,7 @@ Add the CSS files in this order:
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -58,7 +58,7 @@ Add the CSS files in this order:
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -198,7 +198,7 @@ your public assets or use the CDN URLs:
 
 ```javascript
 function setTheme(themeName) {
-  const link = document.getElementById('theme-css');
+  const link = document.getElementById('turbo-theme-css');
   link.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }
@@ -212,7 +212,7 @@ setTheme('catppuccin-latte');
 
 ```javascript
 function setTheme(themeName) {
-  const link = document.getElementById('theme-css');
+  const link = document.getElementById('turbo-theme-css');
   link.href = `https://unpkg.com/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
   localStorage.setItem('turbo-theme', themeName);
 }

--- a/apps/site/src/content/docs/integrations/tailwind.md
+++ b/apps/site/src/content/docs/integrations/tailwind.md
@@ -122,11 +122,11 @@ The preset adds these color utilities:
 ## Theme Switching
 
 Theme switching works automatically. When you change the theme CSS file, Tailwind
-utilities update because they reference CSS variables. Use the same
-`node_modules/…` path as the initial `<link>` (a site-root `/packages/…` URL will
-404 on a standard install). That form suits plain-HTML pages served from the
-project root during development; in production, copy the themes directory into
-your public assets or use the CDN URLs:
+utilities update because they reference CSS variables. Use the same `node_modules/…`
+path as the initial `<link>` (a site-root `/packages/…` URL will 404 on a standard
+install). That form suits plain-HTML pages served from the project root during
+development; in production, copy the themes directory into your public assets or use the
+CDN URLs:
 
 ```javascript
 function setTheme(themeName) {

--- a/apps/site/src/content/docs/integrations/tailwind.md
+++ b/apps/site/src/content/docs/integrations/tailwind.md
@@ -43,7 +43,7 @@ Add the theme CSS to your HTML:
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
-  id="theme-css"
+  id="turbo-theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
@@ -130,7 +130,7 @@ CDN URLs:
 
 ```javascript
 function setTheme(themeName) {
-  const link = document.getElementById('theme-css');
+  const link = document.getElementById('turbo-theme-css');
   link.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
 }
 ```

--- a/apps/site/src/content/docs/integrations/tailwind.md
+++ b/apps/site/src/content/docs/integrations/tailwind.md
@@ -124,7 +124,9 @@ The preset adds these color utilities:
 Theme switching works automatically. When you change the theme CSS file, Tailwind
 utilities update because they reference CSS variables. Use the same
 `node_modules/…` path as the initial `<link>` (a site-root `/packages/…` URL will
-404 on a standard install):
+404 on a standard install). That form suits plain-HTML pages served from the
+project root during development; in production, copy the themes directory into
+your public assets or use the CDN URLs:
 
 ```javascript
 function setTheme(themeName) {

--- a/apps/site/src/content/docs/integrations/tailwind.md
+++ b/apps/site/src/content/docs/integrations/tailwind.md
@@ -43,9 +43,17 @@ Add the theme CSS to your HTML:
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/turbo-core.css"
 />
 <link
+  id="theme-css"
   rel="stylesheet"
   href="node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/catppuccin-mocha.css"
 />
+```
+
+Or with a bundler:
+
+```javascript
+import '@lgtm-hq/turbo-themes/css/core';
+import '@lgtm-hq/turbo-themes/css/themes/catppuccin-mocha.css';
 ```
 
 ## Available Classes
@@ -114,12 +122,14 @@ The preset adds these color utilities:
 ## Theme Switching
 
 Theme switching works automatically. When you change the theme CSS file, Tailwind
-utilities update because they reference CSS variables:
+utilities update because they reference CSS variables. Use the same
+`node_modules/…` path as the initial `<link>` (a site-root `/packages/…` URL will
+404 on a standard install):
 
 ```javascript
 function setTheme(themeName) {
   const link = document.getElementById('theme-css');
-  link.href = `/packages/css/dist/themes/${themeName}.css`;
+  link.href = `node_modules/@lgtm-hq/turbo-themes/packages/css/dist/themes/${themeName}.css`;
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes six functionally broken docs examples surfaced on PR #722 (pre-existing content bugs; the scoping sweep only renamed the package).

## Changes

1. `guides/advanced-theming.md` — replace nonexistent `createTheme` with `createThemeCatalog` curation examples; point full palettes at Custom Themes
2. `guides/performance.md` — import `applyTheme` from `@lgtm-hq/turbo-themes/selector` (not the root entry)
3. `getting-started/quick-start.md` — theme switcher uses npm `node_modules/…` or unpkg URLs (not site-root `/packages/…`); add `#theme-css` + bundler export paths
4. `integrations/bootstrap.md` — CDN switcher stays on unpkg; `#theme-css` on the setup link
5. `integrations/bulma.md` — npm vs CDN switcher hrefs match the initial load path
6. `integrations/tailwind.md` — switcher uses `node_modules/…`; document public `css/*` imports

## Test plan

- [x] Verified exports: `createThemeCatalog`/`getTheme` on root; `applyTheme` on `/selector`; no `createTheme`/`applyTheme` on root
- [x] `uv run lintro chk` (0 issues)
- [x] `bun run test`

Closes #727
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes broken theme setup and switching examples across the documentation. The main changes are:

- Uses the canonical theme stylesheet link ID throughout the guides.
- Aligns local and CDN switchers with their initial stylesheet paths.
- Replaces invalid JavaScript imports with public package exports.
- Adds supported CSS import examples for bundlers.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The stylesheet IDs now match the selector package contract.
- The updated switchers use paths consistent with their setup examples.
- The changed JavaScript and CSS imports match the declared package exports.
- No blocking issues remain in the updated documentation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/content/docs/getting-started/quick-start.md | Adds matching local and CDN switchers, the canonical link ID, and public CSS imports. |
| apps/site/src/content/docs/guides/advanced-theming.md | Replaces the nonexistent theme factory with supported theme catalog examples. |
| apps/site/src/content/docs/guides/performance.md | Imports the theme application helper from its public selector entry point. |
| apps/site/src/content/docs/integrations/bootstrap.md | Keeps the initial theme and switcher on matching CDN paths. |
| apps/site/src/content/docs/integrations/bulma.md | Provides consistent local and CDN setup and switching examples. |
| apps/site/src/content/docs/integrations/tailwind.md | Aligns the local switcher path and documents supported bundler imports. |

</details>

<sub>Reviews (3): Last reviewed commit: ["style(docs): prettier-format theme-switc..."](https://github.com/lgtm-hq/turbo-themes/commit/6795f6dbb585a63bd0530638160e99168d4de6ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45959030)</sub>

<!-- /greptile_comment -->