### PR TITLE
chore(lintro): define an HTML lint policy and re-enable html-validate

### DIFF
--- a/.github/workflows/quality-ci-main.yml
+++ b/.github/workflows/quality-ci-main.yml
@@ -32,9 +32,13 @@ env:
 
 jobs:
   # Matrix build legs via the lgtm-ci build-artifact reusable (lgtm-ci#520).
-  # Org ruleset contexts: build / 🏗️ Build & Quality Checks (20) and (22).
-  # Matrix mode appends -<node-version> to the artifact name, so the legs
-  # upload js-dist-20 / js-dist-22; downstream consumers download js-dist-22.
+  # Org ruleset context: build / 🏗️ Build & Quality Checks. Matrix mode
+  # appends -<node-version> to the artifact name, so the leg uploads
+  # js-dist-22, which is what downstream consumers download.
+  #
+  # Node 20 was dropped in #813: it is end-of-life, README and CONTRIBUTING
+  # already advertise Node 22+, every other workflow pins 22 or 24, and
+  # html-validate (enabled in #787) requires Node ^22.22.0 || >= 24.8.0.
   # The node-22-only reporting side effects of the old matrix job (Codecov,
   # coverage comment/badges, Pages coverage-html, SBOM artifact) are not
   # expressible through the reusable's inputs and live in the reporting job.
@@ -43,7 +47,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-artifact.yml@ee8484ca71db3a2c2c33da6128bbf2330fcd7c88 # v0.59.2
     with:
       job-name: '🏗️ Build & Quality Checks'
-      node-version-matrix: '["20","22"]'
+      node-version-matrix: '["22"]'
       build-command: ./scripts/ci/bootstrap-build-quick.sh
       artifact-name: js-dist
       artifact-path: dist

--- a/.github/workflows/quality-lintro.yml
+++ b/.github/workflows/quality-lintro.yml
@@ -22,9 +22,9 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: '🛠️ Lintro Code Quality'
-      # py-lintro 0.91.48 pinned to immutable digest for reproducibility
+      # py-lintro 0.91.49 pinned to immutable digest for reproducibility
       # yamllint disable-line rule:line-length
-      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.91.48@sha256:d536f15578f28801c0362c6da1f008368c2144d5dc64223e17b4b05b7db9b919
+      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738
       runner-image: ubuntu-24.04
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -64,9 +64,9 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: '🔐 Security Audit'
-      # py-lintro 0.91.48 pinned to immutable digest for reproducibility
+      # py-lintro 0.91.49 pinned to immutable digest for reproducibility
       # yamllint disable-line rule:line-length
-      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.91.48@sha256:d536f15578f28801c0362c6da1f008368c2144d5dc64223e17b4b05b7db9b919
+      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738
       runner-image: ubuntu-24.04
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://html-validate.org/schemas/config.json",
+  "root": true,
+  "extends": ["html-validate:recommended"],
+  "rules": {
+    "void-style": ["error", { "style": "selfclosing" }],
+    "doctype-style": ["error", { "style": "lowercase" }]
+  }
+}

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -106,22 +106,36 @@ tools:
   bandit:
     enabled: true
 
-  # html-validate - disabled: lintro 0.91.9 points it at files the previous
-  # image never covered, and there is no clean subset to keep it on — all 14
-  # HTML files report findings, and the Vue single-file components cannot pass
-  # at all because they are parsed as raw HTML (<Card> is not a valid element
-  # name, <slot> must not be self-closed).
+  # html-validate - HTML linting (rules in .htmlvalidate.json)
   #
-  # The .html findings also conflict with the repo's own Prettier output:
-  # void-style wants <meta> where Prettier writes <meta />. Settling that, plus
-  # Vue-aware parsing and an .htmlvalidate.json scope, is a policy decision
-  # rather than a dependency bump, so it is tracked separately.
+  # Scope: the hand-authored `.html` documents under `examples/` plus the two
+  # CI report templates in `scripts/ci/templates/`. Vue single-file components
+  # are out of scope.
   #
