### PR TITLE
fix(site): stabilize homepage CLS under the 0.1 CWV budget

### DIFF
--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -39,19 +39,24 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
     <title>{pageTitle}</title>
     <SEOHead title={pageTitle} description={description} />
 
-    <!-- Preconnect to Google Fonts (Noir Editorial: Playfair + Instrument Sans + JetBrains Mono) -->
+    <!--
+      Preconnect + optional webfonts (Noir: Playfair + Instrument Sans + JetBrains Mono).
+      display=optional avoids late font-swap layout shifts that push homepage CLS
+      against the 0.1 CWV budget (#729). Fonts apply only if ready in the first
+      paint window; otherwise the page keeps the metric-tuned fallbacks in noir.css.
+    -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="preload"
       as="style"
-      href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&display=optional"
       onload="this.onload=null;this.rel='stylesheet';"
     />
     <noscript>
       <link
         rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&display=optional"
       />
     </noscript>
 

--- a/apps/site/src/styles/noir.css
+++ b/apps/site/src/styles/noir.css
@@ -7,11 +7,43 @@
    Design tokens
    ========================================================================== */
 
+/*
+ * Fallback faces with size-adjust so system fonts approximate webfont metrics.
+ * Paired with display=optional in BaseLayout (#729) to keep homepage CLS under
+ * the 0.1 CWV budget when Instrument Sans / Playfair swap (or never load).
+ */
+@font-face {
+  font-family: 'Instrument Sans Fallback';
+  src: local('Arial'), local('Helvetica Neue'), local('Helvetica');
+  size-adjust: 102%;
+  ascent-override: 95%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+
+@font-face {
+  font-family: 'Playfair Display Fallback';
+  src: local('Times New Roman'), local('Times'), local('Georgia');
+  size-adjust: 108%;
+  ascent-override: 90%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+
+@font-face {
+  font-family: 'JetBrains Mono Fallback';
+  src: local('Menlo'), local('Consolas'), local('Monaco'), local('Courier New');
+  size-adjust: 100%;
+  ascent-override: 92%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+
 :root {
   /* Fonts */
-  --font-display: 'Playfair Display', serif;
-  --font-body: 'Instrument Sans', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-display: 'Playfair Display', 'Playfair Display Fallback', Georgia, serif;
+  --font-body: 'Instrument Sans', 'Instrument Sans Fallback', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'JetBrains Mono Fallback', ui-monospace, monospace;
 
   /* Backgrounds */
   --noir-bg-base: #0a0a0b;

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -71,7 +71,16 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 2rem;
-  align-items: center;
+  /* Top-align so webfont metric deltas in the copy column do not vertically
+     re-center the preview card (dominant CLS source on the homepage, #729). */
+  align-items: start;
+}
+
+.showcase-hero-copy {
+  /* Reserve room for the clamp() headline + lede so late font metrics do not
+     push the marquees / sections below as hard when display=optional still
+     applies a face within the first paint window. */
+  min-height: 22rem;
 }
 
 /* .showcase-badge / .showcase-headline → site.css (#685) */
@@ -768,6 +777,10 @@
 @media (max-width: 900px) {
   .showcase-hero-grid {
     grid-template-columns: 1fr;
+  }
+
+  .showcase-hero-copy {
+    min-height: 0;
   }
 }
 

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -142,27 +142,52 @@ test.describe('Performance @performance', () => {
       await page.goto('/');
       await page.waitForLoadState('networkidle');
 
-      // Get CLS from Performance API with proper accumulation
-      const cls = await page.evaluate(() => {
-        return new Promise<number>((resolve) => {
-          let clsValue = 0;
+      // Accumulate CLS and per-element attributions (#729) so budget failures
+      // name the shifting nodes instead of only reporting a float.
+      const { cls, attributions } = await page.evaluate(() => {
+        type LayoutShiftSource = {
+          node: Element | null;
+          previousRect: DOMRectReadOnly;
+          currentRect: DOMRectReadOnly;
+        };
+        type LayoutShiftEntry = PerformanceEntry & {
+          hadRecentInput: boolean;
+          value: number;
+          sources?: ReadonlyArray<LayoutShiftSource>;
+        };
 
-          // Get existing layout shift entries
-          const existingEntries = performance.getEntriesByType('layout-shift');
-          for (const entry of existingEntries) {
-            const layoutEntry = entry as PerformanceEntry & { hadRecentInput: boolean; value: number };
-            if (!layoutEntry.hadRecentInput) {
-              clsValue += layoutEntry.value;
-            }
+        const describeNode = (node: Element | null): string => {
+          if (!node) return '(unknown)';
+          if (node.id) return `#${node.id}`;
+          const className = typeof node.className === 'string' ? node.className.trim() : '';
+          if (className) return `.${className.split(/\s+/).slice(0, 3).join('.')}`;
+          return node.tagName.toLowerCase();
+        };
+
+        return new Promise<{
+          cls: number;
+          attributions: Array<{ value: number; startTime: number; nodes: string[] }>;
+        }>((resolve) => {
+          let clsValue = 0;
+          const attributions: Array<{ value: number; startTime: number; nodes: string[] }> = [];
+
+          const record = (entry: LayoutShiftEntry) => {
+            if (entry.hadRecentInput) return;
+            clsValue += entry.value;
+            attributions.push({
+              value: entry.value,
+              startTime: entry.startTime,
+              nodes: (entry.sources ?? []).map((source) => describeNode(source.node)),
+            });
+          };
+
+          for (const entry of performance.getEntriesByType('layout-shift')) {
+            record(entry as LayoutShiftEntry);
           }
 
-          // Also observe for new shifts
           const observer = new PerformanceObserver((list) => {
             for (const entry of list.getEntries()) {
-              const layoutEntry = entry as PerformanceEntry & { hadRecentInput: boolean; value: number };
-              if (!layoutEntry.hadRecentInput) {
-                clsValue += layoutEntry.value;
-              }
+              record(entry as LayoutShiftEntry);
             }
           });
 
@@ -172,16 +197,18 @@ test.describe('Performance @performance', () => {
             // CLS observation not supported
           }
 
-          // Wait for any pending shifts and resolve
           setTimeout(() => {
             observer.disconnect();
-            resolve(clsValue);
+            resolve({ cls: clsValue, attributions });
           }, 2000);
         });
       });
 
       // CLS should be under threshold for "good" rating
-      expect(cls).toBeLessThan(WEB_VITALS.CLS);
+      expect(
+        cls,
+        `CLS ${cls.toFixed(5)} exceeded ${WEB_VITALS.CLS}. Attributions: ${JSON.stringify(attributions)}`,
+      ).toBeLessThan(WEB_VITALS.CLS);
     });
 
     test('should have good FCP (First Contentful Paint)', async ({ page }) => {

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -181,10 +181,9 @@ test.describe('Performance @performance', () => {
             });
           };
 
-          for (const entry of performance.getEntriesByType('layout-shift')) {
-            record(entry as LayoutShiftEntry);
-          }
-
+          // The buffered observer below replays entries recorded before
+          // registration — no manual getEntriesByType pre-read, or every
+          // buffered shift would be counted twice.
           const observer = new PerformanceObserver((list) => {
             for (const entry of list.getEntries()) {
               record(entry as LayoutShiftEntry);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Homepage CLS sits on the 0.1 CWV line and flaps the Core Web Vitals e2e assertion on main. Attribution pointed at webfont metric deltas in `.showcase-hero-copy` (and secondary nav width), which vertically re-centered the preview column under `align-items: center`.

## Changes

1. **Instrument** `e2e/performance.spec.ts` CLS check with per-entry node attributions in the failure message
2. **Fonts**: `display=swap` → `display=optional` for Noir Google Fonts; add `size-adjust` fallback `@font-face`s in `noir.css`
3. **Layout**: top-align the hero grid and reserve `min-height` on `.showcase-hero-copy` (cleared below 900px) so residual metric deltas do not shove the preview / marquees

ADR-0007 budget stays at CLS &lt; 0.1.

## Test plan

- [x] Local attribution probe: hero-copy shift eliminated; CLS ≈ 0.0002 (was ~0.003 with swap; CI had reported 0.103)
- [x] `SKIP_PREP=1 bun run e2e --grep @performance` (10 passed)
- [x] `SKIP_PREP=1 bun run e2e:smoke` (16 passed, including visual smoke)
- [x] `bun run test` / `uv run lintro chk`

Closes #729
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45dcb826-0e49-4bf7-84f9-4251e6183288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes homepage layout shifts and improves CLS diagnostics. The main changes are:

- Loads Noir webfonts with `display=optional`.
- Adds metric-adjusted fallback font faces.
- Top-aligns the hero and reserves desktop copy height.
- Reports shifting nodes when the CLS test fails.
- Removes duplicate counting of buffered layout shifts.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The buffered observer now provides a single CLS accumulation path.
- The previously reported duplicate counting is removed.
- No blocking issues remain in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/src/layouts/BaseLayout.astro | Uses optional font loading to avoid late font swaps. |
| apps/site/src/styles/noir.css | Adds metric-adjusted fallback faces to the Noir font stacks. |
| assets/css/home.css | Top-aligns the hero and reserves copy height on wider layouts. |
| e2e/performance.spec.ts | Fixes duplicate CLS accumulation and adds node attribution to failures. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): rely on buffered observer alo..."](https://github.com/lgtm-hq/turbo-themes/commit/d4d5c690e4e795813191d263c61f407c6db01aec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46019712)</sub>

<!-- /greptile_comment -->