### PR TITLE
chore(pkg): declare supported Node range via engines

### DIFF
--- a/docs/LOCAL-CI-SETUP.md
+++ b/docs/LOCAL-CI-SETUP.md
@@ -14,7 +14,7 @@ bun run ci:full
 # Default CI (same as quick)
 bun run ci
 
-# Run CI in Docker (CI-parity: Ubuntu + Ruby 3.3 + Node 20)
+# Run CI in Docker (CI-parity: Ubuntu + Ruby 3.3 + Node 22)
 bun run ci:docker
 
 # Full CI in Docker (includes Lighthouse --full builds)

--- a/docs/LOCAL-CI-SETUP.md
+++ b/docs/LOCAL-CI-SETUP.md
@@ -135,7 +135,7 @@ bundle install
 ### CI Environment
 
 - Ubuntu 24.04
-- Node.js 18/20/22
+- Node.js 22/24
 - Ruby 3.3/3.4
 - GitHub Actions
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "type": "module",
   "private": false,
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "workspaces": [
     "packages/*",
     "packages/adapters/*",


### PR DESCRIPTION
## Summary

Root `package.json` had **no `engines` field at all**. #812 dropped the Node 20 leg from
the build matrix (`node-version-matrix` went `'["20","22"]'` → `'["22"]'`) because
re-enabling html-validate required `html-validate@11.5.6`, which declares
`engines: ^22.22.0 || >= 24.8.0` and uses `fs.globSync` (Node 22+). CI stopped testing
Node 20, but consumers were never told — npm had nothing to warn on.

This declares the range we actually support, and cleans up two stale Node references in
the local CI docs.

## Changes

- `package.json` — add `"engines": { "node": ">=22.12.0" }`.
- `docs/LOCAL-CI-SETUP.md` — Docker CI comment `Node 20` → `Node 22` (the Dockerfile has
  always installed 22.x); CI Environment list `Node.js 18/20/22` → `Node.js 22/24`.

## Why `>=22.12.0`

Derived from what the repo already claims and tests, not copied from html-validate:

| Source | Says |
| --- | --- |
| `README.md` | Node.js 22 badge; "**Node.js** 22+ (alternative to Bun)" |
| `CONTRIBUTING.md` | "**Node.js** (alternative): 22+ with npm" |
| `apps/site/package.json` | already declares `"node": ">=22.12.0"` |
| `Dockerfile` | installs `nodejs=22.*` |
| Workflows | `quality-ci-main.yml` matrix `["22"]`; `publish-npm.yml` also smoke-tests on `24` |

`>=22.12.0` matches `apps/site` exactly, so the repo now says one thing everywhere.
22.12.0 is the first Node 22 LTS release, which also makes it a sensible floor for a
`"type": "module"` package.

**Deliberately not** `^22.22.0 || >= 24.8.0`. That is html-validate's constraint, and
html-validate is a **devDependency** here — it never reaches consumers. Pushing a
lint-tool floor onto everyone who installs the theme pack would be inaccurate. Anyone
building this repo gets html-validate's own `engines` warning from their own install.

## Workspace packages: root only, deliberately

Checked every workspace `package.json`:

- `packages/core`, `packages/css`, `packages/theme-selector` — all `"private": true`
- `packages/adapters/{bootstrap,bulma,home-assistant,tailwind}` — all `"private": true`
- `examples/*` — all `"private": true`
- `apps/site` — `"private": true`, and **already** declares `>=22.12.0`

Only the root package is `"private": false` and published to npm. `engines` on a package
that never leaves the repo is advisory at best, so adding it to the eight private
packages would be noise without a consumer to signal. The one non-root package that had a
reason to declare it already does, and the root now matches it.

## `.nvmrc` / `.node-version`

Neither exists in this repo, nor `.tool-versions` or `mise.toml` — the Node version is
pinned per-workflow via `actions/setup-node` and in the `Dockerfile`. Nothing to align.
Adding a version file would be a new convention rather than a consistency fix, so it is
out of scope here.

## Consequence — please read

This is a behaviour change for consumers, and it is the intended one:

- **npm** prints an `EBADENGINE` warning on install under Node < 22.12.0. If a consumer
  has `engine-strict=true` in their `.npmrc`, the install **fails** rather than warns.
- **Bun**, **pnpm** and **Yarn** treat this differently (bun does not enforce by default;
  pnpm errors under `engine-strict`), so the felt impact varies by package manager.

That is honest signalling: CI has not tested Node 20 since #812, so claiming support by
silence was worse. Anyone on Node 20 was already unsupported — now they find out at
install time instead of at runtime. No runtime code changed, so nothing that works today
stops working; it only gains a warning.

## Verification

- `bun install --frozen-lockfile` — clean, no lockfile drift
- `bun run build` — full build succeeds
- `npm pack --dry-run` — packs 517 files / 597.3 kB, `engines` present in the manifest
- `uv run lintro fmt` + `uv run lintro chk` — 0 issues, health 100/100 (full tool set, no
  `--tools` filtering)
- `git status` clean after build — no generated-artifact drift

## Review

Pre-push CodeRabbit (0 findings) and Greptile. Greptile raised one P1 — the CI Environment
section in `docs/LOCAL-CI-SETUP.md` still listing Node 18/20 — which was correct and is
fixed in `0ce2ff0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local CI setup guidance to reflect Node.js 22/24 compatibility.

* **Chores**
  * Added a minimum supported Node.js version of 22.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Declares Node.js 22.12 or newer for the published root package and updates local CI documentation to reflect the Node 22/24 workflow environment.
- Adds `engines.node` to the root package manifest.
- Corrects the documented Docker Node version to 22.
- Replaces obsolete Node 18/20 CI references with Node 22/24.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the package compatibility declaration and documentation aligned to the repository's existing Node support policy.

The new engine range applies to the published root package and matches the documented Node 22+ requirement, while the updated CI documentation reflects Node 22 for builds and Node 24 for publishing.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds the intended `>=22.12.0` Node engine requirement to the published root package, consistent with the repository's documented and tested support policy. |
| docs/LOCAL-CI-SETUP.md | Updates stale Node version references to match the Docker image and active CI and publishing workflows. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(ci): drop Node 18/20 from the local..."](https://github.com/lgtm-hq/turbo-themes/commit/0ce2ff00bd6f388f38c1a08dbab65292c2d30c26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47371620)</sub>

<!-- /greptile_comment -->