-  # In the build job the tool does not even run: lintro shells
-  # `bunx html-validate@latest`, which aborts under Bun with
-  # "TypeError: fs.globSync is not a function".
+  # Why Vue SFCs are out of scope: html-validate parses `.vue` files as raw
+  # HTML, so every SFC feature reads as a defect — `<Card>` is reported as an
+  # invalid element name and a lowercase violation, and `<slot />` / `<div />`
+  # as illegal self-closing tags. Making them pass would need a Vue-aware
+  # transform that the pinned py-lintro image does not ship. Vue templates are
+  # already checked by `@vue/compiler-sfc` during `bun run build`, so nothing
+  # goes unchecked. lintro always hands html-validate the discovered `.vue`
+  # files, so the exclusion is declared where html-validate itself resolves it:
+  # `examples/vue/src/.htmlvalidate.json` and
+  # `examples/stackblitz/vue/src/.htmlvalidate.json` set `root: true` with an
+  # empty rule set, which stops config inheritance for those directories.
+  #
+  # Rule policy (see .htmlvalidate.json):
+  # - `void-style` is set to `selfclosing`, and `doctype-style` to `lowercase`,
+  #   because Prettier is this repo's authoritative HTML formatter and emits
+  #   `<meta charset="utf-8" />` and `<!doctype html>`. The defaults of both
+  #   rules contradict that output, so leaving them at default would make
+  #   `lintro fmt` and `lintro chk` permanently disagree. Formatting authority
+  #   stays with Prettier; html-validate keeps the correctness rules.
+  # - Every other `html-validate:recommended` rule is left at its default and
+  #   the sources were fixed instead: duplicate attributes, implicit button
+  #   types, a missing password `autocomplete`, and an inline style.
   html_validate:
-    enabled: false
+    enabled: true
 
   # Hadolint - Dockerfile linter (defaults above or .hadolint.yaml)
   hadolint:

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -129,8 +129,8 @@ tools:
   #   because Prettier is this repo's authoritative HTML formatter and emits
   #   `<meta charset="utf-8" />` and `<!doctype html>`. The defaults of both
   #   rules contradict that output, so leaving them at default would make
-  #   `lintro fmt` and `lintro chk` permanently disagree. Formatting authority
-  #   stays with Prettier; html-validate keeps the correctness rules.
+  #   `bun run lint:fix` and `bun run lint` permanently disagree. Formatting
+  #   authority stays with Prettier; html-validate keeps the correctness rules.
   # - Every other `html-validate:recommended` rule is left at its default and
   #   the sources were fixed instead: duplicate attributes, implicit button
   #   types, a missing password `autocomplete`, and an inline style.

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "concurrently": "9.2.1",
         "cssnano": "7.1.9",
         "happy-dom": "20.9.0",
+        "html-validate": "11.5.6",
         "http-server": "14.1.1",
         "husky": "9.1.7",
         "js-yaml": "4.3.0",
@@ -372,6 +373,8 @@
 
     "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
 
