### PR TITLE
fix(ci): grant contents:write to publish sbom jobs (unbreaks npm/gem publish)

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -39,7 +39,7 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      contents: read
+      contents: write
       security-events: write
       id-token: write
       attestations: write

--- a/.github/workflows/publish-npm-test.yml
+++ b/.github/workflows/publish-npm-test.yml
@@ -35,7 +35,7 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      contents: read
+      contents: write
       security-events: write
       id-token: write
       attestations: write

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -39,7 +39,7 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      contents: read
+      contents: write
       security-events: write
       id-token: write
       attestations: write


### PR DESCRIPTION
Fixes #771. publish-npm/gem/npm-test call reusable-sbom v0.59.2, whose release-asset jobs request `contents: write`; the sbom job only granted `contents: read`, so GitHub's caller-grants-the-union validation startup-failed the workflow — **npm and RubyGems did not publish v0.40.1**. Bump the sbom job to `contents: write` (same class as #720/#721; #657's migration missed the contents bump). After merge, re-publish v0.40.1 via workflow_dispatch on the npm + gem publish workflows.

Closes #771

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores package publication workflows by granting the pinned reusable SBOM job its required permission.
- Changes the RubyGems publish workflow SBOM job from `contents: read` to `contents: write`.
- Applies the same permission change to the production and test/beta npm publish workflows.
- Leaves build and publication job permissions unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and narrowly corrects the reusable-workflow permission mismatch.

The changed permission is scoped to pinned SBOM jobs, matches existing sibling workflow usage, and does not expose the write-capable token to repository code, dynamic caller inputs, or downstream publication jobs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-gem.yml | Grants the pinned reusable SBOM workflow the contents permission required for workflow validation while preserving narrower permissions on downstream jobs. |
| .github/workflows/publish-npm-test.yml | Applies the required contents permission to the manual test/beta publication workflow's SBOM job without altering publication behavior. |
| .github/workflows/publish-npm.yml | Applies the required contents permission to the production npm workflow's SBOM job without broadening permissions for build or publish jobs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): grant contents:write to publish..."](https://github.com/lgtm-hq/turbo-themes/commit/15056f5a704ae186f5a0fff879855f86e52c308e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46646167)</sub>

<!-- /greptile_comment -->