### PR TITLE
fix(build): format synced Ayu source with oxfmt, failing loudly

### DIFF
--- a/scripts/sync-ayu.mjs
+++ b/scripts/sync-ayu.mjs
@@ -359,20 +359,19 @@ const rawContent = `import type { ThemePackage } from '../types.js';
 export const ayuSynced: ThemePackage = ${formatObject(pkg)} as const;
 `;
 
-// Write file first, then format with lintro
+// Write file first, then format with the repo-pinned oxfmt devDependency.
+// Must be an environment-independent formatter that fails loudly: silently
+// skipping formatting (e.g. the previous lintro try/catch when uv is absent
+// in the release regen environment) commits single-quoted output and breaks
+// the theme-sync determinism check (issue #651, regressed via #607).
 fs.writeFileSync(outPath, rawContent, 'utf8');
 
 // Also keep W3C Design Token files aligned with the synced palette
 writeW3cThemeFiles(pkg);
 
-// Format with lintro using repository configuration
-try {
-  execSync(`uv run lintro fmt "${outPath}"`, {
-    cwd: projectRoot,
-    stdio: 'inherit',
-  });
-} catch {
-  console.warn(`Warning: lintro fmt failed for ${outPath}, file written but may not be formatted`);
-}
+execSync(`bunx oxfmt --ignore-path=.gitignore "${outPath}"`, {
+  cwd: projectRoot,
+  stdio: 'inherit',
+});
 
 console.log(`Wrote ${outPath}`);


### PR DESCRIPTION
Fixes #767. sync-ayu.mjs formatted `ayu.synced.ts` with `uv run lintro fmt` inside a swallowing try/catch. In the bun-only release-regen environment (no `uv`), the format silently no-ops and the file ships single-quoted, breaking the theme-sync determinism check on release PRs (#766) — a regression of #651. Switch to the repo-pinned, environment-independent `bunx oxfmt` that fails loudly, matching sync-radix/sync-rose-pine.

Verified: regenerated `ayu.synced.ts` is byte-identical to committed (double-quoted); `theme-sync-determinism-check.sh` passes with a clean tree. Follow-up for the single-source-of-truth gap tracked separately.

Closes #767

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Switches Ayu synchronization from an optional, failure-swallowing lintro formatter call to the repository-pinned oxfmt command used by sibling sync scripts.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The formatter is pinned in the repository, available in the Bun-based build environments, and invoked identically by the other theme synchronization scripts; failures now stop generation as intended.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sync-ayu.mjs | Uses the established `bunx oxfmt` invocation and propagates formatter failures so generated Ayu output remains deterministic. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(build): format synced Ayu source wit..."](https://github.com/lgtm-hq/turbo-themes/commit/4d636e8d46b8a8c4660dcec7e26dfeab60d8b7b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46620233)</sub>

**Context used:**

- Knowledge Base — [Build pipeline](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/turbo-themes/-/docs/build-pipeline.md)

<!-- /greptile_comment -->