### PR TITLE
fix(deps): bump postcss to 8.5.12 for GHSA-6g55-p6wh-862q

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -189,7 +189,7 @@
     "minimatch": "10.2.5",
     "path-to-regexp": "8.4.2",
     "picomatch": "4.0.4",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "qs": "6.15.2",
     "sharp": "0.35.0",
     "shell-quote": "1.9.0",
@@ -1720,7 +1720,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postcss-calc": ["postcss-calc@10.1.1", "", { "dependencies": { "postcss-selector-parser": "^7.0.0", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.4.38" } }, "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw=="],
 

--- a/examples/tailwind/bun.lock
+++ b/examples/tailwind/bun.lock
@@ -6,7 +6,7 @@
       "name": "turbo-themes-tailwind-example",
       "devDependencies": {
         "autoprefixer": "10.4.27",
-        "postcss": "8.5.10",
+        "postcss": "8.5.12",
         "tailwindcss": "3.4.19",
         "vite": "8.0.7",
       },
@@ -14,7 +14,7 @@
   },
   "overrides": {
     "esbuild": "0.28.0",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -197,7 +197,7 @@
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 

--- a/examples/tailwind/package.json
+++ b/examples/tailwind/package.json
@@ -9,12 +9,12 @@
   },
   "devDependencies": {
     "autoprefixer": "10.4.27",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "tailwindcss": "3.4.19",
     "vite": "8.0.7"
   },
   "overrides": {
     "esbuild": "0.28.0",
-    "postcss": "8.5.10"
+    "postcss": "8.5.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "happy-dom": "20.9.0",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "ws": "8.20.1",
     "shell-quote": "1.9.0",
     "js-yaml": "4.3.0",


### PR DESCRIPTION
Fixes the osv-scanner gate failure from GHSA-6g55-p6wh-862q (postcss 8.5.10). Bumps both the root lockfile (overrides) and the examples/tailwind lockfile (deps + overrides) to 8.5.12. Gate verified green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PostCSS version used by the Tailwind example and project configuration.
  * Improved consistency across development tooling dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates PostCSS from 8.5.10 to 8.5.12 to address GHSA-6g55-p6wh-862q.
- Pins the root dependency override to PostCSS 8.5.12.
- Updates the standalone Tailwind example dependency and override.
- Regenerates both Bun lockfiles with the matching version and integrity metadata.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the manifests and lockfiles consistently resolve PostCSS 8.5.12.

The dependency override, standalone example dependency, and both Bun lockfile resolutions remain synchronized, with no changed-code-triggered functional or security defect identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Updates the repository-wide PostCSS override from 8.5.10 to 8.5.12. |
| bun.lock | Regenerates the root PostCSS resolution and integrity metadata for 8.5.12. |
| examples/tailwind/package.json | Updates the Tailwind example's direct PostCSS dependency and override to 8.5.12. |
| examples/tailwind/bun.lock | Regenerates the standalone Tailwind example lockfile for PostCSS 8.5.12. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): bump postcss to 8.5.12 for GH..."](https://github.com/lgtm-hq/turbo-themes/commit/d4bd5ef3fad8a89950ec53845da3e8a43e867569) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46785459)</sub>

<!-- /greptile_comment -->