### PR TITLE
fix(security): remove stale ws vulnerability suppression

### DIFF
--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -52,4 +52,3 @@ reason = "vite 8.0.12 — fix in 8.0.16; dev/build-time only, blocked until vite
 id = "GHSA-v6wh-96g9-6wx3"
 ignoreUntil = 2026-10-04
 reason = "vite 8.0.12 — fix in 8.0.16; dev/build-time only, blocked until vitest/tooling support vite 8.0.16+"
-

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -53,9 +53,3 @@ id = "GHSA-v6wh-96g9-6wx3"
 ignoreUntil = 2026-10-04
 reason = "vite 8.0.12 — fix in 8.0.16; dev/build-time only, blocked until vitest/tooling support vite 8.0.16+"
 
-# --- ws: advisory lists no fixed version in the 8.x line ---
-
-[[IgnoredVulns]]
-id = "GHSA-96hv-2xvq-fx4p"
-ignoreUntil = 2026-10-04
-reason = "ws@8.20.1 — advisory fix listed only for the 5.x line; no patched 8.x release yet"


### PR DESCRIPTION
## Summary

Removes the `GHSA-96hv-2xvq-fx4p` (`ws@8.20.1`) entry from `.osv-scanner.toml`. The scheduled `Vulnerability Suppression Check` confirmed it no longer reproduces under osv-scanner, so the suppression is dead weight. The other eight suppressions were classified **Active** in the same run and are left untouched.

## Why this PR exists rather than the workflow's own branch

The check pushed `chore/remove-stale-vulns-20260727073416` with the identical removal, then exited 1. That branch cannot merge:

- its commit `f27cd08` is authored by `github-actions[bot]` and is **unsigned**, while the `main` ruleset enforces `required_signatures`
- **no PR was opened** — the run log ends at GitHub's "Create a pull request … by visiting" hint

So the red scheduled check would not self-heal, and would fail again weekly onto a fresh orphan branch. This reapplies the same one-file change on a signed branch.

## Verification

- `uv run lintro chk` — clean, no issues
- Diff is deletion-only: the `[[IgnoredVulns]]` block and its now-orphaned section comment
- Confirmed zero remaining references to `96hv-2xvq-fx4p` in the file

## Follow-up

The upstream remediation path in `lgtm-hq/lgtm-ci`'s `reusable-vuln-suppression-check.yml` needs fixing so it signs its commit and actually opens a PR — tracked in #833, which stays open for that.

Refs #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated security advisory suppression entry.
  * Security scanning will now report the affected `ws` advisory for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the stale `GHSA-96hv-2xvq-fx4p` vulnerability suppression and its associated comment from `.osv-scanner.toml`.
</details>

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .osv-scanner.toml | Removes one obsolete `ws` advisory suppression so future OSV scans no longer ignore it. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style(security): drop trailing blank lin..."](https://github.com/lgtm-hq/turbo-themes/commit/bdc33c0429ca23c191ff89c40b5614f28c8b8af1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47515081)</sub>

<!-- /greptile_comment -->