### PR TITLE
fix(ci): treat merge-queue push rejection as benign in release version PR

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -179,6 +179,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_BRANCH: release/version-${{ steps.version.outputs.next_version }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           PR_TITLE: ${{ steps.version.outputs.pr_title }}
           PR_BODY_FILE: ${{ steps.version.outputs.pr_body_file }}
         run: ./scripts/ci/retry-release-branch-push.sh
@@ -187,6 +188,8 @@ jobs:
         if: >-
           steps.create_pr.outcome == 'failure' &&
           steps.push_retry.outcome != 'success'
+        env:
+          SKIPPED_MERGE_QUEUE: ${{ steps.push_retry.outputs.skipped-merge-queue }}
         run: ./scripts/ci/fail-release-push.sh
 
       - name: Request CODEOWNER review
@@ -215,4 +218,5 @@ jobs:
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           PUSH_RETRY_TRIGGERED: ${{ steps.create_pr.outcome == 'failure' && steps.push_retry.outcome == 'success' }}
           PUSH_FAILED: ${{ steps.create_pr.outcome == 'failure' && steps.push_retry.outcome != 'success' }}
+          SKIPPED_MERGE_QUEUE: ${{ steps.push_retry.outputs.skipped-merge-queue }}
         run: ./scripts/ci/generate-version-pr-summary.sh

--- a/scripts/ci/fail-release-push.sh
+++ b/scripts/ci/fail-release-push.sh
@@ -9,6 +9,11 @@
 #                        because the release branch is already queued for
 #                        merging (#817). That is a benign outcome, not a
 #                        failure — every other outcome still fails loudly.
+#                        Defence in depth: the workflow already keeps this step
+#                        from running on the skip path (the retry step exits 0,
+#                        so its outcome is 'success'). This guard exists so the
+#                        classification cannot be turned into a red run by a
+#                        later change to that step condition.
 
 set -euo pipefail
 

--- a/scripts/ci/fail-release-push.sh
+++ b/scripts/ci/fail-release-push.sh
@@ -3,8 +3,19 @@
 # Purpose: Terminal failure marker for the release version-PR workflow —
 # invoked when both the primary branch push and the transient-rejection
 # retry have failed.
+#
+# Env vars:
+#   SKIPPED_MERGE_QUEUE  'true' when the retry deliberately skipped the push
+#                        because the release branch is already queued for
+#                        merging (#817). That is a benign outcome, not a
+#                        failure — every other outcome still fails loudly.
 
 set -euo pipefail
+
+if [ "${SKIPPED_MERGE_QUEUE:-}" = "true" ]; then
+  echo "⏭️  Release branch push skipped — the branch is already in the merge queue."
+  exit 0
+fi
 
 echo "❌ Release branch push failed — primary attempt and transient retry both failed." >&2
 exit 1

--- a/scripts/ci/generate-version-pr-summary.sh
+++ b/scripts/ci/generate-version-pr-summary.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # Generate a GitHub Step Summary for the Release Version PR workflow.
-# Expected env vars: BUMP_NEEDED, NEXT_VERSION, PUSH_FAILED, PUSH_RETRY_TRIGGERED
+# Expected env vars: BUMP_NEEDED, NEXT_VERSION, PUSH_FAILED, PUSH_RETRY_TRIGGERED,
+# SKIPPED_MERGE_QUEUE
 set -euo pipefail
 
 {
   echo "## Release Version PR Status"
   if [ "${BUMP_NEEDED:-}" = "true" ]; then
-    if [ "${PUSH_FAILED:-}" = "true" ]; then
+    if [ "${SKIPPED_MERGE_QUEUE:-}" = "true" ]; then
+      echo "⏭️ **Skipped** — release branch for v${NEXT_VERSION} is already in the merge queue."
+      echo ""
+      echo "The queued PR already carries this version bump, so the push was not needed."
+      echo "Merging it triggers a fresh run that recomputes the next version."
+    elif [ "${PUSH_FAILED:-}" = "true" ]; then
       echo "❌ **Push failed** — release branch for v${NEXT_VERSION} could not be pushed."
       echo ""
       echo "Both the primary push attempt and the transient-error retry failed."

--- a/scripts/ci/push-with-retry.sh
+++ b/scripts/ci/push-with-retry.sh
@@ -8,8 +8,23 @@
 #   MAX_RETRIES         Maximum push attempts (default: 3)
 #   INITIAL_DELAY       Seconds before first retry (default: 5)
 #   BACKOFF_MULTIPLIER  Delay multiplier for each retry (default: 2)
+#
+# Exit codes:
+#   0   Push succeeded
+#   75  Push rejected because the branch is enrolled in a merge queue (#817).
+#       This is NOT transient on the retry timescale — the ref only unblocks when
+#       the queued PR merges or is dequeued — so the retry loop stops immediately
+#       and lets the caller decide whether the rejection is benign. Every other
+#       rejection, including a generic GH006 protected-branch/non-fast-forward
+#       one, keeps retrying.
+#   1   Push failed after MAX_RETRIES attempts (or bad configuration)
 
 set -euo pipefail
+
+# Distinct exit code for the merge-queue classification. Callers that know the
+# push is redundant in that situation (e.g. retry-release-branch-push.sh) may
+# treat it as benign; callers that do not will still see a non-zero exit.
+readonly MERGE_QUEUE_EXIT_CODE=75
 
 REMOTE="${1:?usage: push-with-retry.sh <remote> <refspec>}"
 REFSPEC="${2:?usage: push-with-retry.sh <remote> <refspec>}"
@@ -27,14 +42,36 @@ attempt=1
 delay="${INITIAL_DELAY}"
 
 # Never print embedded credentials when the remote is a tokenized URL.
-REMOTE_DISPLAY="$(sed -E 's#(https?://)[^@/]+@#\1#' <<<"${REMOTE}")"
+redact_credentials() {
+  sed -E 's#(https?://)[^@/[:space:]]+@#\1#g'
+}
+
+REMOTE_DISPLAY="$(redact_credentials <<<"${REMOTE}")"
+
+# A merge-queue rejection is GH006 *plus* the merge-queue wording; a plain GH006
+# (protected branch, non-fast-forward, ...) must NOT match so it keeps retrying.
+is_merge_queue_rejection() {
+  local output="$1"
+  grep -q 'GH006' <<<"${output}" || return 1
+  grep -Eqi 'queued for merging|added to a merge queue' <<<"${output}"
+}
 
 echo "🚀 Pushing ${REFSPEC} to ${REMOTE_DISPLAY} (max ${MAX_RETRIES} attempts)..."
 
 while true; do
-  if git push --force-with-lease "${REMOTE}" "${REFSPEC}"; then
+  # Capture the push output so the rejection reason can be classified, then
+  # replay it (credentials redacted) so the logs stay as informative as before.
+  if push_output="$(git push --force-with-lease "${REMOTE}" "${REFSPEC}" 2>&1)"; then
+    redact_credentials <<<"${push_output}"
     echo "✅ Push succeeded on attempt ${attempt}"
     exit 0
+  fi
+  redact_credentials <<<"${push_output}" >&2
+
+  if is_merge_queue_rejection "${push_output}"; then
+    echo "🔀 Push rejected: '${REFSPEC}' is enrolled in a merge queue and cannot be updated."
+    echo "   Retrying cannot help — the ref unblocks only when the queued PR merges or is dequeued."
+    exit "${MERGE_QUEUE_EXIT_CODE}"
   fi
 
   if [[ ${attempt} -ge ${MAX_RETRIES} ]]; then

--- a/scripts/ci/retry-release-branch-push.sh
+++ b/scripts/ci/retry-release-branch-push.sh
@@ -65,6 +65,11 @@ if [[ ${push_status} -eq ${MERGE_QUEUE_EXIT_CODE} ]]; then
     exit 1
   fi
 
+  # This confirms the PR exists and carries the right version, not that it is
+  # still queued at this instant. That is deliberate: GitHub's own rejection is
+  # the authoritative statement that the branch was queued, and a PR dequeued in
+  # the meantime is still open with the identical v${NEXT_VERSION} bump, so
+  # skipping cannot drop the bump either way.
   QUEUED_HEAD=$(gh pr list \
     --repo "${GITHUB_REPOSITORY}" \
     --head "${RELEASE_BRANCH}" \

--- a/scripts/ci/retry-release-branch-push.sh
+++ b/scripts/ci/retry-release-branch-push.sh
@@ -8,17 +8,27 @@
 #
 # Required env vars (set by workflow step):
 #   RELEASE_BRANCH      e.g. release/version-1.2.3
+#   NEXT_VERSION        Computed next version, e.g. 1.2.3
 #   PR_TITLE            Pull request title
 #   PR_BODY_FILE        Path to file containing PR body markdown
 #   GH_TOKEN            GitHub App installation token with PR write access
 #   GITHUB_REPOSITORY   owner/repo  (injected by Actions runner)
 #   GITHUB_OUTPUT       Path to GITHUB_OUTPUT file  (injected by Actions runner)
+#
+# Outputs (GITHUB_OUTPUT):
+#   pull-request-number   Number of the created/updated PR
+#   skipped-merge-queue   'true' when the push was skipped because the release
+#                         branch is already queued for merging (#817)
 
 set -euo pipefail
 
 RELEASE_BRANCH="${RELEASE_BRANCH:?RELEASE_BRANCH is required}"
+NEXT_VERSION="${NEXT_VERSION:?NEXT_VERSION is required}"
 PR_TITLE="${PR_TITLE:?PR_TITLE is required}"
 PR_BODY_FILE="${PR_BODY_FILE:?PR_BODY_FILE is required}"
+
+# Exit code push-with-retry.sh uses for the merge-queue classification.
+readonly MERGE_QUEUE_EXIT_CODE=75
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 chmod +x "${SCRIPT_DIR}/push-with-retry.sh"
@@ -39,7 +49,43 @@ echo "🔁 Retrying push of '${RELEASE_BRANCH}' after transient rejection..."
 PUSH_URL="https://x-access-token:${GH_TOKEN:?GH_TOKEN is required}@github.com/${GITHUB_REPOSITORY}.git"
 git remote set-url --push origin "${PUSH_URL}"
 trap 'git remote set-url --delete --push origin ".*" 2>/dev/null || true' EXIT
-"${SCRIPT_DIR}/push-with-retry.sh" origin "${RELEASE_BRANCH}"
+
+push_status=0
+"${SCRIPT_DIR}/push-with-retry.sh" origin "${RELEASE_BRANCH}" || push_status=$?
+
+if [[ ${push_status} -eq ${MERGE_QUEUE_EXIT_CODE} ]]; then
+  # The branch is queued for merging, so the queued PR already carries this
+  # version bump and its merge will fire a fresh run. Skipping is only safe if
+  # that really is the case — verify before declaring the failure benign, so a
+  # mismatch can never silently drop a version bump (#817).
+  EXPECTED_BRANCH="release/version-${NEXT_VERSION}"
+  if [[ "${RELEASE_BRANCH}" != "${EXPECTED_BRANCH}" ]]; then
+    echo "❌ Refusing to skip: pushed branch '${RELEASE_BRANCH}' does not match" >&2
+    echo "   the branch expected for v${NEXT_VERSION} ('${EXPECTED_BRANCH}')." >&2
+    exit 1
+  fi
+
+  QUEUED_HEAD=$(gh pr list \
+    --repo "${GITHUB_REPOSITORY}" \
+    --head "${RELEASE_BRANCH}" \
+    --state open \
+    --json headRefName \
+    --jq '.[0].headRefName // empty')
+
+  if [[ "${QUEUED_HEAD}" != "${EXPECTED_BRANCH}" ]]; then
+    echo "❌ Refusing to skip: no open PR with head '${EXPECTED_BRANCH}' carries" >&2
+    echo "   the v${NEXT_VERSION} bump (found: '${QUEUED_HEAD:-none}')." >&2
+    exit 1
+  fi
+
+  echo "::notice title=Release branch already in merge queue::Skipping push of '${RELEASE_BRANCH}' — the queued PR already carries the v${NEXT_VERSION} bump and its merge will trigger a fresh run."
+  echo "skipped-merge-queue=true" >>"${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+if [[ ${push_status} -ne 0 ]]; then
+  exit "${push_status}"
+fi
 
 # Create or update the PR.
 echo "🔍 Checking for an existing open PR for '${RELEASE_BRANCH}'..."

--- a/test/release-push-merge-queue.test.ts
+++ b/test/release-push-merge-queue.test.ts
@@ -1,0 +1,323 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+const CI_DIR = join(__dirname, '../scripts/ci');
+const PUSH_WITH_RETRY = join(CI_DIR, 'push-with-retry.sh');
+const RETRY_RELEASE_PUSH = join(CI_DIR, 'retry-release-branch-push.sh');
+const FAIL_RELEASE_PUSH = join(CI_DIR, 'fail-release-push.sh');
+const VERSION_PR_SUMMARY = join(CI_DIR, 'generate-version-pr-summary.sh');
+
+const MERGE_QUEUE_EXIT_CODE = 75;
+
+const MERGE_QUEUE_REJECTION = [
+  'remote: error: GH006: Protected branch update failed for refs/heads/release/version-1.2.3.',
+  'remote: - A pull request for this branch has been added to a merge queue. Branches that',
+  'remote:   are queued for merging cannot be updated. To modify this branch, dequeue the',
+  'remote:   associated pull request.',
+  ' ! [remote rejected] release/version-1.2.3 -> release/version-1.2.3 (protected branch hook declined)',
+].join('\n');
+
+const GENERIC_REJECTION = [
+  'remote: error: GH006: Protected branch update failed for refs/heads/release/version-1.2.3.',
+  'remote: - Changes must be made through a pull request.',
+  ' ! [remote rejected] release/version-1.2.3 -> release/version-1.2.3 (protected branch hook declined)',
+].join('\n');
+
+let sandbox: string;
+
+/** Absolute path to the shim directory prepended to PATH for a test run. */
+function binDir(): string {
+  return join(sandbox, 'bin');
+}
+
+/** Install an executable shim on the sandboxed PATH. */
+function writeShim(name: string, body: string): void {
+  const path = join(binDir(), name);
+  writeFileSync(path, `#!/usr/bin/env bash\n${body}\n`);
+  chmodSync(path, 0o755);
+}
+
+/**
+ * Install a `git` shim whose `push` subcommand fails with the given output and
+ * records one line per attempt in $ATTEMPT_LOG. All other subcommands succeed.
+ */
+function writeGitShim(rejection: string): void {
+  writeShim(
+    'git',
+    [
+      'if [[ "$1" == "push" || "$2" == "push" ]]; then',
+      '  echo "attempt" >>"${ATTEMPT_LOG}"',
+      `  cat <<'REJECTION' >&2`,
+      rejection,
+      'REJECTION',
+      '  exit 1',
+      'fi',
+      'exit 0',
+    ].join('\n'),
+  );
+}
+
+/** Install a `gh` shim whose `pr list --json headRefName` returns $FAKE_PR_HEAD. */
+function writeGhShim(): void {
+  writeShim('gh', 'printf \'%s\\n\' "${FAKE_PR_HEAD:-}"');
+}
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(script: string, env: Record<string, string> = {}): RunResult {
+  const result = spawnSync('bash', [script], {
+    encoding: 'utf8',
+    cwd: sandbox,
+    env: {
+      ...process.env,
+      PATH: `${binDir()}:${process.env.PATH}`,
+      ATTEMPT_LOG: join(sandbox, 'attempts.log'),
+      GITHUB_OUTPUT: join(sandbox, 'github_output'),
+      GITHUB_STEP_SUMMARY: join(sandbox, 'step_summary'),
+      ...env,
+    },
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function readSandboxFile(name: string): string {
+  try {
+    return readFileSync(join(sandbox, name), 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function attemptCount(): number {
+  return readSandboxFile('attempts.log').split('\n').filter(Boolean).length;
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'merge-queue-'));
+  spawnSync('mkdir', ['-p', binDir()]);
+  writeFileSync(join(sandbox, 'github_output'), '');
+  writeFileSync(join(sandbox, 'step_summary'), '');
+  writeFileSync(join(sandbox, 'pr-body.md'), 'body');
+  writeGhShim();
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('push-with-retry.sh', () => {
+  function push(rejection: string, env: Record<string, string> = {}): RunResult {
+    writeGitShim(rejection);
+    const result = spawnSync('bash', [PUSH_WITH_RETRY, 'origin', 'release/version-1.2.3'], {
+      encoding: 'utf8',
+      cwd: sandbox,
+      env: {
+        ...process.env,
+        PATH: `${binDir()}:${process.env.PATH}`,
+        ATTEMPT_LOG: join(sandbox, 'attempts.log'),
+        MAX_RETRIES: '3',
+        INITIAL_DELAY: '0',
+        ...env,
+      },
+    });
+    return {
+      status: result.status ?? -1,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    };
+  }
+
+  test('merge-queue rejection exits 75 on the first attempt without retrying', () => {
+    const result = push(MERGE_QUEUE_REJECTION);
+
+    expect(result.status).toBe(MERGE_QUEUE_EXIT_CODE);
+    expect(attemptCount()).toBe(1);
+    expect(result.stdout).toContain('enrolled in a merge queue');
+  });
+
+  test('generic GH006 rejection still exhausts the retry budget', () => {
+    const result = push(GENERIC_REJECTION);
+
+    expect(result.status).toBe(1);
+    expect(attemptCount()).toBe(3);
+    expect(result.stdout).toContain('Push failed after 3 attempts');
+    expect(result.stdout).not.toContain('merge queue');
+  });
+
+  test('redacts credentials embedded in the remote URL from replayed output', () => {
+    // Assembled from parts so the fake token is not a literal credentialed URI.
+    const fakeSecret = ['ghs', 'notarealtoken'].join('_');
+    const tokenizedRemote = `https://x-access-token:${fakeSecret}@github.com/o/r.git`;
+    writeGitShim(`remote: rejected by ${tokenizedRemote}`);
+
+    const result = spawnSync('bash', [PUSH_WITH_RETRY, tokenizedRemote, 'main'], {
+      encoding: 'utf8',
+      cwd: sandbox,
+      env: {
+        ...process.env,
+        PATH: `${binDir()}:${process.env.PATH}`,
+        ATTEMPT_LOG: join(sandbox, 'attempts.log'),
+        MAX_RETRIES: '1',
+        INITIAL_DELAY: '0',
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).not.toContain(fakeSecret);
+    expect(`${result.stdout}${result.stderr}`).toContain('https://github.com/o/r.git');
+  });
+});
+
+describe('retry-release-branch-push.sh', () => {
+  const baseEnv = {
+    RELEASE_BRANCH: 'release/version-1.2.3',
+    NEXT_VERSION: '1.2.3',
+    PR_TITLE: 'chore(release): version 1.2.3',
+    GH_TOKEN: 'token',
+    GITHUB_REPOSITORY: 'lgtm-hq/turbo-themes',
+    MAX_RETRIES: '3',
+    INITIAL_DELAY: '0',
+  };
+
+  test('skips with skipped-merge-queue=true when the queued PR carries the version', () => {
+    writeGitShim(MERGE_QUEUE_REJECTION);
+
+    const result = run(RETRY_RELEASE_PUSH, {
+      ...baseEnv,
+      PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+      FAKE_PR_HEAD: 'release/version-1.2.3',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('::notice title=Release branch already in merge queue::');
+    expect(readSandboxFile('github_output')).toContain('skipped-merge-queue=true');
+    expect(readSandboxFile('github_output')).not.toContain('pull-request-number=');
+  });
+
+  test('fails loudly when the queued PR is for a different version', () => {
+    writeGitShim(MERGE_QUEUE_REJECTION);
+
+    const result = run(RETRY_RELEASE_PUSH, {
+      ...baseEnv,
+      PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+      FAKE_PR_HEAD: 'release/version-9.9.9',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to skip');
+    expect(readSandboxFile('github_output')).not.toContain('skipped-merge-queue');
+  });
+
+  test('fails loudly when no open PR carries the version bump', () => {
+    writeGitShim(MERGE_QUEUE_REJECTION);
+
+    const result = run(RETRY_RELEASE_PUSH, {
+      ...baseEnv,
+      PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+      FAKE_PR_HEAD: '',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to skip');
+  });
+
+  test('propagates a generic push failure instead of skipping', () => {
+    writeGitShim(GENERIC_REJECTION);
+
+    const result = run(RETRY_RELEASE_PUSH, {
+      ...baseEnv,
+      PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+      FAKE_PR_HEAD: 'release/version-1.2.3',
+    });
+
+    expect(result.status).toBe(1);
+    expect(attemptCount()).toBe(3);
+    expect(readSandboxFile('github_output')).not.toContain('skipped-merge-queue');
+  });
+
+  test('requires NEXT_VERSION', () => {
+    writeGitShim(MERGE_QUEUE_REJECTION);
+
+    const result = spawnSync('bash', [RETRY_RELEASE_PUSH], {
+      encoding: 'utf8',
+      cwd: sandbox,
+      env: {
+        ...process.env,
+        PATH: `${binDir()}:${process.env.PATH}`,
+        RELEASE_BRANCH: 'release/version-1.2.3',
+        PR_TITLE: 'title',
+        PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+        GH_TOKEN: 'token',
+        GITHUB_REPOSITORY: 'lgtm-hq/turbo-themes',
+        NEXT_VERSION: '',
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('NEXT_VERSION is required');
+  });
+});
+
+describe('fail-release-push.sh', () => {
+  test('fails loudly by default', () => {
+    const result = run(FAIL_RELEASE_PUSH);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Release branch push failed');
+  });
+
+  test('exits 0 when the push was skipped for the merge queue', () => {
+    const result = run(FAIL_RELEASE_PUSH, { SKIPPED_MERGE_QUEUE: 'true' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('already in the merge queue');
+  });
+});
+
+describe('generate-version-pr-summary.sh', () => {
+  test('reports the merge-queue skip distinctly from having nothing to do', () => {
+    const result = run(VERSION_PR_SUMMARY, {
+      BUMP_NEEDED: 'true',
+      NEXT_VERSION: '1.2.3',
+      SKIPPED_MERGE_QUEUE: 'true',
+      PUSH_RETRY_TRIGGERED: 'true',
+      PUSH_FAILED: 'false',
+    });
+
+    expect(result.status).toBe(0);
+    const summary = readSandboxFile('step_summary');
+    expect(summary).toContain('**Skipped**');
+    expect(summary).toContain('already in the merge queue');
+    expect(summary).not.toContain('No version bump needed');
+    expect(summary).not.toContain('recovered via push retry');
+  });
+
+  test('still reports a hard push failure', () => {
+    const result = run(VERSION_PR_SUMMARY, {
+      BUMP_NEEDED: 'true',
+      NEXT_VERSION: '1.2.3',
+      PUSH_FAILED: 'true',
+    });
+
+    expect(result.status).toBe(0);
+    expect(readSandboxFile('step_summary')).toContain('**Push failed**');
+  });
+
+  test('reports no bump needed unchanged', () => {
+    const result = run(VERSION_PR_SUMMARY, { BUMP_NEEDED: 'false' });
+
+    expect(result.status).toBe(0);
+    expect(readSandboxFile('step_summary')).toContain('No version bump needed');
+  });
+});

--- a/test/release-push-merge-queue.test.ts
+++ b/test/release-push-merge-queue.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
@@ -60,9 +60,24 @@ function writeGitShim(rejection: string): void {
   );
 }
 
-/** Install a `gh` shim whose `pr list --json headRefName` returns $FAKE_PR_HEAD. */
+/**
+ * Install a `gh` shim that answers only the exact `pr list --json headRefName`
+ * call the script under test makes, echoing $FAKE_PR_HEAD. Any other gh
+ * invocation fails loudly so a new, unstubbed gh call cannot slip through the
+ * verification path unnoticed.
+ */
 function writeGhShim(): void {
-  writeShim('gh', 'printf \'%s\\n\' "${FAKE_PR_HEAD:-}"');
+  writeShim(
+    'gh',
+    [
+      'if [[ "$1" == "pr" && "$2" == "list" && "$*" == *"--json headRefName"* ]]; then',
+      '  printf \'%s\\n\' "${FAKE_PR_HEAD:-}"',
+      '  exit 0',
+      'fi',
+      'echo "unexpected gh invocation: gh $*" >&2',
+      'exit 64',
+    ].join('\n'),
+  );
 }
 
 interface RunResult {
@@ -71,10 +86,18 @@ interface RunResult {
   stderr: string;
 }
 
-function run(script: string, env: Record<string, string> = {}): RunResult {
-  const result = spawnSync('bash', [script], {
+/** Kill a hung script rather than letting the suite stall indefinitely. */
+const SCRIPT_TIMEOUT_MS = 30_000;
+
+/** Run a script under bash with the sandboxed PATH, shims and Actions files. */
+function runScript(
+  script: string,
+  { args = [], env = {} }: { args?: string[]; env?: Record<string, string> } = {},
+): RunResult {
+  const result = spawnSync('bash', [script, ...args], {
     encoding: 'utf8',
     cwd: sandbox,
+    timeout: SCRIPT_TIMEOUT_MS,
     env: {
       ...process.env,
       PATH: `${binDir()}:${process.env.PATH}`,
@@ -91,6 +114,10 @@ function run(script: string, env: Record<string, string> = {}): RunResult {
   };
 }
 
+function run(script: string, env: Record<string, string> = {}): RunResult {
+  return runScript(script, { env });
+}
+
 function readSandboxFile(name: string): string {
   try {
     return readFileSync(join(sandbox, name), 'utf8');
@@ -105,7 +132,7 @@ function attemptCount(): number {
 
 beforeEach(() => {
   sandbox = mkdtempSync(join(tmpdir(), 'merge-queue-'));
-  spawnSync('mkdir', ['-p', binDir()]);
+  mkdirSync(binDir(), { recursive: true });
   writeFileSync(join(sandbox, 'github_output'), '');
   writeFileSync(join(sandbox, 'step_summary'), '');
   writeFileSync(join(sandbox, 'pr-body.md'), 'body');
@@ -119,23 +146,10 @@ afterEach(() => {
 describe('push-with-retry.sh', () => {
   function push(rejection: string, env: Record<string, string> = {}): RunResult {
     writeGitShim(rejection);
-    const result = spawnSync('bash', [PUSH_WITH_RETRY, 'origin', 'release/version-1.2.3'], {
-      encoding: 'utf8',
-      cwd: sandbox,
-      env: {
-        ...process.env,
-        PATH: `${binDir()}:${process.env.PATH}`,
-        ATTEMPT_LOG: join(sandbox, 'attempts.log'),
-        MAX_RETRIES: '3',
-        INITIAL_DELAY: '0',
-        ...env,
-      },
+    return runScript(PUSH_WITH_RETRY, {
+      args: ['origin', 'release/version-1.2.3'],
+      env: { MAX_RETRIES: '3', INITIAL_DELAY: '0', ...env },
     });
-    return {
-      status: result.status ?? -1,
-      stdout: result.stdout ?? '',
-      stderr: result.stderr ?? '',
-    };
   }
 
   test('merge-queue rejection exits 75 on the first attempt without retrying', () => {
@@ -161,16 +175,9 @@ describe('push-with-retry.sh', () => {
     const tokenizedRemote = `https://x-access-token:${fakeSecret}@github.com/o/r.git`;
     writeGitShim(`remote: rejected by ${tokenizedRemote}`);
 
-    const result = spawnSync('bash', [PUSH_WITH_RETRY, tokenizedRemote, 'main'], {
-      encoding: 'utf8',
-      cwd: sandbox,
-      env: {
-        ...process.env,
-        PATH: `${binDir()}:${process.env.PATH}`,
-        ATTEMPT_LOG: join(sandbox, 'attempts.log'),
-        MAX_RETRIES: '1',
-        INITIAL_DELAY: '0',
-      },
+    const result = runScript(PUSH_WITH_RETRY, {
+      args: [tokenizedRemote, 'main'],
+      env: { MAX_RETRIES: '1', INITIAL_DELAY: '0' },
     });
 
     expect(result.status).toBe(1);
@@ -203,6 +210,23 @@ describe('retry-release-branch-push.sh', () => {
     expect(result.stdout).toContain('::notice title=Release branch already in merge queue::');
     expect(readSandboxFile('github_output')).toContain('skipped-merge-queue=true');
     expect(readSandboxFile('github_output')).not.toContain('pull-request-number=');
+  });
+
+  test('fails loudly when the pushed branch does not match the computed version', () => {
+    writeGitShim(MERGE_QUEUE_REJECTION);
+
+    // First guard: fires before the gh query, so a matching FAKE_PR_HEAD must
+    // not be able to rescue a branch/version mismatch.
+    const result = run(RETRY_RELEASE_PUSH, {
+      ...baseEnv,
+      NEXT_VERSION: '9.9.9',
+      PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+      FAKE_PR_HEAD: 'release/version-1.2.3',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('does not match');
+    expect(readSandboxFile('github_output')).not.toContain('skipped-merge-queue');
   });
 
   test('fails loudly when the queued PR is for a different version', () => {
@@ -249,19 +273,10 @@ describe('retry-release-branch-push.sh', () => {
   test('requires NEXT_VERSION', () => {
     writeGitShim(MERGE_QUEUE_REJECTION);
 
-    const result = spawnSync('bash', [RETRY_RELEASE_PUSH], {
-      encoding: 'utf8',
-      cwd: sandbox,
-      env: {
-        ...process.env,
-        PATH: `${binDir()}:${process.env.PATH}`,
-        RELEASE_BRANCH: 'release/version-1.2.3',
-        PR_TITLE: 'title',
-        PR_BODY_FILE: join(sandbox, 'pr-body.md'),
-        GH_TOKEN: 'token',
-        GITHUB_REPOSITORY: 'lgtm-hq/turbo-themes',
-        NEXT_VERSION: '',
-      },
+    const result = run(RETRY_RELEASE_PUSH, {
+      ...baseEnv,
+      PR_BODY_FILE: join(sandbox, 'pr-body.md'),
+      NEXT_VERSION: '',
     });
 
     expect(result.status).not.toBe(0);


### PR DESCRIPTION
## Summary

`Release - Version PR` went red whenever it tried to update a `release/version-<v>`
branch whose PR was already enrolled in the merge queue. GitHub rejects that push with
`GH006`, and the existing in-run retry — designed for *transient* rejections, with a
~17 second budget — cannot help: the ref only unblocks when the queued PR merges or is
dequeued, which is minutes. `fail-release-push.sh` then failed the run.

The push is not actually needed in that situation: the queued PR already carries the
same version bump, and its merge fires a fresh `push: main` run that recomputes the
next version. This PR classifies that one rejection and skips instead of failing —
while keeping every other push failure as loud as before.

## Type

- [ ] ✨ Feature (`feat:`)
- [x] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [x] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- **`scripts/ci/push-with-retry.sh`** — capture the push output and classify the
  rejection. A merge-queue rejection (`GH006` **and** `queued for merging` /
  `added to a merge queue`) exits immediately with a dedicated code `75` instead of
  burning the retry budget. A generic `GH006` (protected branch, non-fast-forward)
  keeps retrying exactly as today. Credential redaction was promoted to a reusable
  function and is now applied to the replayed output on both paths.
- **`scripts/ci/retry-release-branch-push.sh`** — map exit `75` to a `::notice`, a
  `skipped-merge-queue=true` step output, and exit 0. **Before** skipping it verifies
  the queued PR really carries the intended version: the pushed branch must equal
  `release/version-${NEXT_VERSION}`, and an open PR with that head must exist. Any
  mismatch still fails loudly, so a skip can only ever mean "the queued PR already does
  this work". Takes a new `NEXT_VERSION` env var.
- **`scripts/ci/fail-release-push.sh`** — bypass only on that classification. This is
  defence in depth (the workflow already keeps the step from running on the skip path);
  a comment records why.
- **`scripts/ci/generate-version-pr-summary.sh`** — a skipped run now reads
  "⏭️ **Skipped** — release branch for v… is already in the merge queue", visibly
  distinct both from a hard push failure and from a run that simply had nothing to do.
- **`.github/workflows/release-version-pr.yml`** — plumb `NEXT_VERSION` into the retry
  step and `skipped-merge-queue` into the fail and summary steps. No shell logic added
  inline; it all lives in `scripts/ci/*.sh` per repo standards.
- **`test/release-push-merge-queue.test.ts`** — new coverage for all four scripts.

## Closes

- Closes #817

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`npm test`)

14 new tests drive the real scripts under a sandboxed `PATH` with `git`/`gh` shims,
covering the three classification outcomes the issue calls for and more:

- merge-queue rejection ⇒ exit 75 on the **first** attempt, no retries
- generic `GH006` ⇒ still exhausts the full retry budget (3 attempts), never skips
- skip path ⇒ `::notice` + `skipped-merge-queue=true`, no `pull-request-number`
- pushed branch ≠ `release/version-${NEXT_VERSION}` ⇒ still fails
- queued PR head is a different version ⇒ still fails
- no open PR for the head ⇒ still fails
- generic failure through the retry entry point ⇒ propagates, no skip output
- `fail-release-push.sh` fails by default, exits 0 only on the classification
- summary renders skip / hard failure / no-bump distinctly
- tokenized remote URLs stay redacted in the replayed output

The `gh` shim answers only the exact `pr list --json headRefName` call and fails loudly
on anything else, so a future unstubbed `gh` call in the verification path cannot slip
through unnoticed.

### Test Coverage

- [x] Coverage maintained or improved
- [x] No decrease in code coverage
- [x] Coverage report reviewed

Full suite: 3618 tests passing (up from 3604).

## Quality Checks

- [x] Linting passes (`npm run lint`)
- [x] Formatting passes (`npm run format`)
- [x] TypeScript build successful (`npm run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

`uv run lintro fmt` then `uv run lintro chk` — 0 issues, health score 100/100.

## Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [x] Comments added to complex code
- [x] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided below

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

## Additional Context

**Why skip rather than poll-until-merged.** The issue's option 2 preferred branch. The
queued PR's merge already triggers a fresh run that recomputes the next version, so
polling would burn runner minutes for no added correctness.

**On the dequeue race.** The guard confirms the PR exists and carries the right version,
not that it is still queued at that instant (`gh pr list --json` exposes no
merge-queue-entry field). That is deliberate: GitHub's own rejection is the
authoritative statement that the branch *was* queued, and a PR dequeued in the meantime
is still open with the identical bump — so skipping cannot drop a version bump either
way. This is recorded in a comment in the script.

Pre-push AI review: CodeRabbit and Greptile CLIs both run; findings addressed in
follow-up commits (Greptile final pass: confidence 5/5, no review comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release automation now recognizes when a release branch is already queued for merging and avoids unnecessary retries or duplicate pull request updates.
  * Version summaries clearly indicate when processing was skipped because the queued pull request already contains the version bump.

* **Bug Fixes**
  * Improved handling of protected-branch push failures while preserving retries for other failures.
  * Credentials are now redacted from push-related logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR recognizes GitHub merge-queue push rejections and treats a verified release-branch rejection as a successful skip.
- Captures and redacts push output while preserving retries for generic failures.
- Adds merge-queue skip handling, workflow outputs, and distinct step-summary reporting.
- Adds tests for classification, validation, failure propagation, summaries, and credential redaction.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the skip path verifies that the queued branch actually contains the current run’s generated release changes.

A repeated run can generate different content for the same next-version branch, yet the new logic treats an open PR with the matching branch name as equivalent and exits successfully without comparing commits or content.

**Files Needing Attention:** scripts/ci/retry-release-branch-push.sh and test/release-push-merge-queue.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/push-with-retry.sh | Captures and redacts push output, classifies merge-queue-specific GH006 failures, and preserves retries for other failures. |
| scripts/ci/retry-release-branch-push.sh | Handles exit 75 as benign, but validates only the PR head name and can therefore skip newly generated content absent from the queued branch. |
| .github/workflows/release-version-pr.yml | Plumbs the next version and skip output through retry, failure, and summary steps with consistent outcome handling. |
| scripts/ci/generate-version-pr-summary.sh | Adds a distinct merge-queue skip summary ahead of hard-failure and retry-success reporting. |
| scripts/ci/fail-release-push.sh | Adds a defense-in-depth bypass for the explicitly classified merge-queue skip. |
| test/release-push-merge-queue.test.ts | Covers script outcomes and branch-name validation but not a matching branch whose remote commit lacks the current run's generated changes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create/update version PR push fails] --> B[Retry release branch push]
    B --> C{GH006 plus merge-queue wording?}
    C -- No --> D[Continue normal retries]
    C -- Yes --> E{Expected branch name and open PR head match?}
    E -- No --> F[Fail workflow]
    E -- Yes --> G[Mark skipped and exit successfully]
    G --> H[Queued PR later merges]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fretry-release-branch-push.sh%3A73-84%0A**Queued%20branch%20content%20is%20unverified**%0A%0AWhen%20a%20later%20main-branch%20run%20computes%20the%20same%20version%20but%20generates%20updated%20release%20content%2C%20this%20check%20accepts%20the%20existing%20PR%20based%20only%20on%20its%20branch%20name%20and%20exits%20successfully%2C%20causing%20the%20queued%20PR%20to%20merge%20without%20the%20later%20version%20files%2C%20changelog%20content%2C%20or%20regenerated%20artifacts.%0A%0A&pr=821&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fretry-release-branch-push.sh%3A73-84%0A**Queued%20branch%20content%20is%20unverified**%0A%0AWhen%20a%20later%20main-branch%20run%20computes%20the%20same%20version%20but%20generates%20updated%20release%20content%2C%20this%20check%20accepts%20the%20existing%20PR%20based%20only%20on%20its%20branch%20name%20and%20exits%20successfully%2C%20causing%20the%20queued%20PR%20to%20merge%20without%20the%20later%20version%20files%2C%20changelog%20content%2C%20or%20regenerated%20artifacts.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=821&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fturbo-themes%22%20on%20the%20existing%20branch%20%22fix%2F817-merge-queue-push-skip%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F817-merge-queue-push-skip%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fretry-release-branch-push.sh%3A73-84%0A**Queued%20branch%20content%20is%20unverified**%0A%0AWhen%20a%20later%20main-branch%20run%20computes%20the%20same%20version%20but%20generates%20updated%20release%20content%2C%20this%20check%20accepts%20the%20existing%20PR%20based%20only%20on%20its%20branch%20name%20and%20exits%20successfully%2C%20causing%20the%20queued%20PR%20to%20merge%20without%20the%20later%20version%20files%2C%20changelog%20content%2C%20or%20regenerated%20artifacts.%0A%0A&repo=lgtm-hq%2Fturbo-themes&pr=821&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(ci): note why the merge-queue skip ..."](https://github.com/lgtm-hq/turbo-themes/commit/d9f543303c91dcc78efe1fa2e6681b3cad57554b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47423527)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->