### PR TITLE
fix(ci): fail snapshot generation when the served site is stale

### DIFF
--- a/.github/workflows/maintenance-generate-snapshots.yml
+++ b/.github/workflows/maintenance-generate-snapshots.yml
@@ -3,6 +3,11 @@
 # (harden-runner block + same allowlist, playwright install --with-deps, apt Ruby
 # via bootstrap-e2e-snapshots.sh). Audit-mode / setup-env / install-without-deps
 # previously produced byte-stable baselines that still failed e2e (#708).
+#
+# Stale-serve guard (#670): e2e/served-build-freshness.spec.ts is tagged @visual,
+# so it runs inside this job's --grep @visual pass and fails it when the served
+# page's theme set differs from the tokens.json the prep build produced. Upload
+# is gated on that success, so a stale render can never become a baseline.
 name: Maintenance - Generate E2E Snapshots
 
 on:
@@ -90,6 +95,8 @@ jobs:
         run: ./scripts/ci/bootstrap-e2e-snapshots.sh
 
       - name: Upload Linux snapshots
+        # Never publish baselines from a run whose freshness guard failed (#670).
+        if: success()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: e2e-snapshots-linux

--- a/e2e/served-build-freshness.spec.ts
+++ b/e2e/served-build-freshness.spec.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+
+/**
+ * Guard against Playwright rendering a stale site build (#670).
+ *
+ * `maintenance-generate-snapshots.yml` uploads whatever `--update-snapshots`
+ * writes as the committed Linux baselines. If the `webServer` ever serves a
+ * `apps/site/dist` that predates `bun run e2e:prep` (for example because the
+ * prep build silently no-op'd), the run still reports "all passed" and a stale
+ * render is published as the new baseline.
+ *
+ * This test fails the whole run in that case: the theme options the served page
+ * renders must match the theme IDs in the tokens.json produced by the build.
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Candidate locations for the built token manifest, most authoritative first.
+ *
+ * `dist/tokens/style-dictionary/tokens.json` is the direct output of
+ * `bun run build:tokens`; the `packages/core` copy is written from it by
+ * `build:tokens:copy` and is drift-checked in CI.
+ */
+const TOKENS_PATHS = [
+  join(repoRoot, 'dist', 'tokens', 'style-dictionary', 'tokens.json'),
+  join(repoRoot, 'packages', 'core', 'src', 'themes', 'tokens.json'),
+];
+
+/**
+ * Read the theme IDs recorded in the built tokens manifest.
+ *
+ * @returns Sorted theme IDs from the first tokens.json found on disk.
+ * @throws If no tokens.json exists or it declares no themes.
+ */
+function builtThemeIds(): string[] {
+  const tokensPath = TOKENS_PATHS.find((candidate) => existsSync(candidate));
+  if (!tokensPath) {
+    throw new Error(
+      `No built tokens.json found (looked in: ${TOKENS_PATHS.join(', ')}). ` +
+        'Run `bun run e2e:prep` before the E2E suite.'
+    );
+  }
+
+  const tokens = JSON.parse(readFileSync(tokensPath, 'utf8')) as {
+    meta?: { themeIds?: string[] };
+  };
+  const themeIds = tokens.meta?.themeIds ?? [];
+  if (themeIds.length === 0) {
+    throw new Error(`${tokensPath} declares no themes in meta.themeIds`);
+  }
+
+  return [...themeIds].sort();
+}
+
+test.describe('Served build freshness @visual @smoke', () => {
+  test('served page exposes every theme in the built tokens.json', async ({ page }) => {
+    const expected = builtThemeIds();
+
+    await page.goto('/');
+
+    const options = page.locator('#theme-menu [role="option"][data-theme]');
+    await expect(
+      options,
+      'Theme dropdown option count differs from the built tokens.json — the ' +
+        'server is likely serving a stale apps/site/dist (see #670)'
+    ).toHaveCount(expected.length);
+
+    const served = await options.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('data-theme') ?? '')
+    );
+
+    expect(
+      [...new Set(served)].sort(),
+      'Served theme IDs differ from the built tokens.json — the server is ' +
+        'likely serving a stale apps/site/dist (see #670)'
+    ).toEqual(expected);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -181,6 +181,10 @@ const config = defineConfig({
         port: 4173,
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000, // 2 minutes for build + serve
+        // Surface which directory is served and whether the prep build was
+        // skipped; without this the server's stdout is discarded and stale
+        // renders are untraceable after the fact (#670).
+        stdout: 'pipe',
       },
 
   // Screenshot and snapshot settings

--- a/scripts/ci/bootstrap-e2e-full.sh
+++ b/scripts/ci/bootstrap-e2e-full.sh
@@ -21,4 +21,9 @@ ensure_e2e_ruby
 # too short for a cold e2e:prep, so the webServer then only serves the dist.
 bun run e2e:prep
 
+# Serve exactly what the prep above wrote (same contract as
+# bootstrap-e2e-snapshots.sh, so generated baselines and the verifying run
+# render the identical dist).
+export SKIP_PREP=1
+
 exec bun run e2e:ci "$@"

--- a/scripts/ci/bootstrap-e2e-snapshots.sh
+++ b/scripts/ci/bootstrap-e2e-snapshots.sh
@@ -16,5 +16,9 @@ ensure_e2e_ruby
 
 bun run e2e:prep
 
+# The webServer must serve exactly what the prep above wrote. SKIP_PREP=1 makes
+# that explicit instead of relying on e2e-serve.mjs's "dist/index.html exists"
+# heuristic, which silently decides between rebuilding and serving (#670).
+export SKIP_PREP=1
 export UPDATE_SNAPSHOTS=1
 exec bun run e2e --update-snapshots --grep @visual

--- a/scripts/e2e-serve.mjs
+++ b/scripts/e2e-serve.mjs
@@ -13,12 +13,14 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
+const siteDir = join(rootDir, 'apps', 'site');
+const distDir = join(siteDir, 'dist');
 
 /**
  * Check if dist is already built (has index.html).
  */
 function isSiteBuilt() {
-  return existsSync(join(rootDir, 'apps', 'site', 'dist', 'index.html'));
+  return existsSync(join(distDir, 'index.html'));
 }
 
 try {
@@ -26,7 +28,11 @@ try {
   const skipPrep = process.env.SKIP_PREP === '1' || isSiteBuilt();
 
   if (skipPrep) {
-    console.log('Skipping e2e prep (dist already exists)...');
+    console.log(
+      process.env.SKIP_PREP === '1'
+        ? 'Skipping e2e prep (SKIP_PREP=1)...'
+        : 'Skipping e2e prep (dist already exists)...'
+    );
   } else {
     console.log('Running e2e prep (build + Astro build)...');
     execSync('bun run e2e:prep', {
@@ -43,7 +49,9 @@ try {
     console.error(`Invalid PORT: ${process.env.PORT}. Must be a number between 1 and 65535.`);
     process.exit(1);
   }
-  console.log(`Starting astro preview on http://${host}:${port}...`);
+  // Log the exact directory being served so a stale-serve can be diagnosed
+  // from CI logs instead of inferred from screenshots (#670).
+  console.log(`Serving ${distDir} via astro preview on http://${host}:${port}...`);
   const bunxCmd = process.platform === 'win32' ? 'bunx.cmd' : 'bunx';
   const serverArgs = [
     '--no-install',
@@ -55,7 +63,7 @@ try {
     host,
   ];
   const serverProcess = spawn(bunxCmd, serverArgs, {
-    cwd: join(rootDir, 'apps', 'site'),
+    cwd: siteDir,
     stdio: 'inherit',
   });
   // Handle spawn errors


### PR DESCRIPTION
## Summary

`maintenance-generate-snapshots.yml` uploads whatever `--update-snapshots` writes as the
committed Linux `@visual` baselines, but nothing ever verified that Playwright rendered
the `apps/site/dist` the prep build had just produced. On run 29718181142 that gap let a
pre-radix render be published as a "successful" baseline refresh while the `e2e` job on
the same commit rendered the correct 31-theme page and failed (#670).

This PR closes the gap in the direction that cannot silently regress: an assertion that
fails the run when the served page's theme set differs from the theme set in the
`tokens.json` the build produced. The guard runs inside the maintenance job's
`--grep @visual` pass, so a stale render now fails the job and the upload step is
skipped — a stale render can no longer become a baseline.

### On the root cause — read this before re-doing work

Two things to be honest about:

1. **I could not reproduce a deterministic stale-serve, and the existing run logs cannot
   answer it.** Playwright's `webServer.stdout` defaults to `ignore`, so
   `e2e-serve.mjs`'s "Skipping e2e prep…" / "Starting astro preview…" lines were never
   captured in run 29718181142. The log proves the build processed 31 themes; it says
   nothing about which directory was then served or whether prep was skipped. No
   evidence exists to pin the mechanism after the fact.
2. **The prep/serve alignment the issue proposed as one option was already done in
   #724.** Both `bootstrap-e2e-full.sh` and `bootstrap-e2e-snapshots.sh` already run
   `bun run e2e:prep` and then let the `webServer` serve `apps/site/dist`. Nobody needs
   to redo that half.

So what this PR ships is the issue's *other* proposed half — the guard that makes a
stale render fail loudly instead of being silently uploaded — plus the instrumentation
that makes a recurrence diagnosable:

- makes the serve step deterministic (`SKIP_PREP=1` after the explicit prep, in **both**
  bootstrap scripts, instead of relying on the `dist/index.html` existence heuristic that
  silently chooses between rebuilding and serving);
- logs the absolute directory being served;
- pipes `webServer` stdout so that directory and the prep decision appear in CI logs.

If the failure ever recurs, the guard fails the run and the logs now say which directory
was served.

## Type

- [ ] ✨ Feature (`feat:`)
- [x] 🐛 Bug fix (`fix:`)
- [ ] 📚 Documentation (`docs:`)
- [ ] ♻️ Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Tests (`test:`)
- [x] 🔧 CI/CD (`ci:`)
- [ ] 📦 Build (`build:`)
- [ ] 🔨 Chore (`chore:`)

## Changes Made

- Add `e2e/served-build-freshness.spec.ts`, tagged `@visual @smoke`: asserts the theme
  options rendered by the served page (`#theme-menu [role="option"][data-theme]`) match
  `meta.themeIds` in the built `tokens.json`. `@visual` puts it inside the maintenance
  job's `--grep @visual` run; `@smoke` also guards normal CI.
- `scripts/ci/bootstrap-e2e-snapshots.sh` and `scripts/ci/bootstrap-e2e-full.sh`: export
  `SKIP_PREP=1` after `bun run e2e:prep`, so the `webServer` serves exactly what the prep
  wrote rather than deciding via the `dist/index.html` heuristic.
- `scripts/e2e-serve.mjs`: log the absolute directory being served, and distinguish
  "skipped because `SKIP_PREP=1`" from "skipped because dist exists".
- `playwright.config.ts`: `webServer.stdout: 'pipe'` so the above is visible in CI logs.
- `maintenance-generate-snapshots.yml`: document the guard and make the artifact upload
  explicitly `if: success()`.

## Closes

- Closes #670
- Relates to #708

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally (`npm test`)

### How this was verified

- Full unit/package suite: `bun run test` — pass, coverage unchanged.
- Full lint: `uv run lintro fmt` then `uv run lintro chk` — 0 issues, health 100/100.
  (`pip-audit` errors out on this host while creating its own venv; that is a
  pre-existing local environment failure, unrelated to this diff, which touches no
  Python.)
- `bun run e2e:prep` was run locally and the guard's selector and expectation were
  checked against the produced `apps/site/dist/index.html`: 43 theme options in
  `#theme-menu`, 43 IDs in `meta.themeIds`, sets identical.
- The guard makes **no** screenshot assertion (`toHaveScreenshot` / `toMatchSnapshot`),
  so despite living in the `@visual` set it has no baseline of its own and cannot be
  "refreshed" into passing by `--update-snapshots`.

### What is NOT verified locally

- **The Playwright run itself could not be executed on this machine.** Chromium
  extraction hangs indefinitely during `playwright install` on this host (download
  completes, extraction stalls with no CPU, reproducible after clearing locks and
  partials). CI is the E2E gate for this PR.
- **End-to-end validation needs a `workflow_dispatch` run of
  `maintenance-generate-snapshots.yml`, which only the repo owner can trigger.** That
  workflow is dispatch-only, so neither the guard's behaviour inside that job nor the
  new serve logging shows up in a PR check. Suggested confirmation: dispatch it on a
  branch that changes the theme count, then check that the run log shows
  `Serving …/apps/site/dist` and that the uploaded artifact reflects that branch's
  build.
- Pre-push AI review: CodeRabbit ran clean (0 findings across all 6 files). Greptile did
  not return — it first died client-side with `ENOBUFS` against a stale local `main`,
  and the re-run against `origin/main` produced no output before being abandoned, so
  this PR has not had a Greptile pass.

## Quality Checks

- [x] Linting passes (`npm run lint`)
- [x] Formatting passes (`npm run format`)
- [x] TypeScript build successful (`npm run build`)
- [x] No new warnings or errors
- [x] Markdown linting passes (if applicable)

## Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [x] Comments added to complex code
- [ ] CHANGELOG entry added (for semantic-release, this is automatic)

## Breaking Changes

- [ ] This PR contains breaking changes
- [ ] Migration guide provided below

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code and corrected any misspellings
- [x] **I agree to abide by the project's [Code of Conduct](../CODE_OF_CONDUCT.md)**

## Additional Context

No visual baselines are regenerated here — this PR fixes the generator, it is not a
baseline refresh. The rendering-environment divergence tracked in #708 is deliberately
left untouched.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a CI guard that prevents snapshot publication when the served site's theme set differs from the freshly generated token manifest.

- Adds a Playwright freshness test to the visual and smoke suites.
- Makes full and snapshot E2E entrypoints explicitly serve the prepared build.
- Exposes the prep decision and served directory in Playwright logs.
- Gates snapshot artifact upload on successful generation and validation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the freshness test selected by the intended visual and smoke runs and failed runs prevented from uploading snapshots.

The build entrypoints prepare the site before setting SKIP_PREP, the test compares the initial server-rendered theme options against the generated primary token manifest in CI, and snapshot upload occurs only after the guarded test command succeeds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| e2e/served-build-freshness.spec.ts | Adds a correctly selected freshness guard comparing the server-rendered theme options with the generated token manifest. |
| scripts/ci/bootstrap-e2e-full.sh | Explicitly skips redundant web-server preparation after the full E2E build completes. |
| scripts/ci/bootstrap-e2e-snapshots.sh | Ensures snapshot generation serves the exact site output produced immediately beforehand. |
| scripts/e2e-serve.mjs | Reuses normalized site paths and logs both the preparation decision and absolute served directory. |
| playwright.config.ts | Pipes web-server stdout so freshness diagnostics remain visible in CI logs. |
| .github/workflows/maintenance-generate-snapshots.yml | Documents the freshness guard and explicitly limits artifact upload to successful runs. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Job as CI job
  participant Prep as e2e:prep
  participant Server as Playwright webServer
  participant Test as Freshness test
  participant Upload as Snapshot upload
  Job->>Prep: Build tokens and apps/site/dist
  Prep-->>Job: Generated tokens.json and site
  Job->>Server: "Start with SKIP_PREP=1"
  Server-->>Job: Log served dist directory
  Job->>Test: "Run @visual/@smoke test"
  Test->>Server: Load served homepage
  Test->>Test: Compare rendered theme IDs with tokens.json
  alt Theme sets match
    Test-->>Job: Pass
    Job->>Upload: Upload generated snapshots
  else Theme sets differ
    Test-->>Job: Fail
    Job--xUpload: Skip artifact upload
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): fail snapshot generation when t..."](https://github.com/lgtm-hq/turbo-themes/commit/da448b9a8835b4d98a04e836f8338433eb68ed6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47424691)</sub>

**Context used:**

- Knowledge Base — [Build pipeline](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/turbo-themes/-/docs/build-pipeline.md)

<!-- /greptile_comment -->