+    "@html-validate/stylish": ["@html-validate/stylish@6.0.0", "", {}, "sha512-d1/lI3qIXhGVJF3+MmKEBn1dRX6U4Z+BDaOdDI3E6SXcO+OQ7hC/3mSo6BIjwQlcuV6NdDOKm6QCrzIQL1EezQ=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.0", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.0" }, "os": "darwin", "cpu": "arm64" }, "sha512-ZgaYEwaj+lx/5n4W8GmZ2IYz0PQHjN5eqRcfijWGB+2Aq7ZInZGa0qJyAn6DEtyLuWHRSrmWOqT9q3qqTBvmUQ=="],
@@ -691,6 +694,8 @@
     "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@sidvind/better-ajv-errors": ["@sidvind/better-ajv-errors@7.0.0", "", { "peerDependencies": { "ajv": "^8.0.0" } }, "sha512-imVsp5D3KxJ8+uUmu2dsLKnFg3qdX952v/L1gZoCa0NO2ivhQWHMpYM2KmpFrRXHWFjlqkNZ/935nxiTqXEi1A=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
@@ -1270,6 +1275,8 @@
 
     "html-tags": ["html-tags@5.1.0", "", {}, "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ=="],
 
+    "html-validate": ["html-validate@11.5.6", "", { "dependencies": { "@html-validate/stylish": "^6.0.0", "@sidvind/better-ajv-errors": "7.0.0", "ajv": "^8.0.0", "kleur": "^4.1.0", "prompts": "^2.0.0", "semver": "^7.0.0" }, "peerDependencies": { "@jest/globals": "^29.0.3 || ^30.0.0", "@vitest/expect": "^3.0.0 || ^4.0.1", "jest": "^29.0.3 || ^30.0.0", "jest-snapshot": "^29.0.3 || ^30.0.0", "vitest": "^3.0.0 || ^4.0.1" }, "optionalPeers": ["@jest/globals", "@vitest/expect", "jest", "jest-snapshot", "vitest"], "bin": { "html-validate": "bin/html-validate.mjs" } }, "sha512-8ZmIQwN9EQ+FtRcg9Z4voGh4CcFB15nNKSIhc41SxXvFeIza4EzkrBtxl1B0bHerZKCRSWLzWuHWYjYhXZFY0Q=="],
+
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
@@ -1393,6 +1400,8 @@
     "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
@@ -1737,6 +1746,8 @@
     "process-ancestry": ["process-ancestry@0.1.0", "", {}, "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
@@ -2265,6 +2276,8 @@
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "puppeteer-core/devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
 

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -133,8 +133,7 @@
             -->
             <select
               id="theme-selector"
-              class="form-select form-select-sm"
-              style="width: auto"
+              class="form-select form-select-sm w-auto"
               aria-label="Select theme"
             ></select>
           </label>
@@ -150,12 +149,12 @@
         </div>
         <div class="card-body">
           <div class="d-flex flex-wrap gap-2">
-            <button class="btn btn-primary">Primary</button>
-            <button class="btn btn-success">Success</button>
-            <button class="btn btn-danger">Danger</button>
-            <button class="btn btn-warning">Warning</button>
-            <button class="btn btn-info">Info</button>
-            <button class="btn btn-secondary">Secondary</button>
+            <button type="button" class="btn btn-primary">Primary</button>
+            <button type="button" class="btn btn-success">Success</button>
+            <button type="button" class="btn btn-danger">Danger</button>
+            <button type="button" class="btn btn-warning">Warning</button>
+            <button type="button" class="btn btn-info">Info</button>
+            <button type="button" class="btn btn-secondary">Secondary</button>
           </div>
         </div>
       </section>
@@ -244,6 +243,7 @@
               <label for="inputPassword" class="form-label">Password</label>
               <input
                 type="password"
+                autocomplete="current-password"
                 class="form-control"
                 id="inputPassword"
                 placeholder="Password"

--- a/examples/html-vanilla-css-only/index.html
+++ b/examples/html-vanilla-css-only/index.html
@@ -1,10 +1,7 @@
 <!doctype html>
 <html
   lang="en"
-  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light one-dark one-light terminal"
-  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn radix-slate-dark radix-slate-light radix-mauve-dark radix-mauve-light tokyo-night-storm tokyo-night-dark tokyo-night-light"
-  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula everforest-dark-hard everforest-dark everforest-dark-soft everforest-light-hard everforest-light everforest-light-soft gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light"
-  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light kanagawa-wave kanagawa-dragon kanagawa-lotus ayu-dark ayu-mirage ayu-light"
+  data-theme-whitelist="catppuccin-mocha catppuccin-macchiato catppuccin-frappe catppuccin-latte dracula gruvbox-dark-hard gruvbox-dark gruvbox-dark-soft gruvbox-light-hard gruvbox-light gruvbox-light-soft github-dark github-light bulma-dark bulma-light nord solarized-dark solarized-light rose-pine rose-pine-moon rose-pine-dawn tokyo-night-storm tokyo-night-dark tokyo-night-light one-dark one-light terminal radix-slate-dark radix-slate-light radix-mauve-dark radix-mauve-light everforest-dark-hard everforest-dark everforest-dark-soft everforest-light-hard everforest-light everforest-light-soft kanagawa-wave kanagawa-dragon kanagawa-lotus ayu-dark ayu-mirage ayu-light"
 >
   <head>
     <meta charset="UTF-8" />
@@ -178,9 +175,9 @@
     <section class="card">
       <h2>Buttons</h2>
       <div class="buttons">
-        <button class="btn btn-primary">Primary</button>
-        <button class="btn btn-success">Success</button>
-        <button class="btn btn-danger">Danger</button>
+        <button type="button" class="btn btn-primary">Primary</button>
+        <button type="button" class="btn btn-success">Success</button>
+        <button type="button" class="btn btn-danger">Danger</button>
       </div>
     </section>
 

--- a/examples/html-vanilla/index.html
+++ b/examples/html-vanilla/index.html
@@ -199,9 +199,9 @@
     <section class="card">
       <h2>Buttons</h2>
       <div class="buttons">
-        <button class="btn btn-primary">Primary</button>
-        <button class="btn btn-success">Success</button>
-        <button class="btn btn-danger">Danger</button>
+        <button type="button" class="btn btn-primary">Primary</button>
+        <button type="button" class="btn btn-success">Success</button>
+        <button type="button" class="btn btn-danger">Danger</button>
       </div>
     </section>
 

--- a/examples/stackblitz/bootstrap/index.html
+++ b/examples/stackblitz/bootstrap/index.html
@@ -71,11 +71,11 @@
           <h5 class="card-title mb-0">Buttons</h5>
         </div>
         <div class="card-body">
-          <button class="btn btn-primary">Primary</button>
-          <button class="btn btn-success">Success</button>
-          <button class="btn btn-danger">Danger</button>
-          <button class="btn btn-warning">Warning</button>
-          <button class="btn btn-info">Info</button>
+          <button type="button" class="btn btn-primary">Primary</button>
+          <button type="button" class="btn btn-success">Success</button>
+          <button type="button" class="btn btn-danger">Danger</button>
+          <button type="button" class="btn btn-warning">Warning</button>
+          <button type="button" class="btn btn-info">Info</button>
         </div>
       </div>
 
@@ -107,7 +107,12 @@
           </div>
           <div class="mb-3">
             <label for="password" class="form-label">Password</label>
-            <input type="password" class="form-control" id="password" />
+            <input
+              type="password"
+              autocomplete="current-password"
+              class="form-control"
+              id="password"
+            />
           </div>
           <button type="submit" class="btn btn-primary">Submit</button>
         </div>

--- a/examples/stackblitz/html-vanilla/index.html
+++ b/examples/stackblitz/html-vanilla/index.html
@@ -107,9 +107,9 @@
 
     <div class="card">
       <h2>Buttons</h2>
-      <button class="btn btn-primary">Primary</button>
-      <button class="btn btn-success">Success</button>
-      <button class="btn btn-danger">Danger</button>
+      <button type="button" class="btn btn-primary">Primary</button>
+      <button type="button" class="btn btn-success">Success</button>
+      <button type="button" class="btn btn-danger">Danger</button>
     </div>
 
     <script>

--- a/examples/stackblitz/tailwind/index.html
+++ b/examples/stackblitz/tailwind/index.html
@@ -69,13 +69,22 @@
       <div class="bg-surface border border-default rounded-lg p-6 mb-4">
         <h2 class="text-xl font-semibold mb-4">Buttons</h2>
         <div class="flex gap-2">
-          <button class="bg-primary text-inverse px-4 py-2 rounded font-medium">
+          <button
+            type="button"
+            class="bg-primary text-inverse px-4 py-2 rounded font-medium"
+          >
             Primary
           </button>
-          <button class="bg-success text-inverse px-4 py-2 rounded font-medium">
+          <button
+            type="button"
+            class="bg-success text-inverse px-4 py-2 rounded font-medium"
+          >
             Success
           </button>
-          <button class="bg-danger text-inverse px-4 py-2 rounded font-medium">
+          <button
+            type="button"
+            class="bg-danger text-inverse px-4 py-2 rounded font-medium"
+          >
             Danger
           </button>
         </div>

--- a/examples/stackblitz/vue/src/.htmlvalidate.json
+++ b/examples/stackblitz/vue/src/.htmlvalidate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://html-validate.org/schemas/config.json",
+  "root": true,
+  "extends": [],
+  "rules": {}
+}

--- a/examples/tailwind/index.html
+++ b/examples/tailwind/index.html
@@ -77,9 +77,15 @@
     <section class="bg-surface border border-default rounded-lg p-4 mb-4 shadow-sm">
       <h2 class="text-xl font-semibold mb-2">Buttons</h2>
       <div class="flex gap-2 flex-wrap">
-        <button class="bg-primary text-inverse px-4 py-2 rounded">Primary</button>
-        <button class="bg-success text-inverse px-4 py-2 rounded">Success</button>
-        <button class="bg-danger text-inverse px-4 py-2 rounded">Danger</button>
+        <button type="button" class="bg-primary text-inverse px-4 py-2 rounded">
+          Primary
+        </button>
+        <button type="button" class="bg-success text-inverse px-4 py-2 rounded">
+          Success
+        </button>
+        <button type="button" class="bg-danger text-inverse px-4 py-2 rounded">
+          Danger
+        </button>
       </div>
     </section>
 

--- a/examples/vue/src/.htmlvalidate.json
+++ b/examples/vue/src/.htmlvalidate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://html-validate.org/schemas/config.json",
+  "root": true,
+  "extends": [],
+  "rules": {}
+}

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "concurrently": "9.2.1",
     "cssnano": "7.1.9",
     "happy-dom": "20.9.0",
+    "html-validate": "11.5.6",
     "http-server": "14.1.1",
     "husky": "9.1.7",
     "js-yaml": "4.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 
 [dependency-groups]
 dev = [
-  "lintro==0.91.48",
+  "lintro==0.91.49",
   "pytest>=9.0,<10.0",
   "assertpy>=1.1",
   # Formatters/linters lintro drives. Pinned at or above lintro 0.91.9's

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "lintro"
-version = "0.91.48"
+version = "0.91.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -187,9 +187,9 @@ dependencies = [
     { name = "rich" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/b6/b0a2ca76bca1b542be1847c2c014240d13c3cdab2b4b8e04389fae11f0c2/lintro-0.91.48.tar.gz", hash = "sha256:650e4df5f84b0bc13ffa84e0d2eb15f0d0f959d9dc0ef9bb4ebee314f2d9a51a", size = 2800885, upload-time = "2026-07-26T07:17:33.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/3f/5a4331055771f67c16836b37e4f77d6311f62fc8a35c13728ea9c67aa4c8/lintro-0.91.49.tar.gz", hash = "sha256:f435e153ff3f089bf88abd222173d7116e40c1dfe9a172f522029da9dd3fa3d8", size = 2811114, upload-time = "2026-07-26T10:15:27.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/5a/6a255bb6296d05d7a1af7131907786146626d3c9e11686c393318ea6a79f/lintro-0.91.48-py3-none-any.whl", hash = "sha256:e5f056d127bc2d0fa02da0bf3820b38c3ac8bd86093e69e7671dc3357f2353f7", size = 993204, upload-time = "2026-07-26T07:17:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/08/85617951c5714650e5a0fbc8a560c0050e78284b05f5fef4943771990f34/lintro-0.91.49-py3-none-any.whl", hash = "sha256:19ae1fb3aa61f035ead903a764b5c2853ec51ffcd055f7a4d6b3a3d175161f5d", size = 996174, upload-time = "2026-07-26T10:15:26.066Z" },
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ dev = [
 dev = [
     { name = "assertpy", specifier = ">=1.1" },
     { name = "black", specifier = ">=26.3.1" },
-    { name = "lintro", specifier = "==0.91.48" },
+    { name = "lintro", specifier = "==0.91.49" },
     { name = "pytest", specifier = ">=9.0,<10.0" },
     { name = "ruff", specifier = ">=0.15.9" },
 ]


### PR DESCRIPTION
## Summary

`html-validate` was disabled in `.lintro-config.yaml` during the py-lintro
0.61 → 0.91.9 image bump (#779): the newer image pointed it at files the
previous one never covered, it reported **141 findings across 17 files** with
no repo config to judge them against, and it aborted outright in the build job.

This PR defines the missing policy, fixes the real defects it found, and turns
the tool back on.

The blocker on the tool-crash side is cleared upstream: py-lintro
[#1731](https://github.com/lgtm-hq/py-lintro/pull/1731) pins html-validate
executable resolution and passes literal paths instead of globs, shipped in
**v0.91.49**. Both digest-pinned workflow images and the local dev pin move to
0.91.49 here.

## Type

- [ ] ✨ Feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [ ] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [x] 🔨 Chore (`chore:`)

## Changes Made

### 1. py-lintro re-pinned to 0.91.49

- `quality-lintro.yml` and `security-dependency-review.yml`:
  `ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c…`
- `pyproject.toml` / `uv.lock`: `lintro==0.91.49`

### 2. New `.htmlvalidate.json` — the HTML lint policy

```json
{
  "root": true,
  "extends": ["html-validate:recommended"],
  "rules": {
    "void-style": ["error", { "style": "selfclosing" }],
    "doctype-style": ["error", { "style": "lowercase" }]
  }
}
```

**Scope.** The hand-authored `.html` documents under `examples/`, plus the two
CI report templates under `scripts/ci/templates/`. Vue single-file components
are out of scope.

**Why Vue SFCs are out of scope.** html-validate parses `.vue` files as raw
HTML, so ordinary SFC syntax reads as a defect: `<Card>` is reported as an
invalid element name *and* a lowercase violation, and `<slot />` / `<div />` as
illegal self-closing tags. A Vue-aware transform is not available in the pinned
image, and Vue templates are already type/structure-checked by
`@vue/compiler-sfc` during `bun run build`, so nothing goes unchecked. lintro
always hands html-validate every discovered `.vue` file, so the exclusion is
declared where html-validate itself resolves scope: directory-level
`examples/vue/src/.htmlvalidate.json` and
`examples/stackblitz/vue/src/.htmlvalidate.json` with `root: true` and an empty
rule set, which stops config inheritance for those directories.

**Why two rules are configured rather than fixed.** Prettier is this repo's
authoritative HTML formatter and emits `<meta charset="utf-8" />` and
`<!doctype html>`. The defaults of `void-style` (`omit`) and `doctype-style`
(`uppercase`) contradict that output, so leaving them at default would make
`lintro fmt` and `lintro chk` permanently disagree — every `fmt` run would
reintroduce `chk` failures. Formatting authority stays with Prettier;
html-validate keeps the correctness rules. No correctness rule is disabled.

### 3. Source fixes — every other rule kept its default

| Rule | Count | Resolution |
| --- | --- | --- |
| `no-implicit-button-type` | 26 | Fixed — `type="button"` added to demo buttons so they cannot implicitly submit |
| `no-dup-attr` | 3 | Fixed — genuine bug, see below |
| `autocomplete-password` | 2 | Fixed — `autocomplete="current-password"` on both password inputs |
| `no-inline-style` | 1 | Fixed — `style="width: auto"` replaced with Bootstrap's `w-auto` utility |
| `void-style` | 72 | Configured to `selfclosing` (Prettier conflict) |
| `doctype-style` | 14 | Configured to `lowercase` (Prettier conflict) |
| `element-case` / `element-name` / `no-self-closing` | 17 | Out of scope — Vue SFCs |

**141 total: 32 source fixes, 86 reconciled with Prettier, 17 out of scope.**

The `no-dup-attr` finding was a real latent bug.
`examples/html-vanilla-css-only/index.html` declared `data-theme-whitelist`
four separate times on `<html>`, accumulated across theme-family PRs. Only the
first is ever read by the DOM, so the CSS-only demo silently rejected every
theme added after that first list. Merged into one attribute holding the union
of all four, which is exactly the current 43-theme catalogue in
`schema/tokens/themes/`.

### 4. `html_validate` re-enabled

`.lintro-config.yaml` flips `enabled: false` → `true`, and the stale
"disabled because…" comment is replaced with the policy rationale above.

## Closes

- Closes #787
- Relates to #788

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`bun run test` — 3602 passed)

### Test Coverage

- [x] Coverage maintained or improved
- [x] No decrease in code coverage
- [x] Coverage report reviewed

## Quality Checks

- [x] Linting passes (`uv run lintro chk` — 0 issues, health 100/100)
- [x] Formatting passes (`uv run lintro fmt`)
- [x] TypeScript build successful (`bun run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

**No new tool dropouts on 0.91.49.** A side-by-side `lintro chk` on 0.91.48 and
0.91.49 against this tree produced an identical skip/failure list
(`astro-check` and `commitlint` below local minimums, `pip-audit` failing on a
local `ensurepip` abort, `tsc`/`vue-tsc`/`vale`/`idiom-review` as configured).

## Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [x] Comments added to complex code
- [ ] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided below

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

## Additional Context

The `type="button"` additions are behaviour-neutral for the demos (none of the
patched buttons sit inside a `<form>` except where `type="submit"` was already
explicit) and produce no visual change, so the e2e visual snapshots for
`html-vanilla` and `tailwind` are unaffected.

### 5. `html-validate` pinned as a dev dependency

The first CI run on this branch showed the bare-runner `build` job still
aborting with `TypeError: fs.globSync is not a function`. py-lintro#1731 pins
the *version* resolved through `bunx` but the bunx fallback still executes
html-validate under Bun, whose `node:fs` has no `globSync` — and
html-validate's CLI calls it unconditionally while expanding its file
arguments, before any path handling.

py-lintro 0.91.49 also makes lintro prefer a target-local
`node_modules/.bin` executable over that fallback. Pinning
`html-validate@11.5.6` as a devDependency gives it one: the bin shim is
`#!/usr/bin/env node`, so it runs under Node and `globSync` exists. This
matches how `stylelint`, `oxlint` and `oxfmt` are already pinned in this repo,
and fixes the version CI and local runs agree on.

### 6. Node 20 dropped from the build matrix (#813)

The pinned devDependency was still not enough on one CI leg. `quality-ci-main.yml`
built over `node-version-matrix: '["20","22"]'`, and `html-validate@11.5.6` —
py-lintro 0.91.49's *enforced minimum*, so it cannot be pinned lower without
lintro skipping the tool entirely — declares
`engines: { node: "^22.22.0 || >= 24.8.0" }`. Its CLI calls `fs.globSync`
unconditionally while expanding file arguments, and `fs.globSync` does not exist
before Node 22. The Node 22 leg passed; the Node 20 leg aborted.

Node 20 was already the only Node 20 target left in the repository: `README.md`
advertises Node 22, `CONTRIBUTING.md` states Node 22+, every other workflow pins
`22` (or `24` for the npm provenance publish leg), and Node 20 reached
end-of-life on 2026-04-30. Both matrix legs reported under the same check name,
so no org ruleset change is required.

Tracked as #813. Flagging it explicitly for review: it is a change to the
supported-runtime matrix, not part of the HTML lint policy, and it is included
here only because #787 cannot land without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added HTML validation with recommended rules, including lowercase doctypes and self-closing void elements.
  - Expanded supported theme options in the vanilla CSS example.

- **Bug Fixes**
  - Prevented example buttons from unintentionally submitting forms.
  - Improved password field autofill behavior.

- **Chores**
  - Updated automated quality checks and build validation to use current supported tooling.
  - Standardized HTML formatting across example pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Defines and enables an HTML validation policy across the repository.
- Pins lintro 0.91.49 and html-validate 11.5.6 for consistent local and CI execution.
- Excludes Vue single-file components from raw HTML validation through directory-level configurations.
- Corrects HTML validation findings in examples, including duplicate attributes, implicit button types, password autocomplete, and inline styling.
- Consolidates the CSS-only demo’s theme whitelist.
- Removes the end-of-life Node 20 build leg and retains Node 22.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .htmlvalidate.json | Adds the recommended HTML validation policy with formatting-compatible void-element and doctype rules. |
| .lintro-config.yaml | Re-enables html-validate and documents its intended scope and Vue exclusions. |
| .github/workflows/quality-ci-main.yml | Removes the Node 20 matrix leg, consistent with the repository’s documented Node 22+ support. |
| package.json | Pins html-validate as a development dependency so lintro resolves a Node-executed local binary. |
| examples/html-vanilla-css-only/index.html | Consolidates duplicate whitelist attributes into a complete set matching all 43 canonical theme identifiers. |
| examples/vue/src/.htmlvalidate.json | Stops root HTML rules from applying to Vue single-file components in the main Vue example. |
| examples/stackblitz/vue/src/.htmlvalidate.json | Stops root HTML rules from applying to Vue single-file components in the StackBlitz example. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(lintro): reference the repository&#39;s..."](https://github.com/lgtm-hq/turbo-themes/commit/de7e62605c6c0ea8a14d76138ab9c1289b5862ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47357881)</sub>

<!-- /greptile_comment -->